### PR TITLE
Prevent dividend double-counting: add persistent dividend ledger and fix tests

### DIFF
--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -241,8 +241,17 @@ def detect_and_apply_splits(state: PortfolioState, market_data: dict, cfg: Ultim
             if div > 0:
                 shares_held = state.shares.get(sym, 0)
                 if shares_held > 0:
-                    state.cash = round(state.cash + (div * shares_held), 10)
-                    logger.info("DIVIDEND SWEEP: %s distributed ₹%.2f per share (x %d shares). Added to cash.", sym, div, shares_held)
+                    div_date = pd.Timestamp(row.index[-1]).strftime("%Y-%m-%d")
+                    event_id = f"{div_date}:{div:.8f}"
+                    if state.dividend_ledger.get(sym) != event_id:
+                        state.cash = round(state.cash + (div * shares_held), 10)
+                        state.dividend_ledger[sym] = event_id
+                        logger.info(
+                            "DIVIDEND SWEEP: %s distributed ₹%.2f per share (x %d shares). Added to cash.",
+                            sym,
+                            div,
+                            shares_held,
+                        )
 
         current_price = float(row["Close"].iloc[-1])
         if not np.isfinite(current_price) or current_price <= 0:

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -216,6 +216,7 @@ class PortfolioState:
     absent_periods:       Dict[str, int]   = field(default_factory=dict)
     last_known_prices:    Dict[str, float] = field(default_factory=dict)
     decay_rounds:         int              = 0
+    dividend_ledger:      Dict[str, str]   = field(default_factory=dict)
 
     def update_exposure(
         self,
@@ -318,6 +319,7 @@ class PortfolioState:
             "absent_periods":       dict(sorted(self.absent_periods.items())),
             "last_known_prices":    _r(self.last_known_prices),
             "decay_rounds":         self.decay_rounds,
+            "dividend_ledger":      dict(sorted(self.dividend_ledger.items())),
         }
 
     @classmethod
@@ -362,6 +364,7 @@ class PortfolioState:
         ps.absent_periods       = _get("absent_periods",       lambda v: {k: int(x) for k, x in v.items()},   {})
         ps.last_known_prices    = _get("last_known_prices",    lambda v: {k: float(x) for k, x in v.items()}, {})
         ps.decay_rounds         = _get("decay_rounds",         int,                                             0)
+        ps.dividend_ledger      = _get("dividend_ledger",      lambda v: {k: str(x) for k, x in v.items()},     {})
 
         if errors:
             logger.error(

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -382,10 +382,24 @@ def test_detect_and_apply_splits_fractional_cash():
     state.last_known_prices = {"A": 100.0}
 
     market_data = {"A": pd.DataFrame({"Close": [200.0]})}
-    detect_and_apply_splits(state, market_data)
+    detect_and_apply_splits(state, market_data, UltimateConfig())
 
     assert state.shares["A"] == 50, "Shares should floor correctly on splits."
     assert state.cash == 200.0, "Fractional value must be safely routed to Cash."
+
+def test_detect_and_apply_splits_dividend_sweep_idempotent():
+    state = PortfolioState(cash=0.0)
+    state.shares = {"A": 100}
+    state.last_known_prices = {"A": 100.0}
+    idx = pd.to_datetime(["2024-01-01", "2024-01-02"])
+    market_data = {"A.NS": pd.DataFrame({"Close": [100.0, 102.0], "Dividends": [0.0, 2.0]}, index=idx)}
+
+    cfg = UltimateConfig(DIVIDEND_SWEEP=True)
+    detect_and_apply_splits(state, market_data, cfg)
+    detect_and_apply_splits(state, market_data, cfg)
+
+    assert state.cash == 200.0
+    assert state.dividend_ledger["A"] == "2024-01-02:2.00000000"
 
 
 # ─── PortfolioState.record_eod ────────────────────────────────────────────────
@@ -862,7 +876,6 @@ def test_book_cvar_screen_forces_liquidation():
     # Ensure sticky counter is eradicated
     assert bt.state.consecutive_failures == 0
 
-# ... existing code ...
 def test_compute_book_cvar_empty_book_returns_zero():
     cfg      = UltimateConfig()
     state    = PortfolioState()
@@ -877,27 +890,58 @@ def test_compute_book_cvar_missing_columns_handled_as_ghosts():
     state      = PortfolioState(cash=0.0)
     state.shares = {"OFFUNIVERSE": 100}
     state.last_known_prices = {"OFFUNIVERSE": 10.0}
-    
-    result     = compute_book_cvar(state, np.array([]), [], log_rets, cfg)
+
+    result = compute_book_cvar(state, np.array([]), [], log_rets, cfg)
     assert result > 0.0, "Ghost position must have synthetic tail risk applied, yielding non-zero CVaR."
 
 
 def test_compute_book_cvar_high_loss_book():
-# ... existing code ...
+    cfg = UltimateConfig(CVAR_LOOKBACK=50)
+    log_rets = _make_log_rets(80, 2)
+    log_rets.iloc[-20:, :] = -0.10
+
+    state = PortfolioState(cash=0.0)
+    state.shares = {"SYM00": 100, "SYM01": 100}
+    state.last_known_prices = {"SYM00": 100.0, "SYM01": 100.0}
+
+    result = compute_book_cvar(state, np.array([100.0, 100.0]), ["SYM00", "SYM01"], log_rets, cfg)
+    assert result > 0.05
+
+
 def test_compute_decay_targets_enforces_single_name_cap():
     cfg = UltimateConfig(DECAY_FACTOR=0.85, MAX_SINGLE_NAME_WEIGHT=0.25)
     state = PortfolioState()
     state.weights = {"A": 0.35}
-    
+
     targets = compute_decay_targets(state, [0], ["A"], cfg)
     assert targets[0] == pytest.approx(0.2125), "Decayed target must cap the pre-decay weight, then scale."
 
 
 def test_book_cvar_screen_with_ghost_resets_failures():
-# ... existing code ...
-    assert "BOMB" not in bt.state.shares, "BOMB must be fully liquidated."
-    assert "GHOST" in bt.state.shares, "GHOST has no liquidity, so it must physically persist."
-    assert bt.state.absent_periods["GHOST"] == 1
+    cfg = UltimateConfig(INITIAL_CAPITAL=1_000_000)
+    n_days, n_syms = 120, 2
+    close = _make_close(n_days, n_syms)
+    volume = pd.DataFrame(np.ones((n_days, n_syms)) * 1e6, index=close.index, columns=close.columns)
+    returns = close.pct_change(fill_method=None).clip(lower=-0.99)
+
+    engine = InstitutionalRiskEngine(cfg)
+    bt = BacktestEngine(engine, initial_cash=cfg.INITIAL_CAPITAL)
+    bt.state.shares = {"SYM00": 100, "GHOST": 10}
+    bt.state.weights = {"SYM00": 0.5, "GHOST": 0.1}
+    bt.state.last_known_prices = {"SYM00": 100.0, "GHOST": 50.0}
+    bt.state.entry_prices = {"SYM00": 100.0, "GHOST": 50.0}
+    bt.state.consecutive_failures = 2
+
+    import unittest.mock as mock
+
+    with mock.patch("backtest_engine.compute_book_cvar", return_value=cfg.CVAR_DAILY_LIMIT + 0.01):
+        rebal_dates = close.index[60:61]
+        bt.run(close, volume, returns, rebal_dates, close.index[0].strftime("%Y-%m-%d"))
+
+    assert "SYM00" not in bt.state.shares, "Tradable symbol should be fully liquidated on hard CVaR breach."
+    assert "GHOST" in bt.state.shares, "Off-universe ghost should persist until absent-period threshold is reached."
+    assert bt.state.absent_periods.get("GHOST", 0) == 1
+    assert bt.state.consecutive_failures == 0
 
 
 def test_decay_rounds_exhaustion_forces_liquidation():


### PR DESCRIPTION
### Motivation
- Prevent repeated crediting of the same dividend event across repeated scans which inflated cash/equity.
- Make the dividend dedupe durable across restarts by persisting the last-processed dividend per symbol.
- Repair a few malformed / placeholder tests so the test-suite can be exercised cleanly.

### Description
- Add `dividend_ledger: Dict[str, str]` to `PortfolioState` and include it in `to_dict`/`from_dict` so ledger entries persist across saves and loads (`momentum_engine.py`).
- Modify `detect_and_apply_splits` to deduplicate dividend sweeps by constructing an `event_id` (`date:amount`) and only crediting cash if the ledger does not already contain that `event_id` for the symbol (`daily_workflow.py`).
- Update tests in `test_momentum.py` to call `detect_and_apply_splits` with the `cfg` parameter and to add/restore deterministic coverage for idempotent dividend sweeps and CVaR edge cases (several test functions adjusted/added).

### Testing
- Ran `python -m py_compile momentum_engine.py daily_workflow.py test_momentum.py` and it succeeded.
- Executed unit test attempts: an initial `pytest` run earlier failed during collection due to an unrelated indentation error in tests which was fixed; a later targeted `pytest` run was blocked by a pre-existing import issue in `universe_manager` (`ImportError: cannot import name 'STATIC_NSE_SECTORS'`), not introduced by this change.
- Performed a manual runtime validation script that calls `detect_and_apply_splits` twice and confirmed the dividend is credited only once and the `dividend_ledger` entry is populated as expected (observed output: `200.0 {'A': '2024-01-02:2.00000000'}`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a93dffa278832b817215d823a27f38)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dividend processing logic to prevent duplicate dividend cash additions and maintain accurate portfolio balance tracking.

* **Testing**
  * Expanded test suite coverage for dividend handling idempotency and enhanced risk management feature testing to improve system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->