### PR TITLE
Bootstrap both historical parquets, document `--paper`, and clarify adv-vector first-day behavior

### DIFF
--- a/User Guide.txt
+++ b/User Guide.txt
@@ -31,3 +31,7 @@ Production Notes (v11.46+)
 4) Reproducible environments
 - Install from `requirements-lock.txt` for reproducible dependency versions:
   - `pip install -r requirements-lock.txt`
+
+5) Paper mode and bootstrap helper
+- For safe dry-runs, start the dashboard with `python daily_workflow.py --paper` to disable portfolio state file writes, and if you are setting up backtests for the first time run `python historical_builder.py` to bootstrap both required historical universe files (`data/historical_nifty500.parquet` and `data/historical_nse_total.parquet`).
+

--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -346,7 +346,7 @@ def _build_adv_vector(symbols: List[str], close: pd.DataFrame, volume: pd.DataFr
             if pos > 0:
                 signal_date = idx[pos - 1]
             else:
-                signal_date = idx[0]
+                signal_date = idx[0]  # first trading day in dataset — use itself (no lookahead)
 
     for sym in symbols:
         if sym in volume.columns and sym in close.columns and signal_date is not None:

--- a/historical_builder.py
+++ b/historical_builder.py
@@ -14,12 +14,12 @@ import pandas as pd
 
 def bootstrap_historical_parquet(
     output_path: str = "data/historical_nifty500.parquet",
-    tickers: list[str] | None = None,
+    default_tickers: list[str] | None = None,
 ) -> Path:
     """Create a minimal historical parquet with DatetimeIndex + tickers list column."""
-    default_tickers = tickers or ["RELIANCE", "TCS", "HDFCBANK"]
+    tickers = default_tickers or ["RELIANCE", "TCS", "HDFCBANK"]
     idx = pd.DatetimeIndex([pd.Timestamp.today().normalize()], name="date")
-    df = pd.DataFrame({"tickers": [default_tickers]}, index=idx)
+    df = pd.DataFrame({"tickers": [tickers]}, index=idx)
 
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -28,8 +28,12 @@ def bootstrap_historical_parquet(
 
 
 def main() -> None:
-    path = bootstrap_historical_parquet()
-    print(f"[+] Bootstrap complete: {path}")
+    outputs = [
+        bootstrap_historical_parquet("data/historical_nifty500.parquet"),
+        bootstrap_historical_parquet("data/historical_nse_total.parquet"),
+    ]
+    for path in outputs:
+        print(f"[+] Bootstrap complete: {path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Allow a single bootstrap run to create both required historical universe files used by backtests so new users can get started quickly.
- Make the bootstrap API match the suggested call style (`default_tickers`) and avoid confusing internal names.
- Document the non-persistent paper mode (`--paper`) and the bootstrap helper in the User Guide so users know how to dry-run and initialize data.
- Clarify the first-day ADV calculation behavior to avoid accidental lookahead in `_build_adv_vector`.

### Description
- Changed `historical_builder.bootstrap_historical_parquet` signature to accept `default_tickers` and use an internal `tickers` variable when constructing the sample parquet (`historical_builder.py`).
- Updated `historical_builder.py` `main()` to run `bootstrap_historical_parquet` for both `data/historical_nifty500.parquet` and `data/historical_nse_total.parquet` in one invocation.
- Added an inline comment to `_build_adv_vector` in `backtest_engine.py` at the fallback case to document that the first trading day uses itself (no lookahead).
- Added a short paragraph to `User Guide.txt` describing `python daily_workflow.py --paper` and `python historical_builder.py` to bootstrap required files.

### Testing
- Ran the full test suite with `python -m pytest -q`, which completed successfully with `80 passed` and warnings reported.
- An earlier attempt to run specific targeted tests by node names failed due to incorrect selection syntax, but this did not affect the full-suite run which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab037c28c832b87fd7cfaa3b0d08e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Production Notes covering safe dry-run usage via Paper mode and bootstrap setup instructions.

* **New Features**
  * Bootstrap process enhanced to generate multiple historical data files for different market indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->