### PR TITLE
Fix optimizer atomic save path and add MAX_DD_CAP prune coverage

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -14,7 +14,6 @@ import tempfile
 import sys
 import warnings
 
-import numpy as np
 import pandas as pd
 import optuna
 from optuna.samplers import TPESampler
@@ -97,16 +96,16 @@ class MomentumObjective:
         cagr = metrics.get("cagr", 0.0)
         max_dd = abs(metrics.get("max_dd", 100.0))
 
-        # 5. Objective Calculation (Calmar Ratio)
-        if max_dd == 0:
-            return 0.0
-            
-        calmar = cagr / max_dd
-
         # 6. Hard prune if IS drawdown exceeds the pre-COVID cap.
         # IS window (2018-2019) has no crash, so >25% DD is a real structural fail.
         if max_dd > MAX_DD_CAP:
             raise optuna.TrialPruned()
+
+        # 5. Objective Calculation (Calmar Ratio)
+        if max_dd == 0:
+            return 0.0
+
+        calmar = cagr / max_dd
 
         return calmar
 
@@ -149,7 +148,7 @@ def save_optimal_config(best_params: dict, filepath: str = "data/optimal_cfg.jso
     with tempfile.NamedTemporaryFile(
         mode="w",
         encoding="utf-8",
-        dir=output_dir or None,
+        dir=output_dir or os.path.dirname(os.path.abspath(filepath)) or ".",
         delete=False,
     ) as tmp_file:
         json.dump(best_params, tmp_file, indent=4)

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -84,6 +84,27 @@ def test_objective_prunes_trial_on_optimization_error(monkeypatch):
         objective(trial)
 
 
+def test_objective_prunes_trial_when_drawdown_exceeds_cap(monkeypatch):
+    class _Result:
+        metrics = {"cagr": 10.0, "max_dd": 30.0}
+
+    monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
+
+    objective = optimizer.MomentumObjective(market_data={}, universe_type="nifty500")
+    trial = optuna.trial.FixedTrial(
+        {
+            "HALFLIFE_FAST": 21,
+            "HALFLIFE_SLOW": 63,
+            "CONTINUITY_BONUS": 0.15,
+            "RISK_AVERSION": 5.0,
+            "CVAR_DAILY_LIMIT": 0.04,
+        }
+    )
+
+    with pytest.raises(optuna.TrialPruned):
+        objective(trial)
+
+
 def test_save_optimal_config_replaces_existing_file_atomically(tmp_path: Path):
     output_path = tmp_path / "optimal_cfg.json"
     output_path.write_text('{"old": 1}', encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Prevent cross-device `os.replace` failures when callers pass a plain filename to `save_optimal_config` by ensuring the temp file is created in the target directory.
- Remove an unused `numpy` import to eliminate dead code.
- Make the objective flow clearer by pruning excessive in-sample drawdowns before computing the Calmar ratio.
- Add unit coverage for the `MAX_DD_CAP` prune path which was not exercised by existing tests.

### Description
- Updated `save_optimal_config` to create the temporary file in `output_dir or os.path.dirname(os.path.abspath(filepath)) or "."` to guarantee the atomic rename succeeds even when `filepath` is a plain filename (file: `optimizer.py`).
- Removed the unused `import numpy as np` from `optimizer.py`.
- Reordered the objective logic in `MomentumObjective.__call__` to perform the `MAX_DD_CAP` hard prune before computing the Calmar ratio, while preserving the `max_dd == 0` early return (file: `optimizer.py`).
- Added `test_objective_prunes_trial_when_drawdown_exceeds_cap` to `test_optimizer.py` which verifies an Optuna trial is pruned when `max_dd` exceeds the in-sample cap.

### Testing
- Ran `pytest -q test_optimizer.py` and all tests passed; result: `7 passed in 1.64s`.
- The new test `test_objective_prunes_trial_when_drawdown_exceeds_cap` ran successfully as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa811fc5c0832bb026928a3b11a107)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added market data pre-loading capability to cache data before optimization runs.

* **Bug Fixes**
  * Improved calculation logic and added protection for edge cases in financial metrics.
  * Enhanced temporary file handling for more reliable operations.

* **Tests**
  * Added test coverage for pruning behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->