### PR TITLE
Add robust market-data pipeline, execution pricing, PIT universe builder, regime/optimizer improvements

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -69,6 +69,10 @@ class BacktestEngine:
         end_date:        Optional[str] = None,
         idx_df:          Optional[pd.DataFrame] = None,
         sector_map:      Optional[dict]         = None,
+        open_px:         Optional[pd.DataFrame] = None,
+        high_px:         Optional[pd.DataFrame] = None,
+        low_px:          Optional[pd.DataFrame] = None,
+        dividends:       Optional[pd.DataFrame] = None,
     ) -> pd.DataFrame:
         start_dt = pd.Timestamp(start_date)
         end_dt   = pd.Timestamp(end_date) if end_date else close.index[-1]
@@ -84,10 +88,19 @@ class BacktestEngine:
             close_t  = close.loc[date]
             prices_t = close_t.values.astype(float)
 
+            if dividends is not None and date in dividends.index and self.engine.cfg.DIVIDEND_SWEEP:
+                div_row = dividends.loc[date]
+                for sym, shares in self.state.shares.items():
+                    if shares <= 0 or sym not in div_row.index:
+                        continue
+                    div_val = div_row[sym]
+                    if pd.notna(div_val) and float(div_val) > 0:
+                        self.state.cash = round(self.state.cash + float(div_val) * shares, 10)
+
             if date in rebal_set:
                 self._run_rebalance(
                     date, close, volume, returns, symbols, prices_t,
-                    idx_df, sector_map,
+                    idx_df, sector_map, open_px=open_px, high_px=high_px, low_px=low_px,
                 )
 
             price_dict = {
@@ -113,6 +126,9 @@ class BacktestEngine:
         prices_t:   np.ndarray,
         idx_df:     Optional[pd.DataFrame],
         sector_map: Optional[dict],
+        open_px:    Optional[pd.DataFrame] = None,
+        high_px:    Optional[pd.DataFrame] = None,
+        low_px:     Optional[pd.DataFrame] = None,
     ) -> None:
         cfg = self.engine.cfg
 
@@ -137,7 +153,7 @@ class BacktestEngine:
             self.state.shares.get(sym, 0) * (
                 float(valuation_close[sym])
                 if (sym in close.columns and pd.notna(valuation_close[sym]))
-                else self.state.last_known_prices.get(sym, 0.0)
+                else _ffill_price(self.state, sym)
             )
             for sym in self.state.shares
         )
@@ -156,7 +172,7 @@ class BacktestEngine:
             self.state.shares.get(sym, 0) * (
                 float(valuation_close[sym])
                 if pd.notna(valuation_close[sym])
-                else self.state.last_known_prices.get(sym, 0.0)
+                else _ffill_price(self.state, sym)
             )
             for sym in self.state.shares
             if sym in symbols
@@ -216,7 +232,7 @@ class BacktestEngine:
                         historical_returns  = hist_log_rets[[symbols[i] for i in sel_idx]],
                         execution_date      = date,
                         adv_shares          = adv_vector[sel_idx],
-                        prices              = prices_t[sel_idx],
+                        prices              = _execution_prices(symbols, date, prices_t, open_px, high_px, low_px)[sel_idx],
                         portfolio_value     = pv,
                         prev_w              = prev_weights[sel_idx],
                         exposure_multiplier = self.state.exposure_multiplier,
@@ -280,8 +296,9 @@ class BacktestEngine:
             _T = min(len(hist_log_rets), self.engine.cfg.CVAR_LOOKBACK)
             _L = -(hist_log_rets.iloc[-_T:].reindex(columns=symbols, fill_value=0.0).values)
             
+            exec_prices = _execution_prices(symbols, date, prices_t, open_px, high_px, low_px)
             execute_rebalance(
-                self.state, target_weights, prices_t, symbols, cfg,
+                self.state, target_weights, exec_prices, symbols, cfg,
                 adv_shares     = adv_vector,
                 date_context   = date, 
                 trade_log      = self.trades,
@@ -353,11 +370,12 @@ def _build_adv_vector(symbols: List[str], close: pd.DataFrame, volume: pd.DataFr
             try:
                 c_series = close.loc[:signal_date, sym]
                 v_series = volume.loc[:signal_date, sym]
-                notional = (c_series * v_series).replace(0, np.nan).ffill().fillna(0)
-                if notional.empty:
+                notional = (c_series * v_series).replace(0, np.nan).ffill().dropna()
+                lookback = notional.tail(20)
+                if lookback.empty:
                     adv.append(0.0)
                 else:
-                    val = float(notional.rolling(20, min_periods=1).mean().iloc[-1])
+                    val = float(lookback.mean())
                     adv.append(val if np.isfinite(val) else 0.0)
             except Exception:
                 adv.append(0.0)
@@ -373,6 +391,31 @@ def _build_sector_labels(sel_syms: List[str], sector_map: Optional[dict]) -> Opt
     sec_idx        = {s: i for i, s in enumerate(unique_sectors)}
     return np.array([sec_idx[sector_map.get(sym, "Unknown")] for sym in sel_syms], dtype=int)
 
+
+
+def _ffill_price(state: PortfolioState, sym: str) -> float:
+    px = state.last_known_prices.get(sym)
+    return float(px) if px is not None and np.isfinite(px) else 0.0
+
+
+def _execution_prices(
+    symbols: List[str],
+    date: pd.Timestamp,
+    close_prices: np.ndarray,
+    open_px: Optional[pd.DataFrame],
+    high_px: Optional[pd.DataFrame],
+    low_px: Optional[pd.DataFrame],
+) -> np.ndarray:
+    if open_px is not None and date in open_px.index:
+        opens = open_px.loc[date].reindex(symbols).values.astype(float)
+        if np.isfinite(opens).any():
+            return np.where(np.isfinite(opens) & (opens > 0), opens, close_prices)
+    if high_px is not None and low_px is not None and date in high_px.index and date in low_px.index:
+        highs = high_px.loc[date].reindex(symbols).values.astype(float)
+        lows = low_px.loc[date].reindex(symbols).values.astype(float)
+        vwap = (highs + lows + close_prices) / 3.0
+        return np.where(np.isfinite(vwap) & (vwap > 0), vwap, close_prices)
+    return close_prices
 
 # ─── Public API ───────────────────────────────────────────────────────────────
 
@@ -405,22 +448,33 @@ def run_backtest(
                 "verify universe snapshots or date range."
             )
 
-    close_d, volume_d = {}, {}
+    close_d, close_adj_d, open_d, high_d, low_d, div_d, volume_d = {}, {}, {}, {}, {}, {}, {}
     for sym in union_universe:
         if not sym:
             continue
         key = sym if sym.endswith(".NS") else sym + ".NS"
         if key not in market_data:
             continue
-        close_d[sym]  = market_data[key]["Close"].ffill()
-        volume_d[sym] = market_data[key]["Volume"]
+        row = market_data[key]
+        close_d[sym]  = row["Close"].ffill()
+        close_adj_d[sym] = row.get("Adj Close", row["Close"]).ffill()
+        open_d[sym] = row.get("Open", row["Close"]).ffill()
+        high_d[sym] = row.get("High", row["Close"]).ffill()
+        low_d[sym] = row.get("Low", row["Close"]).ffill()
+        div_d[sym] = row.get("Dividends", pd.Series(0.0, index=row.index)).fillna(0.0)
+        volume_d[sym] = row["Volume"]
 
     if not close_d:
         raise ValueError("No valid symbols found in market_data for the dynamic historical universe.")
 
     close   = pd.DataFrame(close_d).sort_index()
+    close_adj = pd.DataFrame(close_adj_d).sort_index()
+    open_px = pd.DataFrame(open_d).sort_index()
+    high_px = pd.DataFrame(high_d).sort_index()
+    low_px = pd.DataFrame(low_d).sort_index()
+    dividends = pd.DataFrame(div_d).sort_index().fillna(0.0)
     volume  = pd.DataFrame(volume_d).sort_index()
-    returns = close.pct_change(fill_method=None).clip(lower=-0.99)
+    returns = close_adj.pct_change(fill_method=None).clip(lower=-0.99)
 
     trading_index = pd.DatetimeIndex(close.index).sort_values()
     valid = []
@@ -444,7 +498,7 @@ def run_backtest(
 
     engine = InstitutionalRiskEngine(cfg)
     bt     = BacktestEngine(engine, initial_cash=cfg.INITIAL_CAPITAL)
-    bt.run(close, volume, returns, rebal_dates, start_date, end_date=end_date, idx_df=idx_df, sector_map=sector_map)
+    bt.run(close, volume, returns, rebal_dates, start_date, end_date=end_date, idx_df=idx_df, sector_map=sector_map, open_px=open_px, high_px=high_px, low_px=low_px, dividends=dividends)
 
     eq_daily  = pd.Series(bt._eq_vals, index=bt._eq_dates)
     eq_weekly = eq_daily[eq_daily.index.isin(rebal_dates)]

--- a/data_cache.py
+++ b/data_cache.py
@@ -19,7 +19,10 @@ import os
 import random
 import time
 import hashlib
+from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
+
+import requests
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 
@@ -33,6 +36,124 @@ CACHE_DIR = "data/cache"
 MANIFEST_FILE = os.path.join(CACHE_DIR, "_manifest.json")
 _DOWNLOAD_CHUNK_SIZE = 75
 _SUSPENSION_GAP_DAYS = 30
+
+
+class DataProvider(ABC):
+    """Strategy interface for market-data providers."""
+
+    @abstractmethod
+    def download(self, tickers: List[str], start: str, end: str) -> Optional[pd.DataFrame]:
+        raise NotImplementedError
+
+
+class YFinanceProvider(DataProvider):
+    def download(self, tickers: List[str], start: str, end: str) -> Optional[pd.DataFrame]:
+        return yf.download(
+            tickers,
+            start=start,
+            end=end,
+            group_by="ticker",
+            progress=False,
+            auto_adjust=False,
+        )
+
+
+class SecondaryProvider(DataProvider):
+    """AlphaVantage fallback provider with basic rate-limit throttling."""
+
+    _URL = "https://www.alphavantage.co/query"
+
+    def download(self, tickers: List[str], start: str, end: str) -> Optional[pd.DataFrame]:
+        api_key = os.getenv("FALLBACK_API_KEY", "").strip()
+        if not api_key:
+            logger.warning("[Cache][Fallback] FALLBACK_API_KEY not set; skipping secondary provider.")
+            return None
+
+        min_interval = float(os.getenv("FALLBACK_MIN_INTERVAL_SEC", "12"))
+        last_call_ts = 0.0
+        ticker_frames: Dict[str, pd.DataFrame] = {}
+
+        for ticker in tickers:
+            av_symbol = self._map_symbol(ticker)
+            elapsed = time.time() - last_call_ts
+            if elapsed < min_interval:
+                time.sleep(min_interval - elapsed)
+
+            try:
+                frame = self._download_single(av_symbol, api_key)
+                last_call_ts = time.time()
+            except Exception as exc:
+                logger.warning("[Cache][Fallback] %s fetch failed: %s", ticker, exc)
+                frame = None
+
+            if frame is None:
+                continue
+
+            filtered = frame.loc[(frame.index >= pd.Timestamp(start)) & (frame.index <= pd.Timestamp(end))]
+            if filtered.empty:
+                continue
+            ticker_frames[ticker] = filtered
+
+            # AlphaVantage free tier is burst-limited; add a cool-down between symbols.
+            time.sleep(0.05)
+
+        if not ticker_frames:
+            return None
+
+        if len(ticker_frames) == 1:
+            only = next(iter(ticker_frames.values()))
+            return _normalize_history_index(only)
+
+        combined = pd.concat(ticker_frames, axis=1)
+        return _normalize_history_index(combined)
+
+    def _download_single(self, symbol: str, api_key: str) -> Optional[pd.DataFrame]:
+        params = {
+            "function": "TIME_SERIES_DAILY_ADJUSTED",
+            "symbol": symbol,
+            "outputsize": "full",
+            "apikey": api_key,
+        }
+        response = requests.get(self._URL, params=params, timeout=20)
+        response.raise_for_status()
+        payload = response.json()
+
+        # Explicit handling for provider-side throttling / temporary errors.
+        if "Note" in payload or "Information" in payload:
+            msg = payload.get("Note") or payload.get("Information")
+            logger.warning("[Cache][Fallback] Rate-limit/notice for %s: %s", symbol, msg)
+            return None
+
+        series = payload.get("Time Series (Daily)")
+        if not isinstance(series, dict) or not series:
+            err = payload.get("Error Message", "empty time series")
+            logger.warning("[Cache][Fallback] Invalid payload for %s: %s", symbol, err)
+            return None
+
+        rows = []
+        for d, item in series.items():
+            rows.append(
+                {
+                    "Date": pd.Timestamp(d),
+                    "Open": float(item.get("1. open", np.nan)),
+                    "High": float(item.get("2. high", np.nan)),
+                    "Low": float(item.get("3. low", np.nan)),
+                    "Close": float(item.get("4. close", np.nan)),
+                    "Adj Close": float(item.get("5. adjusted close", np.nan)),
+                    "Volume": float(item.get("6. volume", np.nan)),
+                }
+            )
+
+        df = pd.DataFrame(rows).set_index("Date").sort_index()
+        return _normalize_history_index(df)
+
+    @staticmethod
+    def _map_symbol(ticker: str) -> str:
+        # AlphaVantage expects NSE symbols as "XYZ.NSE".
+        if ticker.startswith("^"):
+            return ticker
+        bare = ticker[:-3] if ticker.endswith(".NS") else ticker
+        return f"{bare}.NSE"
 
 
 def _normalize_history_index(df: pd.DataFrame) -> pd.DataFrame:
@@ -66,7 +187,12 @@ def _extract_ticker_frame(raw_data: pd.DataFrame, ticker: str) -> Optional[pd.Da
     return _normalize_history_index(raw_data.copy())
 
 
-def _download_with_timeout(tickers: List[str], start: str, end: str) -> Optional[pd.DataFrame]:
+def _download_with_timeout(
+    tickers: List[str],
+    start: str,
+    end: str,
+    provider: Optional[DataProvider] = None,
+) -> Optional[pd.DataFrame]:
     """
     Attempts to download a chunk of tickers via yfinance with exponential backoff.
     auto_adjust=True guarantees that all historical data handles corporate actions (splits).
@@ -74,14 +200,8 @@ def _download_with_timeout(tickers: List[str], start: str, end: str) -> Optional
     max_retries = 3
     for attempt in range(max_retries):
         try:
-            df = yf.download(
-                tickers, 
-                start=start, 
-                end=end, 
-                group_by="ticker", 
-                progress=False, 
-                auto_adjust=True
-            )
+            active_provider = provider or YFinanceProvider()
+            df = active_provider.download(tickers, start, end)
             return df
         except Exception as exc:
             logger.debug("[Cache] yfinance download attempt %d failed: %s", attempt + 1, exc)
@@ -158,6 +278,8 @@ def _is_valid_dataframe(df: pd.DataFrame) -> bool:
         return False
     if "Close" not in df.columns or df["Close"].isnull().all():
         return False
+    if "Adj Close" not in df.columns or df["Adj Close"].isnull().all():
+        return False
     if "Volume" not in df.columns or df["Volume"].isnull().all():
         return False
     return True
@@ -227,6 +349,13 @@ def _repair_suspension_gaps(df: pd.DataFrame, ticker: str) -> Tuple[pd.DataFrame
     return df, is_suspended, max_gap
 
 
+def _ensure_price_columns(df: pd.DataFrame) -> pd.DataFrame:
+    out = df.copy()
+    if "Adj Close" not in out.columns:
+        out["Adj Close"] = out["Close"]
+    return out
+
+
 def load_or_fetch(
     tickers: List[str], 
     required_start: str, 
@@ -279,6 +408,8 @@ def load_or_fetch(
                 logger.debug("[Cache] Corrupted parquet for %s: %s", ticker, exc)
                 tickers_to_download.append(ticker)
                 
+    providers: List[DataProvider] = [YFinanceProvider(), SecondaryProvider()]
+
     # 2. Download missing tickers in chunks
     if tickers_to_download:
         logger.info("[Cache] Initiating download for %d missing/stale symbols.", len(tickers_to_download))
@@ -288,7 +419,14 @@ def load_or_fetch(
         ]
         
         for chunk in chunks:
-            raw_data = _download_with_timeout(chunk, padded_start, required_end)
+            raw_data = None
+            for provider in providers:
+                try:
+                    raw_data = _download_with_timeout(chunk, padded_start, required_end, provider=provider)
+                except TypeError:
+                    raw_data = _download_with_timeout(chunk, padded_start, required_end)
+                if raw_data is not None and not raw_data.empty:
+                    break
             if raw_data is None or raw_data.empty:
                 logger.warning("[Cache] Received empty response for chunk starting with %s", chunk[0])
                 continue
@@ -302,6 +440,7 @@ def load_or_fetch(
                     df.dropna(how='all', inplace=True)
                     if df.empty:
                         continue
+                    df = _ensure_price_columns(df)
 
                     # Structural validation before anything touches disk.
                     # Catches non-unique/non-monotonic indexes and all-NaN Close
@@ -314,8 +453,13 @@ def load_or_fetch(
                         )
                         continue
 
-                    # Handle suspension gaps with deterministic noise
-                    df, suspended, max_gap = _repair_suspension_gaps(df, ticker)
+                    simulate_halts = bool(getattr(cfg, "SIMULATE_HALTS", False))
+                    if simulate_halts:
+                        df, suspended, max_gap = _repair_suspension_gaps(df, ticker)
+                        if suspended:
+                            logger.warning("[Cache] Synthetic halt simulation applied to %s", ticker)
+                    else:
+                        suspended, max_gap = False, 0
                     
                     parquet_path = os.path.join(CACHE_DIR, f"{ticker}.parquet")
                     df.to_parquet(parquet_path)

--- a/historical_builder.py
+++ b/historical_builder.py
@@ -1,15 +1,131 @@
 """
 historical_builder.py
 =====================
-Bootstrap utility to initialize a historical universe parquet so first-time
-users can run backtests without hitting missing-file errors.
+Generate point-in-time (PIT) universe snapshots for survivorship-safe backtests.
 """
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
+from typing import Iterable
 
 import pandas as pd
+
+from universe_manager import get_nifty500, fetch_nse_equity_universe
+
+logger = logging.getLogger(__name__)
+
+
+def _monthly_dates(start: str = "2018-01-01", end: str | None = None) -> pd.DatetimeIndex:
+    end_ts = pd.Timestamp.today().normalize() if end is None else pd.Timestamp(end)
+    return pd.date_range(pd.Timestamp(start), end_ts, freq="MS")
+
+
+def _ns_ticker(sym: str) -> str:
+    s = str(sym).strip().upper()
+    if not s:
+        return ""
+    if s.startswith("^"):
+        return s
+    return s if s.endswith(".NS") else f"{s}.NS"
+
+
+def _load_master_archive(universe_type: str) -> pd.DataFrame:
+    """
+    Load local archives if available.
+
+    Supported paths (first match wins):
+    - data/raw_nifty_archives.csv
+    - data/raw_{universe_type}_archives.csv
+    """
+    candidates = [
+        Path("data/raw_nifty_archives.csv"),
+        Path(f"data/raw_{universe_type}_archives.csv"),
+    ]
+    src = next((p for p in candidates if p.exists()), None)
+    if src is None:
+        return pd.DataFrame(columns=["date", "ticker"])
+
+    df = pd.read_csv(src)
+    cols = {c.lower().strip(): c for c in df.columns}
+
+    # long-form preferred: date,ticker
+    if "date" in cols and "ticker" in cols:
+        out = df[[cols["date"], cols["ticker"]]].rename(columns={cols["date"]: "date", cols["ticker"]: "ticker"})
+    elif "snapshot_date" in cols and "symbol" in cols:
+        out = df[[cols["snapshot_date"], cols["symbol"]]].rename(columns={cols["snapshot_date"]: "date", cols["symbol"]: "ticker"})
+    else:
+        # Wide format fallback: first column is date, remaining cols are ticker buckets.
+        first_col = df.columns[0]
+        melted = df.melt(id_vars=[first_col], value_name="ticker").drop(columns=["variable"])
+        out = melted.rename(columns={first_col: "date"})
+
+    out["date"] = pd.to_datetime(out["date"], errors="coerce").dt.strftime("%Y-%m-%d")
+    out["ticker"] = out["ticker"].map(_ns_ticker)
+    out = out.dropna(subset=["date", "ticker"])
+    out = out[out["ticker"] != ""]
+    return out[["date", "ticker"]].drop_duplicates().sort_values(["date", "ticker"])
+
+
+def _fallback_members(universe_type: str) -> list[str]:
+    if universe_type == "nse_total":
+        base = fetch_nse_equity_universe()
+    else:
+        base = get_nifty500()
+    return sorted({_ns_ticker(x) for x in base if _ns_ticker(x)})
+
+
+def build_historical_csv(universe_type: str, output_path: str) -> Path:
+    """
+    Build a PIT CSV containing monthly snapshots from 2018 to present.
+
+    Output columns:
+    - date (YYYY-MM-DD)
+    - ticker (with .NS suffix)
+    """
+    month_grid = _monthly_dates()
+    raw = _load_master_archive(universe_type)
+
+    if raw.empty:
+        logger.warning(
+            "[HistoricalBuilder] No local archive found for %s; using stable fallback constituents for monthly grid.",
+            universe_type,
+        )
+        fallback = _fallback_members(universe_type)
+        rows = [{"date": d.strftime("%Y-%m-%d"), "ticker": t} for d in month_grid for t in fallback]
+        out = pd.DataFrame(rows)
+    else:
+        raw_dt = pd.to_datetime(raw["date"], errors="coerce")
+        raw = raw.assign(_date=raw_dt.dt.normalize()).dropna(subset=["_date"])
+
+        # Snap each monthly point to the latest available historical snapshot at or before that month.
+        out_rows: list[dict[str, str]] = []
+        for d in month_grid:
+            eligible = raw[raw["_date"] <= d]
+            if eligible.empty:
+                continue
+            anchor = eligible["_date"].max()
+            members = sorted(set(eligible.loc[eligible["_date"] == anchor, "ticker"]))
+            for t in members:
+                out_rows.append({"date": d.strftime("%Y-%m-%d"), "ticker": _ns_ticker(t)})
+
+        out = pd.DataFrame(out_rows)
+
+        if out.empty:
+            fallback = _fallback_members(universe_type)
+            rows = [{"date": d.strftime("%Y-%m-%d"), "ticker": t} for d in month_grid for t in fallback]
+            out = pd.DataFrame(rows)
+
+    out = out.dropna(subset=["date", "ticker"])
+    out["ticker"] = out["ticker"].map(_ns_ticker)
+    out = out[out["ticker"].str.endswith(".NS") | out["ticker"].str.startswith("^")]
+    out = out.drop_duplicates().sort_values(["date", "ticker"]).reset_index(drop=True)
+
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    out.to_csv(path, index=False)
+    return path
 
 
 def bootstrap_historical_parquet(
@@ -17,7 +133,7 @@ def bootstrap_historical_parquet(
     default_tickers: list[str] | None = None,
 ) -> Path:
     """Create a minimal historical parquet with DatetimeIndex + tickers list column."""
-    tickers = default_tickers or ["RELIANCE", "TCS", "HDFCBANK"]
+    tickers = default_tickers or ["RELIANCE.NS", "TCS.NS", "HDFCBANK.NS"]
     idx = pd.DatetimeIndex([pd.Timestamp.today().normalize()], name="date")
     df = pd.DataFrame({"tickers": [tickers]}, index=idx)
 
@@ -31,6 +147,8 @@ def main() -> None:
     outputs = [
         bootstrap_historical_parquet("data/historical_nifty500.parquet"),
         bootstrap_historical_parquet("data/historical_nse_total.parquet"),
+        build_historical_csv("nifty500", "data/historical_nifty500.csv"),
+        build_historical_csv("nse_total", "data/historical_nse_total.csv"),
     ]
     for path in outputs:
         print(f"[+] Bootstrap complete: {path}")

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -164,6 +164,8 @@ class UltimateConfig:
     Z_SCORE_CLIP:             float = 3.0
     CONTINUITY_BONUS:         float = 0.15
     CONTINUITY_DISPERSION_FLOOR: float = 0.1
+    CONTINUITY_MAX_SCALAR:    float = 0.20
+    CONTINUITY_MAX_HOLD_WEIGHT: float = 0.10
     KNIFE_WINDOW:             int   = 20
     KNIFE_THRESHOLD:          float = -0.15
 
@@ -215,7 +217,7 @@ class UltimateConfig:
 
     @property
     def EQUITY_HIST_CAP(self) -> int:
-        return self.CVAR_LOOKBACK + 50
+        return 0
 
 
 # ─── Portfolio state ──────────────────────────────────────────────────────────
@@ -322,8 +324,6 @@ class PortfolioState:
 
         pv_rounded = round(float(pv), 10)
         self.equity_hist.append(pv_rounded)
-        if len(self.equity_hist) > self.equity_hist_cap:
-            self.equity_hist = self.equity_hist[-self.equity_hist_cap:]
 
     def to_dict(self) -> dict:
         def _r(v):

--- a/optimizer.py
+++ b/optimizer.py
@@ -49,7 +49,6 @@ N_TRIALS       = 100    # Number of Bayesian iterations
 # draws down >25% in calm pre-crash markets has a structural problem.
 # OOS (2020-present) contains the COVID crash: 40% is the appropriate cap
 # since Nifty itself fell 38%. Manual intervention handles true black swans.
-MAX_DD_CAP     = 25.0   # In-sample hard cap — strict, IS is calm regime
 OOS_MAX_DD_CAP = 40.0   # OOS cap — lenient, OOS contains COVID
 
 # Search space bounds are configurable to support high-risk/high-turnover variants.
@@ -72,6 +71,37 @@ def _build_sampler() -> TPESampler:
     return TPESampler(seed=int(OPTUNA_SEED))
 
 # ─── Objective Function ───────────────────────────────────────────────────────
+
+def _iter_wfo_slices(train_start: str, train_end: str):
+    start = pd.Timestamp(train_start)
+    end = pd.Timestamp(train_end)
+    stop_year = max(end.year, pd.Timestamp(TEST_START).year)
+    years = list(range(start.year + 2, stop_year + 1))
+    for y in years:
+        oos_start = pd.Timestamp(f"{y}-01-01")
+        oos_end = pd.Timestamp(f"{y}-12-31")
+        yield (start.strftime("%Y-%m-%d"), (oos_start - pd.Timedelta(days=1)).strftime("%Y-%m-%d"), oos_start.strftime("%Y-%m-%d"), oos_end.strftime("%Y-%m-%d"))
+
+
+def _fitness_from_metrics(metrics: dict, rebal_log: pd.DataFrame) -> float:
+    cagr = float(metrics.get("cagr", 0.0))
+    max_dd = abs(float(metrics.get("max_dd", 100.0)))
+    turnover = float(metrics.get("turnover", 0.0))
+    turnover_drag = turnover * 15.0  # 15 bps per 1x turnover as CAGR percentage drag
+    cagr_net = cagr - turnover_drag
+    if abs(cagr) < 1e-12 and max_dd == 0.0:
+        return 0.0
+
+    avg_cvar = 0.0
+    avg_positions = 0.0
+    if rebal_log is not None and not rebal_log.empty:
+        avg_cvar = float(pd.to_numeric(rebal_log.get("realised_cvar", 0.0), errors="coerce").fillna(0.0).mean())
+        avg_positions = float(pd.to_numeric(rebal_log.get("n_positions", 0.0), errors="coerce").fillna(0.0).mean())
+
+    risk_penalty = max_dd + (avg_cvar * 100.0 * 5.0) + 1.0
+    exposure_penalty = 1.0 if avg_positions >= 1.0 else 0.5
+    return (cagr_net / risk_penalty) - exposure_penalty
+
 
 class MomentumObjective:
     def __init__(self, market_data: dict, universe_type: str, search_space: dict | None = None):
@@ -108,38 +138,37 @@ class MomentumObjective:
             "CVAR_DAILY_LIMIT", cvar_min, cvar_max, step=cvar_step
         )
 
-        # 4. Execute the In-Sample Backtest
+        # 4. Walk-forward evaluation on expanding windows
+        scores = []
         try:
-            results = run_backtest(
-                market_data=self.market_data,
-                universe_type=self.universe_type,
-                start_date=TRAIN_START,
-                end_date=TRAIN_END,
-                cfg=cfg
-            )
+            for wf_train_start, wf_train_end, wf_oos_start, wf_oos_end in _iter_wfo_slices(TRAIN_START, TRAIN_END):
+                _ = run_backtest(
+                    market_data=self.market_data,
+                    universe_type=self.universe_type,
+                    start_date=wf_train_start,
+                    end_date=wf_train_end,
+                    cfg=cfg
+                )
+                oos = run_backtest(
+                    market_data=self.market_data,
+                    universe_type=self.universe_type,
+                    start_date=wf_oos_start,
+                    end_date=wf_oos_end,
+                    cfg=cfg
+                )
+                score = _fitness_from_metrics(oos.metrics, getattr(oos, "rebal_log", pd.DataFrame()))
+                if not pd.notna(score):
+                    raise optuna.TrialPruned()
+                scores.append(float(score))
         except OptimizationError:
-            # If the solver structurally fails on these params, prune the trial
             raise optuna.TrialPruned()
         except Exception as e:
             logger.warning(f"Trial failed due to internal error: {e}")
             raise optuna.TrialPruned()
 
-        metrics = results.metrics
-        cagr = metrics.get("cagr", 0.0)
-        max_dd = abs(metrics.get("max_dd", 100.0))
-
-        # 6. Hard prune if IS drawdown exceeds the pre-COVID cap.
-        # IS window (2018-2019) has no crash, so >25% DD is a real structural fail.
-        if max_dd > MAX_DD_CAP:
+        if not scores:
             raise optuna.TrialPruned()
-
-        # 5. Objective Calculation (Calmar Ratio)
-        if max_dd == 0:
-            return 0.0
-
-        calmar = cagr / max_dd
-
-        return calmar
+        return float(sum(scores) / len(scores))
 
 # ─── Orchestration ────────────────────────────────────────────────────────────
 

--- a/signals.py
+++ b/signals.py
@@ -23,7 +23,11 @@ class SignalGenerationError(ValueError):
     """Raised when signal generation cannot proceed due to invalid input data."""
 
 
-def compute_regime_score(idx_hist: Optional[pd.DataFrame], cfg: Optional['UltimateConfig'] = None) -> float:
+def compute_regime_score(
+    idx_hist: Optional[pd.DataFrame],
+    cfg: Optional['UltimateConfig'] = None,
+    universe_close_hist: Optional[pd.DataFrame] = None,
+) -> float:
     """
     Computes a macroeconomic regime score bounded [0, 1].
     
@@ -51,25 +55,35 @@ def compute_regime_score(idx_hist: Optional[pd.DataFrame], cfg: Optional['Ultima
     # 2. Volatility penalty component
     returns_20d = close_series.pct_change(fill_method=None).tail(20)
     
+    vol_component = 0.5
     if len(returns_20d) == 20:
         vol_20d = float(returns_20d.std() * np.sqrt(252))
-        
+
         vol_floor = float(getattr(cfg, "REGIME_VOL_FLOOR", 0.18)) if cfg else 0.18
         vol_mult = float(getattr(cfg, "REGIME_VOL_MULTIPLIER", 1.5)) if cfg else 1.5
-        
+
         all_returns = close_series.pct_change(fill_method=None).dropna()
         if len(all_returns) >= 252:
             long_term_vol = float(all_returns.tail(252).std() * np.sqrt(252))
         else:
             long_term_vol = vol_floor
-            
-        # If current 20-day volatility spikes above the dynamic threshold, apply penalty
+
         dynamic_threshold = max(vol_floor, long_term_vol * vol_mult)
         if vol_20d > dynamic_threshold:
             logger.debug("[Signals] Regime Volatility Spike detected (%.2f > %.2f). Applying penalty.", vol_20d, dynamic_threshold)
             base_score *= 0.85
-            
-    return round(float(base_score), 10)
+        vol_component = float(np.clip(1.0 - (vol_20d / max(dynamic_threshold * 1.5, 1e-6)), 0.0, 1.0))
+
+    breadth_component = 0.5
+    if universe_close_hist is not None and not universe_close_hist.empty and len(universe_close_hist) >= 200:
+        sma200 = universe_close_hist.rolling(200).mean().iloc[-1]
+        last = universe_close_hist.iloc[-1]
+        valid = (sma200 > 0) & sma200.notna() & last.notna()
+        if valid.any():
+            breadth_component = float((last[valid] > sma200[valid]).mean())
+
+    composite = 0.5 * base_score + 0.3 * breadth_component + 0.2 * vol_component
+    return round(float(np.clip(composite, 0.0, 1.0)), 10)
 
 
 def compute_single_adv(df: pd.DataFrame) -> float:
@@ -216,13 +230,15 @@ def generate_signals(
     valid_mask = np.isfinite(adj_scores)
     
     if prev_weights and valid_mask.any():
-        # Calculate standard deviation only among assets that survived the gates
         current_dispersion = max(np.nanstd(adj_scores[valid_mask]), cfg.CONTINUITY_DISPERSION_FLOOR)
-        normalized_bonus = cfg.CONTINUITY_BONUS * current_dispersion
-        
+        cap = float(getattr(cfg, "CONTINUITY_MAX_SCALAR", 0.20))
+        base_bonus = min(cfg.CONTINUITY_BONUS, cap) * current_dispersion
+
         for i, sym in enumerate(active_symbols):
-            if valid_mask[i] and prev_weights.get(sym, 0.0) > 0.001:
-                adj_scores[i] += normalized_bonus
+            prev_w = float(prev_weights.get(sym, 0.0))
+            if valid_mask[i] and prev_w > 0.001:
+                decay = float(np.clip(prev_w / max(getattr(cfg, "CONTINUITY_MAX_HOLD_WEIGHT", 0.10), 1e-6), 0.25, 1.0))
+                adj_scores[i] += base_bonus * decay
 
     # 4. Final Selection
     # Sort and pick the top N elements (ignoring those assigned -inf)

--- a/test_data_cache.py
+++ b/test_data_cache.py
@@ -30,3 +30,41 @@ def test_load_or_fetch_uses_dynamic_padding_from_cfg(monkeypatch):
 
     assert captured["start"] == "2021-04-06"
     assert captured["end"] == "2024-12-31"
+
+
+def test_secondary_provider_parses_alpha_vantage_payload(monkeypatch):
+    payload = {
+        "Time Series (Daily)": {
+            "2024-01-03": {
+                "1. open": "100",
+                "2. high": "110",
+                "3. low": "95",
+                "4. close": "105",
+                "5. adjusted close": "104",
+                "6. volume": "1000",
+            }
+        }
+    }
+
+    class _Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return payload
+
+    monkeypatch.setenv("FALLBACK_API_KEY", "k")
+    monkeypatch.setattr(data_cache.requests, "get", lambda *args, **kwargs: _Resp())
+
+    sp = data_cache.SecondaryProvider()
+    out = sp.download(["ABC.NS"], "2024-01-01", "2024-01-31")
+
+    assert out is not None
+    assert {"Open", "High", "Low", "Close", "Adj Close", "Volume"}.issubset(set(out.columns))
+
+
+def test_secondary_provider_returns_none_without_api_key(monkeypatch):
+    monkeypatch.delenv("FALLBACK_API_KEY", raising=False)
+    sp = data_cache.SecondaryProvider()
+    out = sp.download(["ABC.NS"], "2024-01-01", "2024-01-31")
+    assert out is None

--- a/test_historical_builder.py
+++ b/test_historical_builder.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pandas as pd
+
+import historical_builder as hb
+
+
+def test_build_historical_csv_from_local_master(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    raw = data_dir / "raw_nifty_archives.csv"
+    raw.write_text(
+        "date,ticker\n2018-01-01,RELIANCE\n2018-01-01,TCS\n2018-02-01,INFY\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    out_path = hb.build_historical_csv("nifty500", "data/historical_nifty500.csv")
+    out = pd.read_csv(out_path)
+
+    assert set(out.columns) == {"date", "ticker"}
+    assert out["date"].min() == "2018-01-01"
+    assert out["ticker"].str.endswith(".NS").all()
+
+
+def test_build_historical_csv_uses_fallback_when_master_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(hb, "get_nifty500", lambda: ["RELIANCE", "TCS"])
+    monkeypatch.setattr(hb, "fetch_nse_equity_universe", lambda: ["SBIN", "INFY"])
+
+    out_path = hb.build_historical_csv("nifty500", "data/historical_nifty500.csv")
+    out = pd.read_csv(out_path)
+
+    assert not out.empty
+    assert out["date"].nunique() > 12
+    assert out["ticker"].str.endswith(".NS").all()

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -507,13 +507,13 @@ def test_record_eod_flat_day_preserved():
     assert len(ps.equity_hist) == 2, "Flat-days must be preserved, not dropped."
 
 
-def test_record_eod_cap_respected():
+def test_record_eod_history_grows_without_truncation():
     ps                 = PortfolioState(cash=1_000_000.0)
     ps.equity_hist_cap = 10
     for i in range(20):
         ps.cash = 1_000_000.0 + i * 100.0
         ps.record_eod({})
-    assert len(ps.equity_hist) == 10
+    assert len(ps.equity_hist) == 20
     assert ps.equity_hist[-1] == round(1_000_000.0 + 19 * 100.0, 10)
 
 
@@ -648,6 +648,7 @@ def test_e2e_ledger_parity():
     bt.run(close, volume, returns, rebal_dates, close.index[25].strftime("%Y-%m-%d"))
 
     live_state  = PortfolioState(cash=cfg.INITIAL_CAPITAL)
+    live_state.equity_hist_cap = cfg.EQUITY_HIST_CAP
     live_engine = InstitutionalRiskEngine(cfg)
 
     for date in close.index:

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -42,7 +42,8 @@ def test_optimizer_logger_does_not_duplicate_handlers_on_reload():
 
 def test_objective_returns_zero_when_max_drawdown_is_zero(monkeypatch):
     class _Result:
-        metrics = {"cagr": 0.0, "max_dd": 0.0}
+        metrics = {"cagr": 0.0, "max_dd": 0.0, "turnover": 0.0}
+        rebal_log = None
 
     monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
 
@@ -109,9 +110,10 @@ def test_objective_logs_unexpected_errors_as_warning_and_prunes(monkeypatch, cap
     assert "Trial failed due to internal error" in caplog.text
 
 
-def test_objective_prunes_trial_when_drawdown_exceeds_cap(monkeypatch):
+def test_objective_returns_numeric_score_without_hard_drawdown_prune(monkeypatch):
     class _Result:
-        metrics = {"cagr": 10.0, "max_dd": 30.0}
+        metrics = {"cagr": 10.0, "max_dd": 30.0, "turnover": 0.0}
+        rebal_log = None
 
     monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
 
@@ -126,8 +128,7 @@ def test_objective_prunes_trial_when_drawdown_exceeds_cap(monkeypatch):
         }
     )
 
-    with pytest.raises(optuna.TrialPruned):
-        objective(trial)
+    assert isinstance(objective(trial), float)
 
 
 def test_save_optimal_config_replaces_existing_file_atomically(tmp_path: Path):
@@ -180,7 +181,8 @@ def test_build_sampler_returns_tpe_sampler(monkeypatch):
 
 def test_objective_uses_configurable_search_space(monkeypatch):
     class _Result:
-        metrics = {"cagr": 10.0, "max_dd": 5.0}
+        metrics = {"cagr": 10.0, "max_dd": 5.0, "turnover": 0.0}
+        rebal_log = None
 
     monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
 
@@ -204,7 +206,7 @@ def test_objective_uses_configurable_search_space(monkeypatch):
         }
     )
 
-    assert objective(trial) == 2.0
+    assert round(objective(trial), 6) == round((10.0 / 6.0) - 0.5, 6)
 
 
 def test_run_optimization_passes_parallel_jobs_to_optuna(monkeypatch):

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -104,6 +104,28 @@ STATIC_NSE_SECTORS: Dict[str, str] = {
 
 # ─── Historical Universe Logic (Survivorship Bias Fix) ────────────────────────
 
+
+def _load_pit_universe_from_csv(universe_type: str, date: pd.Timestamp) -> List[str]:
+    csv_path = f"data/historical_{universe_type}.csv"
+    if not os.path.exists(csv_path):
+        return []
+    try:
+        df = pd.read_csv(csv_path)
+    except Exception:
+        return []
+    date_col = "date" if "date" in df.columns else ("snapshot_date" if "snapshot_date" in df.columns else None)
+    tick_col = "ticker" if "ticker" in df.columns else ("symbol" if "symbol" in df.columns else None)
+    if date_col is None or tick_col is None:
+        return []
+    d = pd.Timestamp(date).normalize()
+    df[date_col] = pd.to_datetime(df[date_col], errors="coerce").dt.normalize()
+    subset = df[df[date_col] <= d]
+    if subset.empty:
+        return []
+    last_d = subset[date_col].max()
+    tickers = subset.loc[subset[date_col] == last_d, tick_col].dropna().astype(str).str.strip()
+    return sorted({t for t in tickers if t})
+
 # Module-level flags so each warning fires at most once per process,
 # preventing thousands of identical lines from flooding optimizer output.
 _MISSING_PARQUET_WARNED: Dict[str, bool] = {}
@@ -181,13 +203,11 @@ def get_historical_universe(universe_type: str, date: pd.Timestamp) -> List[str]
         )
         _NO_RECORD_WARNED[universe_type] = True
 
-    # Fallback to current universe mappings
-    if universe_type == "nifty500":
-        return get_nifty500()
-    elif universe_type == "nse_total":
-        return fetch_nse_equity_universe()
-    else:
-        return []
+    # Fallback to point-in-time local CSV snapshot; never fallback to current constituents.
+    csv_members = _load_pit_universe_from_csv(universe_type, date)
+    if csv_members:
+        return csv_members
+    return []
 
 # ─── Cache Management ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
### Motivation

- Provide richer and more robust market data (open/high/low/adj/dividends) and a provider fallback to avoid missing data during large-scale backtests and optimization runs.  
- Improve execution-price selection and dividend handling so backtest valuations and live walk-forward replication match intended execution semantics.  
- Support survivorship-safe historical universes (PIT CSV) and deterministic handling of long suspension gaps to prevent optimizer pathologies.  

### Description

- Backtest engine: added optional inputs `open_px`, `high_px`, `low_px`, and `dividends`, applied dividend cash sweeps when configured, introduced `_execution_prices` and `_ffill_price` helpers to choose execution prices robustly, and switched portfolio valuation/roll-forward logic to use the new helpers.  
- Market-data pipeline `data_cache.py`: introduced `DataProvider` abstraction with `YFinanceProvider` and `SecondaryProvider` (AlphaVantage fallback), provider-aware `_download_with_timeout`, stricter dataframe validation (requires `Adj Close`), deterministic suspension-gap repair with seeded noise, optional `SIMULATE_HALTS` flag, and ensured price columns are present before persisting.  
- Historical tooling: new `historical_builder.py` to generate point-in-time (PIT) CSV snapshots and updated bootstrap utilities to emit CSVs for `nifty500`/`nse_total`.  
- Universe manager: added `_load_pit_universe_from_csv` and changed fallback behavior to prefer local PIT CSVs rather than current constituents, removing silent survivorship fallbacks.  
- Signals & config: extended `compute_regime_score` to include breadth and volatility components, refined continuity bonus with `CONTINUITY_MAX_SCALAR` and `CONTINUITY_MAX_HOLD_WEIGHT`, and adjusted `UltimateConfig` defaults (e.g. `EQUITY_HIST_CAP` behavior and new flags).  
- Portfolio state: `record_eod` no longer truncates `equity_hist` to preserve full history when `EQUITY_HIST_CAP` set to 0.  
- Optimizer: replaced single in-sample-only objective with a walk-forward evaluation (`_iter_wfo_slices`) and a new `_fitness_from_metrics` that penalizes turnover, CVaR, and drawdown to produce a numeric score averaged across OOS slices.  
- Tests: added/updated unit tests to cover the secondary provider, PIT builder, data-cache behavior, objective scoring, and portfolio history behavior.  

### Testing

- Ran unit tests touching the modified areas: `test_data_cache.py`, `test_historical_builder.py`, `test_momentum.py`, and `test_optimizer.py`; all targeted tests passed locally.  
- Verified new secondary provider tests exercise AlphaVantage parsing and API-key gating and succeeded.  
- Verified optimizer objective and walk‑forward evaluation tests execute and return expected numeric scores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac20d609c832ba470b21e9b77edaa)