### PR TITLE
Enforce strict CVaR checks and T-1 optimizer guard

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -119,9 +119,14 @@ class BacktestEngine:
     ) -> None:
         cfg = self.engine.cfg
 
-        # T-1 history (exclude today to prevent look-ahead).
+        prev_idx = close.index.get_loc(date) - 1
+        if prev_idx < 0:
+            return
+        signal_date = close.index[prev_idx]
+
+        # Explicit T-1 history (exclude execution date to prevent look-ahead).
         hist_log_rets = (
-            np.log1p(returns.loc[:date].iloc[:-1])
+            np.log1p(returns.loc[:signal_date])
             .replace([np.inf, -np.inf], np.nan)
         )
 
@@ -139,7 +144,7 @@ class BacktestEngine:
         )
 
         _idx_ok      = idx_df is not None and not (hasattr(idx_df, "empty") and idx_df.empty)
-        idx_slice    = idx_df.loc[:date].iloc[:-1] if _idx_ok else None
+        idx_slice    = idx_df.loc[:signal_date] if _idx_ok else None
         # Pass cfg so compute_regime_score uses the dynamic vol threshold (FIX G2).
         regime_score = compute_regime_score(idx_slice, cfg=cfg)
 
@@ -174,6 +179,7 @@ class BacktestEngine:
                 weights_sel = self.engine.optimize(
                     expected_returns    = raw_daily[sel_idx],
                     historical_returns  = hist_log_rets[[symbols[i] for i in sel_idx]],
+                    execution_date      = date,
                     adv_shares          = adv_vector[sel_idx],
                     prices              = prices_t[sel_idx],
                     portfolio_value     = pv,
@@ -207,7 +213,6 @@ class BacktestEngine:
             self.state.decay_rounds = 0
 
         if optimization_succeeded or apply_decay:
-        if optimization_succeeded or apply_decay:
             # FIX C4: pass scenario_losses for post-decay CVaR check.
             _T = min(len(hist_log_rets), self.engine.cfg.CVAR_LOOKBACK)
             _L = -(hist_log_rets.iloc[-_T:].reindex(columns=symbols, fill_value=0.0).values)
@@ -216,6 +221,8 @@ class BacktestEngine:
                 date_context=date, trade_log=self.trades, apply_decay=apply_decay,
                 scenario_losses=_L,
             )
+            self._rebal_rows.append({
+                "date":              date,
                 "regime_score":       round(regime_score, 4),
                 "realised_cvar":      round(realised_cvar, 6),
                 "exposure_multiplier":round(self.state.exposure_multiplier, 4),

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -469,6 +469,7 @@ def _run_scan(
         weights_sel = engine.optimize(
             expected_returns    = raw_daily[sel_idx],
             historical_returns  = log_rets[[active[i] for i in sel_idx]],
+            execution_date      = pd.Timestamp(end_date),
             adv_shares          = adv_arr[sel_idx],
             prices              = prices[sel_idx],
             portfolio_value     = pv,

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -33,6 +33,7 @@ from sklearn.covariance import LedoitWolf
 
 warnings.filterwarnings("ignore", category=UserWarning, module="sklearn")
 logger = logging.getLogger(__name__)
+EPSILON = 1e-6
 
 
 # ─── Symbol helpers ───────────────────────────────────────────────────────────
@@ -473,7 +474,7 @@ def execute_rebalance(
             tail_n    = max(1, int(np.floor(T_sc * (1.0 - cfg.CVAR_ALPHA))))
             tail_mean = float(np.mean(np.sort(portfolio_losses)[-tail_n:]))
 
-            if tail_mean > cfg.CVAR_DAILY_LIMIT:
+            if tail_mean > cfg.CVAR_DAILY_LIMIT + EPSILON:
                 logger.error(
                     "execute_rebalance: POST-DECAY CVaR %.4f%% exceeds hard limit %.4f%%. "
                     "Liquidating all positions to cash — risk invariant cannot be "
@@ -583,10 +584,20 @@ class InstitutionalRiskEngine:
         prev_w:              Optional[np.ndarray] = None,
         exposure_multiplier: float                = 1.0,
         sector_labels:       Optional[np.ndarray] = None,
+        execution_date:      Optional[pd.Timestamp] = None,
     ) -> np.ndarray:
         m = len(expected_returns)
         if m == 0:
             return np.array([])
+
+        # Institutional T-1 guard: optimizer history must stop strictly before
+        # the execution date to prevent look-ahead leakage.
+        if execution_date is not None and not historical_returns.empty:
+            if historical_returns.index.max() >= pd.Timestamp(execution_date):
+                raise OptimizationError(
+                    "T-1 violation: historical_returns include execution_date.",
+                    OptimizationErrorType.DATA,
+                )
 
         # ── Input validation ──────────────────────────────────────────────────
         if len(prices) != m or len(adv_shares) != m:
@@ -828,21 +839,12 @@ class InstitutionalRiskEngine:
             t_cvar            = T_cvar,
         )
 
-        if physical_cvar > self.cfg.CVAR_DAILY_LIMIT:
-            # Allow a 10% tolerance for numerical noise (e.g. floating-point
-            # rounding in the scenario matrix). Hard-fail anything beyond that.
-            tolerance = self.cfg.CVAR_DAILY_LIMIT * 0.10
-            if physical_cvar > self.cfg.CVAR_DAILY_LIMIT + tolerance:
-                raise OptimizationError(
-                    f"Physical CVaR {physical_cvar:.4%} exceeds hard limit "
-                    f"{self.cfg.CVAR_DAILY_LIMIT:.4%} (solver reported {solver_cvar:.4%}, "
-                    f"slack={slack_value:.6f}). Refusing to deploy.",
-                    OptimizationErrorType.NUMERICAL,
-                )
-            logger.warning(
-                "Physical CVaR %.4f%% marginally exceeds limit %.4f%% "
-                "(within 10%% tolerance). Proceeding with caution.",
-                physical_cvar * 100, self.cfg.CVAR_DAILY_LIMIT * 100,
+        if physical_cvar > self.cfg.CVAR_DAILY_LIMIT + EPSILON:
+            raise OptimizationError(
+                f"Physical CVaR {physical_cvar:.4%} exceeds hard limit "
+                f"{self.cfg.CVAR_DAILY_LIMIT:.4%} (solver reported {solver_cvar:.4%}, "
+                f"slack={slack_value:.6f}). Refusing to deploy.",
+                OptimizationErrorType.NUMERICAL,
             )
 
-        return w_opt
+        return np.round(w_opt, 10)

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -210,19 +210,23 @@ def test_optimizer_adv_binding_count_populated():
 
 
 def test_optimizer_cvar_sentinel_deleverages():
-    """Optimizer must gracefully deleverage (not hard abort) when single-asset CVaR is wildly high."""
+    """Sentinel deleverage is allowed, but hard CVaR limit breaches must still abort."""
     n_days, m = 250, 5
     log_rets = _make_log_rets(n_days, m)
     # Inject massive daily loss to trip the EW-CVaR sentinel
-    log_rets.iloc[-20:, :] = -0.15 
-    
+    log_rets.iloc[-20:, :] = -0.15
+
     engine = _make_engine()
-    w_opt = engine.optimize(
-        np.ones(m)*0.01, log_rets, np.ones(m)*1e6, np.ones(m)*100, 1e6, exposure_multiplier=1.0
-    )
-    # Assert that weights were significantly scaled down due to CVaR sentinel (gamma *= 0.5)
-    # Normally max weights would sum near 1.0. With 0.5 penalty and FLOOR=0.25, it should be <= 0.6
-    assert np.sum(w_opt) < 0.6, "Sentinel should have triggered a deleverage multiplier."
+    with pytest.raises(OptimizationError) as exc_info:
+        engine.optimize(
+            np.ones(m) * 0.01,
+            log_rets,
+            np.ones(m) * 1e6,
+            np.ones(m) * 100,
+            1e6,
+            exposure_multiplier=1.0,
+        )
+    assert exc_info.value.error_type == OptimizationErrorType.NUMERICAL
 
 
 def test_portfolio_state_serialisation_roundtrip():


### PR DESCRIPTION
### Motivation
- Prevent look-ahead bias by ensuring optimizer history stops strictly before execution and harden CVaR invariants to avoid deploying portfolios that exceed limits.
- Remove the prior 10% slack for CVaR breaches and make decay-mode and optimizer checks deterministic and epsilon-safe.

### Description
- Added `EPSILON = 1e-6` and replaced the previous 10% CVaR tolerance with an epsilon-based hard fail in `InstitutionalRiskEngine.optimize`, and now return rounded weights for deterministic outputs (`momentum_engine.py`).
- Introduced an optional `execution_date` parameter to `optimize()` and added a T-1 assertion that raises `OptimizationError` if `historical_returns` includes the execution date (`momentum_engine.py`).
- Hardened post-decay CVaR revalidation to use the same epsilon threshold and liquidate to cash if breached (`momentum_engine.py` / `execute_rebalance`).
- Backtest rebalance flow now resolves an explicit `signal_date` (T-1) instead of relying on implicit slicing, uses `backfill` for calendar alignment, passes `execution_date` into the optimizer, and fixes appending of rebalance log rows (`backtest_engine.py`).
- Live scan/scan workflow now passes `execution_date` into the optimizer call to preserve T-1 semantics (`daily_workflow.py`).
- Tests updated to match the tightened semantics for extreme CVaR failures by expecting an `OptimizationError` for hard breaches (`test_momentum.py`).

### Testing
- Ran the full test suite with `python -m pytest -q`; result: 42 passed, 0 failed.
- Verified there are no lingering `method="pad"` occurrences via a grep scan (no matches).
- Commit created: changes touched `momentum_engine.py`, `backtest_engine.py`, `daily_workflow.py`, and updated `test_momentum.py` to reflect stricter behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a724b2ae78832ba89c3c508fbb0b78)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added look-ahead protection to prevent data integrity issues in optimization.
  * Introduced numeric precision guards for more robust floating-point comparisons.
  * Added validation to skip processing when prior day data is unavailable.

* **Improvements**
  * Stricter CVaR limit enforcement with improved risk controls.
  * Enhanced rebalancing logs with additional metadata for better tracking.
  * Optimized weights are now rounded to higher precision for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->