### PR TITLE
Improve CLI menu handling and make cache padding dynamic; add workflow/cache tests

### DIFF
--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -725,13 +725,14 @@ def _render_main_menu(states: Dict[str, PortfolioState]) -> None:
     print(f"    Custom Screener → {_portfolio_activity_badge(states['custom'])}")
 
 def _prompt_menu_choice(prompt: str, valid: List[str], default: Optional[str] = None) -> str:
-    raw = input(prompt).strip().lower()
-    if not raw and default is not None:
-        return default
-    if raw not in valid:
-        print(f"  {C.RED}Invalid choice. Valid options: {', '.join(valid)}{C.RST}")
-        return ""
-    return raw
+    while True:
+        raw = input(prompt).strip().lower()
+        if not raw and default is not None:
+            return default
+        if raw not in valid:
+            print(f"  {C.RED}Invalid choice. Valid options: {', '.join(valid)}{C.RST}")
+            continue
+        return raw
 
 def _normalise_start_date(raw: str, default: str = "2020-01-01") -> str:
     candidate = raw.strip() or default

--- a/data_cache.py
+++ b/data_cache.py
@@ -248,9 +248,12 @@ def load_or_fetch(
         for t in tickers
     ))
     
-    # We always pad the required start date back by ~400 days to guarantee
-    # we have enough history for 200-day SMAs and long-term CVaR lookbacks.
-    padded_start = (pd.Timestamp(required_start or "2020-01-01") - timedelta(days=400)).strftime("%Y-%m-%d")
+    # Dynamic padding based on strategy lookback requirements (plus safety margin).
+    cfg_lookback = int(getattr(cfg, "CVAR_LOOKBACK", 200) or 200)
+    dynamic_padding_days = max(400, cfg_lookback * 2)
+    padded_start = (
+        pd.Timestamp(required_start or "2020-01-01") - timedelta(days=dynamic_padding_days)
+    ).strftime("%Y-%m-%d")
     
     # Latest valid business day
     latest_bday = (pd.Timestamp.today() - pd.offsets.BDay(1)).strftime("%Y-%m-%d")

--- a/test_daily_workflow.py
+++ b/test_daily_workflow.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+import daily_workflow as dw
+from momentum_engine import PortfolioState, UltimateConfig
+
+
+def test_prompt_menu_choice_retries_until_valid(monkeypatch):
+    responses = iter(["bad", "2"])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(responses))
+
+    choice = dw._prompt_menu_choice("Choice: ", ["1", "2", "q"])
+
+    assert choice == "2"
+
+
+def test_load_optimized_config_ignores_unknown_fields(tmp_path: Path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "optimal_cfg.json").write_text(
+        json.dumps({"HALFLIFE_FAST": 34, "DOES_NOT_EXIST": 1}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    cfg = dw.load_optimized_config()
+
+    assert cfg.HALFLIFE_FAST == 34
+    assert not hasattr(cfg, "DOES_NOT_EXIST")
+
+
+def test_get_custom_universe_uses_local_fallback_when_confirmed(tmp_path: Path, monkeypatch):
+    fallback = tmp_path / "custom_screener.txt"
+    fallback.write_text("ABC\n123456\nXYZ\nABC\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(dw, "_scrape_screener", lambda _url: [])
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    tickers = dw._get_custom_universe()
+
+    assert tickers == ["ABC", "XYZ"]
+
+
+def test_run_scan_returns_early_when_universe_has_no_data(monkeypatch):
+    captured = {}
+
+    def _fake_load_or_fetch(tickers, required_start, required_end, cfg=None):
+        captured["tickers"] = tickers
+        captured["required_start"] = required_start
+        captured["required_end"] = required_end
+        captured["cfg"] = cfg
+        return {"^NSEI": pd.DataFrame({"Close": [100.0]}, index=pd.date_range("2024-01-01", periods=1))}
+
+    monkeypatch.setattr(dw, "load_or_fetch", _fake_load_or_fetch)
+    monkeypatch.setattr(dw, "_print_stage_status", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(dw, "detect_and_apply_splits", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(dw, "compute_regime_score", lambda *_args, **_kwargs: 0.5)
+
+    cfg = UltimateConfig(CVAR_LOOKBACK=260)
+    state = PortfolioState()
+
+    returned_state, market_data = dw._run_scan(["ABC"], state, "TEST", cfg_override=cfg)
+
+    assert returned_state is state
+    assert "^NSEI" in market_data
+    assert captured["cfg"] is cfg

--- a/test_data_cache.py
+++ b/test_data_cache.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pandas as pd
+
+import data_cache
+from momentum_engine import UltimateConfig
+
+
+def test_load_or_fetch_uses_dynamic_padding_from_cfg(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(data_cache, "_load_manifest", lambda: {"schema_version": 1, "entries": {}})
+    monkeypatch.setattr(data_cache, "_save_manifest", lambda _manifest: None)
+
+    def _fake_download_with_timeout(tickers, start, end):
+        captured["start"] = start
+        captured["end"] = end
+        return pd.DataFrame()
+
+    monkeypatch.setattr(data_cache, "_download_with_timeout", _fake_download_with_timeout)
+
+    cfg = UltimateConfig(CVAR_LOOKBACK=500)
+    data_cache.load_or_fetch(
+        tickers=["ABC"],
+        required_start="2024-01-01",
+        required_end="2024-12-31",
+        force_refresh=True,
+        cfg=cfg,
+    )
+
+    assert captured["start"] == "2021-04-06"
+    assert captured["end"] == "2024-12-31"

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -142,7 +142,7 @@ def test_save_optimal_config_replaces_existing_file_atomically(tmp_path: Path):
     assert payload == {"HALFLIFE_FAST": 34}
 
 
-def test_pre_load_data_normalizes_universe_type_and_deduplicates_tickers(monkeypatch):
+def test_pre_load_data_deduplicates_inputs_and_appends_crsldx_index(monkeypatch):
     monkeypatch.setattr(optimizer, "TRAIN_START", "2020-01-01")
     monkeypatch.setattr(optimizer, "TEST_END", "2020-12-31")
     monkeypatch.setattr(optimizer, "fetch_nse_equity_universe", lambda: ["ABC", "^NSEI", "ABC"])
@@ -162,7 +162,9 @@ def test_pre_load_data_normalizes_universe_type_and_deduplicates_tickers(monkeyp
     assert result == {"ok": True}
     assert captured["required_start"] == "2020-01-01"
     assert captured["required_end"] == "2020-12-31"
-    assert captured["tickers"] == ["ABC", "^NSEI", "^CRSLDX"]
+    assert captured["tickers"].count("ABC") == 1
+    assert "^NSEI" in captured["tickers"]
+    assert "^CRSLDX" in captured["tickers"]
 
 
 def test_build_sampler_returns_tpe_sampler(monkeypatch):


### PR DESCRIPTION
### Motivation
- Eliminate noisy menu UX when an operator mistypes by making the menu prompt retry internally instead of returning an empty sentinel.  
- Ensure the data cache fetches enough history for tuned CVaR lookbacks by replacing the hardcoded 400-day padding with a dynamic padding derived from `cfg.CVAR_LOOKBACK` (with a safety floor).  
- Add unit tests for the interactive/CLI and cache layers to catch regressions in workflow helper code and to clarify a slightly misleading optimizer test assertion.

### Description
- Make `_prompt_menu_choice` loop until a valid choice (or default) is provided so callers no longer have to re-render the entire main menu on invalid input (`daily_workflow.py`).  
- Replace the fixed `timedelta(days=400)` start padding in `load_or_fetch` with a dynamic calculation that uses `int(getattr(cfg, "CVAR_LOOKBACK", 200))` and computes `dynamic_padding_days = max(400, cfg_lookback * 2)`, then subtracts that many days from `required_start` (`data_cache.py`).  
- Add unit tests covering CLI/workflow behavior in `test_daily_workflow.py` and a cache-padding test in `test_data_cache.py`, and adjust an optimizer test to assert deduplication and mandatory index inclusion more clearly (`test_optimizer.py`).

### Testing
- Ran the focused pytest suite: `pytest -q test_daily_workflow.py test_data_cache.py test_optimizer.py::test_pre_load_data_deduplicates_inputs_and_appends_crsldx_index`.  
- Result: all tests passed (`6 passed`), confirming the prompt retry behaviour and the dynamic padding calculation behave as expected.  
- Added mocks in tests to validate interaction points (`load_or_fetch` start/end args, `_prompt_menu_choice` input flow, and local fallback for custom screener).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa9c1e0948832b8cf674a61df91f39)