### PR TITLE
Fix exposure override cooldown cycling and backtest parity valuation

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -127,11 +127,11 @@ class BacktestEngine:
 
         adv_vector = _build_adv_vector(symbols, close, volume, date)
 
-        signal_close = close.loc[signal_date]
+        execution_close = close.loc[date]
         pv = self.state.cash + sum(
             self.state.shares.get(sym, 0) * (
-                float(signal_close[sym])
-                if (sym in close.columns and pd.notna(signal_close[sym]))
+                float(execution_close[sym])
+                if (sym in close.columns and pd.notna(execution_close[sym]))
                 else self.state.last_known_prices.get(sym, 0.0)
             )
             for sym in self.state.shares
@@ -149,8 +149,8 @@ class BacktestEngine:
 
         gross_exposure = sum(
             self.state.shares.get(sym, 0) * (
-                float(signal_close[sym])
-                if pd.notna(signal_close[sym])
+                float(execution_close[sym])
+                if pd.notna(execution_close[sym])
                 else self.state.last_known_prices.get(sym, 0.0)
             )
             for sym in self.state.shares

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -243,13 +243,15 @@ class PortfolioState:
         normalised_cvar = realized_cvar / max(float(gross_exposure), 0.05)
         breach = normalised_cvar > cfg.MAX_PORTFOLIO_RISK_PCT
 
+        cooled_down_this_step = False
         if self.override_cooldown > 0:
             self.override_cooldown -= 1
+            cooled_down_this_step = self.override_cooldown == 0
 
         if self.override_cooldown == 0 and self.override_active:
             self.override_active = False
 
-        if breach and not self.override_active and self.override_cooldown == 0:
+        if breach and not self.override_active and self.override_cooldown == 0 and not cooled_down_this_step:
             override_mult            = max(cfg.MIN_EXPOSURE_FLOOR, self.exposure_multiplier * 0.5)
             self.exposure_multiplier = min(new_mult, override_mult)
             self.override_active     = True


### PR DESCRIPTION
### Motivation
- A sustained CVaR breach could re-trigger the exposure override immediately in the same timestep the cooldown reached zero, breaking the expected trigger cadence.  
- Backtest ledger state diverged from manual replication because portfolio valuation (`pv`) and `gross_exposure` were computed using the signal-date close instead of the execution-date close.  

### Description
- Prevent `PortfolioState.update_exposure` from re-activating the override on the same call where `override_cooldown` decrements to zero by tracking `cooled_down_this_step` and gating re-triggering.  
- In `BacktestEngine._run_rebalance`, compute `pv` and `gross_exposure` against the execution-date prices (`execution_close = close.loc[date]`) so the backtest uses the same valuation basis as live/manual execution.  
- Minor formatting/newline normalization in `momentum_engine.py` return value (no behavioral change).  

### Testing
- Ran targeted tests with `pytest -q test_momentum.py::test_update_exposure_sustained_cvar_breach_recovery test_momentum.py::test_e2e_ledger_parity`, and both tests passed.  
- Ran the full suite with `pytest -q`, and the test run completed successfully with all tests passing (56 passed, 1 skipped in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a974240ef4832bbb81c54356fddc14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Portfolio value and exposure calculations now use current date pricing data for more accurate position valuation.
  * Refined cooldown logic to prevent consecutive override triggers within the same time step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->