### PR TITLE
Harden T-1 ADV boundary handling and add optimizer guard test

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -263,13 +263,27 @@ def _build_prev_weights(
 def _build_adv_vector(symbols: List[str], volume: pd.DataFrame, date: pd.Timestamp) -> np.ndarray:
     """
     Build the ADV (average daily volume) vector for sizing constraints.
-    Applies the T-1 slice (iloc[:-1]) before delegating to compute_single_adv.
+
+    Uses an explicit T-1 signal_date boundary to avoid implicit slicing.
     """
     adv = []
+    signal_date: Optional[pd.Timestamp] = None
+
+    if not volume.empty:
+        idx = volume.index
+        if date in idx:
+            pos = idx.get_loc(date)
+            if isinstance(pos, slice):
+                pos = pos.start
+            elif isinstance(pos, np.ndarray):
+                pos = int(pos[0]) if len(pos) else -1
+            if pos > 0:
+                signal_date = idx[pos - 1]
+
     for sym in symbols:
-        if sym in volume.columns:
+        if sym in volume.columns and signal_date is not None:
             try:
-                series = volume.loc[:date, sym].iloc[:-1]
+                series = volume.loc[:signal_date, sym]
                 adv.append(compute_single_adv(series))
             except Exception:
                 adv.append(0.0)

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -200,6 +200,25 @@ def test_optimizer_rejects_prev_weights_length_mismatch():
     assert exc_info.value.error_type == OptimizationErrorType.DATA
 
 
+def test_optimizer_enforces_t_minus_one_execution_date_guard():
+    log_rets = _make_log_rets(120, 4)
+    engine   = _make_engine()
+    execution_date = log_rets.index.max()
+
+    with pytest.raises(OptimizationError) as exc_info:
+        engine.optimize(
+            np.array([0.001, 0.002, 0.0005, 0.0015]),
+            log_rets,
+            np.ones(4) * 1e6,
+            np.ones(4) * 200,
+            1_000_000.0,
+            exposure_multiplier=1.0,
+            execution_date=execution_date,
+        )
+
+    assert exc_info.value.error_type == OptimizationErrorType.DATA
+
+
 def test_optimizer_adv_binding_count_populated():
     """SolverDiagnostics.adv_binding_count must not always be zero."""
     n, m = 150, 3


### PR DESCRIPTION
### Motivation
- Remove an implicit `iloc[:-1]` look-ahead in ADV construction to eliminate ghost-slice ambiguity and ensure strict T-1 semantics. 
- Ensure the optimizer's T-1 guard (history must not include `execution_date`) is exercised by the test-suite. 
- Close remaining institutional hardening checklist items around calendar/ADV temporal parity.

### Description
- Replace the previous `iloc[:-1]` approach in `_build_adv_vector` with an explicit `signal_date` computed from `volume.index.get_loc(date)` and slice `volume.loc[:signal_date, sym]` to guarantee the previous trading session is used. 
- Preserve defensive fallbacks so missing symbols or absent signal dates yield `0.0` ADV entries instead of raising. 
- Add `test_optimizer_enforces_t_minus_one_execution_date_guard` to `test_momentum.py` which asserts `InstitutionalRiskEngine.optimize` raises an `OptimizationError` of type `DATA` when `historical_returns` includes the provided `execution_date`.

### Testing
- Ran targeted unit tests with `pytest -q test_momentum.py -k "test_volume_no_lookahead or test_optimizer_enforces_t_minus_one_execution_date_guard"` and both tests passed. 
- Ran a second targeted invocation `pytest -q test_momentum.py -k "build_adv_vector or optimizer_enforces_t_minus_one_execution_date_guard"` which also passed. 
- Confirmed no remaining `method="pad"` usage with `rg -n "method=\"pad\"|method='pad'" *.py` which reported no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72919eb54832ba65510b1129ad544)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed volume calculation in backtesting to use explicit previous-day boundary, ensuring accurate average daily volume computation only for available symbols.
  * Improved data validation to prevent using current date as execution reference in optimization.

* **Tests**
  * Added validation test to ensure optimizer rejects invalid execution dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->