### PR TITLE
Introduce configurable `SIGNAL_LAG_DAYS` and blind momentum ranker to recent data

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -155,6 +155,7 @@ class UltimateConfig:
     HISTORY_GATE:             int   = 90
     HALFLIFE_FAST:            int   = 21
     HALFLIFE_SLOW:            int   = 63
+    SIGNAL_LAG_DAYS:          int   = 21
     RISK_AVERSION:            float = 5.0
     SLACK_PENALTY:            float = 10.0
     DIMENSIONALITY_MULTIPLIER:int   = 3

--- a/signals.py
+++ b/signals.py
@@ -190,18 +190,24 @@ def generate_signals(
     active_symbols = list(log_rets.columns)
     
     # 1. Base Signal Calculation (Blended EWMA)
-    fast_ema = log_rets.ewm(halflife=cfg.HALFLIFE_FAST).mean().iloc[-1].values
-    slow_ema = log_rets.ewm(halflife=cfg.HALFLIFE_SLOW).mean().iloc[-1].values
-    
+    signal_lag_days = max(int(getattr(cfg, "SIGNAL_LAG_DAYS", 0)), 0)
+    if signal_lag_days > 0 and len(log_rets) > signal_lag_days:
+        signal_log_rets = log_rets.iloc[:-signal_lag_days]
+    else:
+        signal_log_rets = log_rets
+
+    fast_ema = signal_log_rets.ewm(halflife=cfg.HALFLIFE_FAST).mean().iloc[-1].values
+    slow_ema = signal_log_rets.ewm(halflife=cfg.HALFLIFE_SLOW).mean().iloc[-1].values
+
     raw_daily_momentum = 0.5 * fast_ema + 0.5 * slow_ema
-    
+
     # Cross-sectional Z-score standardization
     mu_cross = np.nanmean(raw_daily_momentum)
     std_cross = max(np.nanstd(raw_daily_momentum), 1e-8)
-    
+
     adj_scores = np.clip(
-        (raw_daily_momentum - mu_cross) / std_cross, 
-        -cfg.Z_SCORE_CLIP, 
+        (raw_daily_momentum - mu_cross) / std_cross,
+        -cfg.Z_SCORE_CLIP,
         cfg.Z_SCORE_CLIP
     )
 


### PR DESCRIPTION
### Motivation
- Prevent the 1-month short-term reversal (reversal trap) by preventing the momentum ranker from seeing the most recent noisy days when computing alpha ranks.
- Make the lag configurable so strategy operators can tune the blind period without impacting liquidity or risk calculations.
- Preserve risk and liquidity gates to continue using the latest T-1 information for safe execution decisions.

### Description
- Added a new configuration parameter `SIGNAL_LAG_DAYS: int = 21` to `UltimateConfig` to expose the lag window (`momentum_engine.py`).
- In `generate_signals` (`signals.py`) introduced `signal_log_rets = log_rets.iloc[:-signal_lag_days]` when sufficient history exists and computed `fast_ema`/`slow_ema` on that lagged view.
- Ensured only the alpha ranking math (`raw_daily_momentum` and `adj_scores`) is derived from the lagged `signal_log_rets`, while `adv_arr`, history gating, falling-knife checks, and any downstream risk/liquidity logic continue to use the original `log_rets` and `adv_arr`.
- Kept cross-sectional z-score standardization and continuity bonus mechanics unchanged except for using the lagged ranking inputs.

### Testing
- Ran `python -m py_compile momentum_engine.py signals.py` and the files compiled without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaccd94a40832bae124dcc89caf4f5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced signal calculation with automatic lag adjustment. When sufficient historical data is available, signal processing now accounts for a configurable lag period before computing indicators.

* **Configuration**
  * New SIGNAL_LAG_DAYS parameter enables users to customize the signal lag handling (default: 21 days).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->