### PR TITLE
Robustness fixes: ADV edge-case, trade metrics, OOS hard-fail, exposure cap, paper mode, sector cache lock, historical bootstrap

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -345,6 +345,8 @@ def _build_adv_vector(symbols: List[str], close: pd.DataFrame, volume: pd.DataFr
                     pos = int(pos[0]) if len(pos) else -1
             if pos > 0:
                 signal_date = idx[pos - 1]
+            else:
+                signal_date = idx[0]
 
     for sym in symbols:
         if sym in volume.columns and sym in close.columns and signal_date is not None:
@@ -463,7 +465,7 @@ def run_backtest(
     return BacktestResults(
         equity_curve = eq_weekly,
         trades       = bt.trades,
-        metrics      = _compute_metrics(eq_daily, cfg.INITIAL_CAPITAL, cfg.SIGNAL_ANNUAL_FACTOR),
+        metrics      = _compute_metrics(eq_daily, cfg.INITIAL_CAPITAL, cfg.SIGNAL_ANNUAL_FACTOR, trades=bt.trades),
         rebal_log    = rebal_log,
     )
 
@@ -488,9 +490,23 @@ def print_backtest_results(results: BacktestResults) -> None:
     print(f"  \033[90m{chr(9472)*65}\033[0m\n")
 
 
-def _compute_metrics(eq: pd.Series, initial: float, periods_per_year: int = 252) -> Dict:
+def _compute_metrics(
+    eq: pd.Series,
+    initial: float,
+    periods_per_year: int = 252,
+    trades: Optional[List[Trade]] = None,
+) -> Dict:
     if eq.empty:
-        return {"cagr": 0.0, "max_dd": 0.0, "final": initial, "sharpe": 0.0, "sortino": 0.0, "calmar": 0.0}
+        return {
+            "cagr": 0.0,
+            "max_dd": 0.0,
+            "final": initial,
+            "sharpe": 0.0,
+            "sortino": 0.0,
+            "calmar": 0.0,
+            "hit_rate": 0.0,
+            "turnover": 0.0,
+        }
 
     final  = float(eq.iloc[-1])
     n_periods = max(len(eq) - 1, 1)
@@ -514,6 +530,47 @@ def _compute_metrics(eq: pd.Series, initial: float, periods_per_year: int = 252)
 
     calmar = (cagr / abs(max_dd)) if max_dd < 0 else 0.0
 
+    hit_rate = 0.0
+    turnover = 0.0
+    if trades:
+        buy_trades = [t for t in trades if t.direction == "BUY" and t.delta_shares > 0]
+        sell_trades = [t for t in trades if t.direction == "SELL" and t.delta_shares < 0]
+
+        round_trip_pnls: List[float] = []
+        buy_queue: Dict[str, List[tuple[int, float]]] = {}
+
+        for trade in trades:
+            if trade.delta_shares == 0:
+                continue
+
+            qty = abs(int(trade.delta_shares))
+            price = float(trade.exec_price)
+
+            if trade.direction == "BUY" and trade.delta_shares > 0:
+                buy_queue.setdefault(trade.symbol, []).append((qty, price))
+            elif trade.direction == "SELL" and trade.delta_shares < 0:
+                lots = buy_queue.setdefault(trade.symbol, [])
+                remaining = qty
+                while remaining > 0 and lots:
+                    lot_qty, lot_px = lots[0]
+                    matched = min(remaining, lot_qty)
+                    round_trip_pnls.append((price - lot_px) * matched)
+                    remaining -= matched
+                    lot_qty -= matched
+                    if lot_qty == 0:
+                        lots.pop(0)
+                    else:
+                        lots[0] = (lot_qty, lot_px)
+
+        if round_trip_pnls:
+            hit_rate = (sum(1 for pnl in round_trip_pnls if pnl > 0) / len(round_trip_pnls)) * 100.0
+
+        total_buy_notional = sum(t.delta_shares * t.exec_price for t in buy_trades)
+        total_sell_notional = sum(abs(t.delta_shares) * t.exec_price for t in sell_trades)
+        avg_equity = float(eq.mean()) if len(eq) > 0 else float(initial)
+        if avg_equity > 0:
+            turnover = ((total_buy_notional + total_sell_notional) / 2.0) / avg_equity
+
     return {
         "cagr":    round(cagr,    2),
         "max_dd":  round(max_dd,  2),
@@ -521,4 +578,6 @@ def _compute_metrics(eq: pd.Series, initial: float, periods_per_year: int = 252)
         "sharpe":  round(sharpe,  2),
         "sortino": sortino if not np.isfinite(sortino) else round(sortino, 2),
         "calmar":  round(calmar,  2),
+        "hit_rate": round(hit_rate, 2),
+        "turnover": round(turnover, 4),
     }

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -8,6 +8,7 @@ Dividend Sweeping, and Impact-Aligned Rebalancing.
 
 from __future__ import annotations
 
+import argparse
 import copy
 import json
 import logging
@@ -49,6 +50,7 @@ from signals import generate_signals, compute_adv, compute_regime_score
 __version__ = "11.46"
 
 BACKUP_GENERATIONS = 3
+PAPER_MODE = False
 
 # ─── ANSI colour palette ─────────────────────────────────────────────────────
 
@@ -312,6 +314,10 @@ def detect_and_apply_splits(state: PortfolioState, market_data: dict, cfg: Ultim
 # ─── State persistence ────────────────────────────────────────────────────────
 
 def save_portfolio_state(state: PortfolioState, name: str) -> None:
+    if PAPER_MODE:
+        print(f"  {C.YLW}[!] Paper mode active. State will not be saved.{C.RST}")
+        return
+
     os.makedirs("data", exist_ok=True)
     state_file = f"data/portfolio_state_{name}.json"
     tmp_file   = f"{state_file}.tmp"
@@ -945,7 +951,21 @@ def main_menu() -> None:
             print(f"  {C.GRY}Goodbye!{C.RST}\n")
             break
 
+
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Ultimate Momentum daily workflow")
+    parser.add_argument(
+        "--paper",
+        action="store_true",
+        help="Enable paper trading mode (disables portfolio state file writes).",
+    )
+    return parser.parse_args(argv)
+
+
 if __name__ == "__main__":
+    args = _parse_args()
+    PAPER_MODE = bool(args.paper)
+
     os.makedirs("logs", exist_ok=True)
 
     logging.basicConfig(
@@ -959,4 +979,6 @@ if __name__ == "__main__":
     )
 
     logger.info("Ultimate Momentum v%s started", __version__)
+    if PAPER_MODE:
+        logger.warning("[!] Paper mode active. State will not be saved.")
     main_menu()

--- a/historical_builder.py
+++ b/historical_builder.py
@@ -1,0 +1,36 @@
+"""
+historical_builder.py
+=====================
+Bootstrap utility to initialize a historical universe parquet so first-time
+users can run backtests without hitting missing-file errors.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def bootstrap_historical_parquet(
+    output_path: str = "data/historical_nifty500.parquet",
+    tickers: list[str] | None = None,
+) -> Path:
+    """Create a minimal historical parquet with DatetimeIndex + tickers list column."""
+    default_tickers = tickers or ["RELIANCE", "TCS", "HDFCBANK"]
+    idx = pd.DatetimeIndex([pd.Timestamp.today().normalize()], name="date")
+    df = pd.DataFrame({"tickers": [default_tickers]}, index=idx)
+
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(path)
+    return path
+
+
+def main() -> None:
+    path = bootstrap_historical_parquet()
+    print(f"[+] Bootstrap complete: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -464,6 +464,11 @@ def execute_rebalance(
             state.decay_rounds, cfg.MAX_DECAY_ROUNDS,
         )
 
+    capped_targets = np.array(target_weights, dtype=float, copy=True)
+    capped_targets = np.where(np.isfinite(capped_targets), capped_targets, 0.0)
+    capped_targets = np.clip(capped_targets, 0.0, cfg.MAX_SINGLE_NAME_WEIGHT)
+    target_weights = capped_targets
+
     new_weights:      Dict[str, float] = {}
     new_shares:       Dict[str, int]   = {}
     new_entry_prices: Dict[str, float] = dict(state.entry_prices)

--- a/optimizer.py
+++ b/optimizer.py
@@ -271,8 +271,13 @@ def run_optimization(universe_type: str = "nifty500"):
         if m.get('calmar', 0) > 1.0 and abs(m.get('max_dd', 100)) <= OOS_MAX_DD_CAP:
             print("\n\033[1;32m[PASS]\033[0m Strategy parameters survived Out-of-Sample verification without structural decay.")
         else:
-            print("\n\033[1;31m[FAIL]\033[0m Parameters degraded severely Out-of-Sample. The model is overfitted to the training data.")
+            raise RuntimeError(
+                "OOS Validation Failed: Parameters degraded severely Out-of-Sample. "
+                "The model is overfitted."
+            )
 
+    except RuntimeError:
+        raise
     except Exception as e:
         print(f"\n\033[1;31m[FAIL]\033[0m OOS Validation threw an exception: {e}")
 

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -214,7 +214,7 @@ def test_run_optimization_passes_parallel_jobs_to_optuna(monkeypatch):
     monkeypatch.setattr(optimizer, "save_optimal_config", lambda best_params: None)
 
     class _Result:
-        metrics = {"final": 1.0, "cagr": 1.0, "max_dd": 1.0, "calmar": 1.0}
+        metrics = {"final": 1.0, "cagr": 1.0, "max_dd": 1.0, "calmar": 1.1}
 
     monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
 
@@ -254,7 +254,7 @@ def test_run_optimization_uses_selected_universe(monkeypatch):
     monkeypatch.setattr(optimizer, "pre_load_data", _fake_pre_load_data)
 
     class _Result:
-        metrics = {"final": 1.0, "cagr": 1.0, "max_dd": 1.0, "calmar": 1.0}
+        metrics = {"final": 1.0, "cagr": 1.0, "max_dd": 1.0, "calmar": 1.1}
 
     monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
 

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -13,6 +13,7 @@ import io
 import json
 import logging
 import os
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
@@ -107,6 +108,7 @@ STATIC_NSE_SECTORS: Dict[str, str] = {
 # preventing thousands of identical lines from flooding optimizer output.
 _MISSING_PARQUET_WARNED: Dict[str, bool] = {}
 _NO_RECORD_WARNED: Dict[str, bool] = {}
+_SECTOR_MAP_CACHE_LOCK = threading.Lock()
 
 
 def get_historical_universe(universe_type: str, date: pd.Timestamp) -> List[str]:
@@ -361,15 +363,16 @@ def get_sector_map(tickers: List[str], use_cache: bool = True, cfg=None) -> Dict
                 
         # Update cache with newly found sectors
         if use_cache:
-            cache = _load_universe_cache()
-            existing_sector_cache = cache.get("sector_map", {}).get("sectors", {})
-            existing_sector_cache.update({sym: resolved_map[sym] for sym in missing_tickers})
-            
-            cache["sector_map"] = {
-                "fetched_at": datetime.now().isoformat(),
-                "sectors": existing_sector_cache
-            }
-            _save_universe_cache(cache)
+            with _SECTOR_MAP_CACHE_LOCK:
+                cache = _load_universe_cache()
+                existing_sector_cache = cache.get("sector_map", {}).get("sectors", {})
+                existing_sector_cache.update({sym: resolved_map[sym] for sym in missing_tickers})
+
+                cache["sector_map"] = {
+                    "fetched_at": datetime.now().isoformat(),
+                    "sectors": existing_sector_cache
+                }
+                _save_universe_cache(cache)
             
     # Format the return dictionary to match exactly the requested input tickers
     final_map = {}


### PR DESCRIPTION
### Motivation
- Prevent subtle look-ahead and silent failures when computing ADV for rebalance dates that fall on the first row of the price/volume index. 
- Improve post-backtest analytics by reporting trade-based hit rate and portfolio turnover. 
- Make Out-of-Sample (OOS) validation fail loudly in automation/CI when parameters degrade severely. 
- Reduce concentration and race conditions by capping incoming targets and making sector-cache updates thread-safe, and ease first-time setup by providing a historical parquet bootstrap.

### Description
- Fixed ADV edge handling in `_build_adv_vector()` so a rebalance on the first index row uses `idx[0]` instead of silently looking ahead, and threaded the backtest trade log (`bt.trades`) into metrics calculation via `run_backtest()` → `_compute_metrics()` in `backtest_engine.py`. 
- Extended `_compute_metrics()` to accept an optional `trades: Optional[List[Trade]]` argument and compute `hit_rate` (percentage of positive round-trip PnL trades) and `turnover` (notional flow normalized by average equity), and included those metrics in the returned dict. 
- Changed OOS validation in `optimizer.py` to raise `RuntimeError("OOS Validation Failed: Parameters degraded severely Out-of-Sample. The model is overfitted.")` on failure and re-raise `RuntimeError` so CI and automation pipelines halt explicitly. 
- Applied explicit incoming `target_weights` clipping to `[0, cfg.MAX_SINGLE_NAME_WEIGHT]` at the top of `execute_rebalance()` in `momentum_engine.py` to guarantee the single-name exposure cap is enforced before share-calculation logic. 
- Implemented a `--paper` flag and `PAPER_MODE` in `daily_workflow.py`, and made `save_portfolio_state()` a no-op in paper mode while printing the requested warning `[!] Paper mode active. State will not be saved.`. 
- Added a module-level `threading.Lock()` and wrapped sector-map cache update/save logic in `universe_manager.py` to avoid races when multiple threads update the cache concurrently. 
- Added a new utility `historical_builder.py` which creates a minimal `data/historical_nifty500.parquet` (DatetimeIndex + `tickers` list column) to bootstrap first-time runs and avoid the missing-historical-parquet error. 
- Updated `test_optimizer.py` expectations to align with the stricter OOS pass condition used by the new hard-fail behavior.

### Testing
- Ran the full test suite with `python -m pytest -q` and observed all tests passing (`80 passed`, `152 warnings`). 
- Exercised the new bootstrap utility with `historical_builder.bootstrap_historical_parquet()` to create a sample parquet file as a smoke test. 
- Confirmed repository state and diffs via `git status` / `git diff` to validate intended file updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaadc84454832bae01415692e5d811)