### PR TITLE
Harden regime score history gate to 253 days

### DIFF
--- a/signals.py
+++ b/signals.py
@@ -40,6 +40,7 @@ def compute_regime_score(
         max(REGIME_VOL_FLOOR, long_term_vol * REGIME_VOL_MULTIPLIER)
 
     where `long_term_vol` is the trailing 252-day annualised vol of the index.
+    A minimum of 253 closing prices is required (252 returns + 1 seed row).
     This prevents the penalty from triggering constantly during healthy
     small/mid-cap momentum rallies where sustained vols of 20-30% are normal.
     Config fields used:
@@ -50,7 +51,7 @@ def compute_regime_score(
 
     Returns 0.5 (neutral) on any data quality issue rather than raising.
     """
-    if idx_hist is None or len(idx_hist) < 200:
+    if idx_hist is None or len(idx_hist) < 253:
         return 0.5
     if "Close" not in idx_hist.columns:
         return 0.5
@@ -60,7 +61,7 @@ def compute_regime_score(
             "compute_regime_score: index not monotonic — deduplicating and continuing."
         )
         idx_hist = idx_hist[~idx_hist.index.duplicated(keep="last")]
-        if len(idx_hist) < 200:
+        if len(idx_hist) < 253:
             return 0.5
 
     close  = idx_hist["Close"]

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -105,6 +105,14 @@ def test_regime_score_neutral_on_thin_history():
     assert compute_regime_score(idx) == 0.5
 
 
+def test_regime_score_neutral_below_vol_lookback_requirement():
+    idx = pd.DataFrame(
+        {"Close": np.linspace(100.0, 120.0, 252)},
+        index=pd.date_range("2020-01-01", periods=252),
+    )
+    assert compute_regime_score(idx) == 0.5
+
+
 def test_regime_score_bull_market():
     """Price well above SMA200 should give score > 0.5."""
     closes = np.linspace(80, 120, 400)      # steady uptrend


### PR DESCRIPTION
### Motivation
- The dynamic volatility penalty in `compute_regime_score` relies on a 252-day returns baseline but the prior guard allowed histories shorter than the required 252 returns, creating a warm-up inconsistency. 
- The change enforces the minimum data required so the long-term volatility benchmark is truly a 252-day estimate and avoids subtle behavioral differences during backtest warmup.

### Description
- Updated `compute_regime_score` in `signals.py` to require at least `253` rows (252 returns + 1 seed row) before computing regime features and applied the same post-deduplication guard. 
- Clarified the `compute_regime_score` docstring to state the minimum of 253 closing prices required for a true 252-return long-term volatility estimate. 
- Added a unit test in `test_momentum.py` (`test_regime_score_neutral_below_vol_lookback_requirement`) asserting a 252-row history returns neutral `0.5`.

### Testing
- Ran `pytest -q test_momentum.py -k regime_score` and the targeted tests completed successfully with `4 passed, 39 deselected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72704c428832b912e42a989d1217e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased minimum historical data requirement for regime score calculations to ensure more robust and reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->