### PR TITLE
Fix historical-universe fallback warnings, first-day ADV lookahead, and show hit_rate/turnover; add tests

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -363,7 +363,7 @@ def _build_adv_vector(symbols: List[str], close: pd.DataFrame, volume: pd.DataFr
             if pos > 0:
                 signal_date = idx[pos - 1]
             else:
-                signal_date = idx[0]  # first trading day in dataset — use itself (no lookahead)
+                signal_date = None  # first trading day in dataset — no prior bar, keep lookahead-free
 
     for sym in symbols:
         if sym in volume.columns and sym in close.columns and signal_date is not None:
@@ -540,6 +540,10 @@ def print_backtest_results(results: BacktestResults) -> None:
         f"\033[1mSortino:\033[0m {sortino_display}  "
         f"\033[1mMaxDD:\033[0m {m.get('max_dd', 0):.2f}%  "
         f"\033[1mCalmar:\033[0m {m.get('calmar', 0):.2f}"
+    )
+    print(
+        f"  \033[1mHitRate:\033[0m {m.get('hit_rate', 0):.2f}%  "
+        f"\033[1mTurnover:\033[0m {m.get('turnover', 0):.4f}x"
     )
     print(f"  \033[90m{chr(9472)*65}\033[0m\n")
 

--- a/historical_builder.py
+++ b/historical_builder.py
@@ -134,6 +134,13 @@ def bootstrap_historical_parquet(
 ) -> Path:
     """Create a minimal historical parquet with DatetimeIndex + tickers list column."""
     tickers = default_tickers or ["RELIANCE.NS", "TCS.NS", "HDFCBANK.NS"]
+    if default_tickers is None:
+        logger.warning(
+            "[HistoricalBuilder] Bootstrapping %s with a 3-ticker stub universe only (%s). "
+            "Use build_historical_csv outputs for full PIT backtests.",
+            output_path,
+            ", ".join(tickers),
+        )
     idx = pd.DatetimeIndex([pd.Timestamp.today().normalize()], name="date")
     df = pd.DataFrame({"tickers": [tickers]}, index=idx)
 

--- a/test_historical_builder.py
+++ b/test_historical_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import pandas as pd
 
 import historical_builder as hb
@@ -34,3 +35,13 @@ def test_build_historical_csv_uses_fallback_when_master_missing(tmp_path, monkey
     assert not out.empty
     assert out["date"].nunique() > 12
     assert out["ticker"].str.endswith(".NS").all()
+
+
+def test_bootstrap_historical_parquet_warns_stub_content(tmp_path, monkeypatch, caplog):
+    monkeypatch.chdir(tmp_path)
+    caplog.set_level(logging.WARNING)
+
+    out = hb.bootstrap_historical_parquet("data/historical_nifty500.parquet")
+
+    assert out.exists()
+    assert "3-ticker stub universe" in caplog.text

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -94,6 +94,30 @@ def test_generate_signals_continuity_bonus():
     assert scores[0] > scores[1], "Held asset must receive continuity bonus."
 
 
+
+
+def test_generate_signals_continuity_decay_scales_with_prev_weight():
+    """Continuity bonus should scale from 25% to 100% with previous holding size."""
+    base_col = np.linspace(-0.01, 0.01, 120)
+    log_rets = pd.DataFrame(
+        np.column_stack([base_col, base_col, base_col]), columns=["SMALL", "LARGE", "NONE"]
+    )
+    adv = np.ones(3) * 1e6
+    cfg = UltimateConfig(HISTORY_GATE=10, MAX_POSITIONS=3)
+
+    _, scores, _ = generate_signals(
+        log_rets,
+        adv,
+        cfg,
+        prev_weights={"SMALL": 0.01, "LARGE": 0.10, "NONE": 0.0},
+    )
+
+    small_bonus = float(scores[0] - scores[2])
+    large_bonus = float(scores[1] - scores[2])
+
+    assert small_bonus == pytest.approx(0.00375, abs=1e-6)
+    assert large_bonus == pytest.approx(0.015, abs=1e-6)
+
 def test_generate_signals_blocks_empty_input():
     """A completely empty array should trip the defensive barrier before math crash."""
     cfg = UltimateConfig()
@@ -1074,3 +1098,14 @@ def test_decay_rounds_exhaustion_forces_liquidation():
 if __name__ == '__main__':
     import sys
     sys.exit(pytest.main([__file__, '-v']))
+
+
+def test_volume_first_day_adv_is_zero_no_lookahead():
+    cols = ["SYM00", "SYM01"]
+    idx = pd.date_range("2020-01-02", periods=5, freq="B")
+    close = pd.DataFrame(np.ones((5, 2)) * 100.0, index=idx, columns=cols)
+    volume = pd.DataFrame(np.ones((5, 2)) * 1e6, index=idx, columns=cols)
+
+    adv_day0 = _build_adv_vector(cols, close, volume, idx[0])
+
+    assert np.allclose(adv_day0, 0.0)

--- a/test_universe_manager.py
+++ b/test_universe_manager.py
@@ -1,0 +1,36 @@
+import logging
+import pandas as pd
+import universe_manager as um
+
+
+def test_get_historical_universe_uses_csv_without_survivorship_warning(tmp_path, monkeypatch, caplog):
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "historical_nifty500.csv").write_text(
+        "date,ticker\n2020-01-01,RELIANCE.NS\n2020-01-01,INFY.NS\n",
+        encoding="utf-8",
+    )
+
+    um._MISSING_PARQUET_WARNED.clear()
+    um._NO_RECORD_WARNED.clear()
+
+    caplog.set_level(logging.WARNING)
+    members = um.get_historical_universe("nifty500", pd.Timestamp("2020-02-01"))
+
+    assert members == ["INFY.NS", "RELIANCE.NS"]
+    assert "survivorship bias" not in caplog.text.lower()
+
+
+def test_get_historical_universe_warns_when_no_parquet_or_csv(tmp_path, monkeypatch, caplog):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data").mkdir()
+
+    um._MISSING_PARQUET_WARNED.clear()
+    um._NO_RECORD_WARNED.clear()
+
+    caplog.set_level(logging.WARNING)
+    members = um.get_historical_universe("nifty500", pd.Timestamp("2020-02-01"))
+
+    assert members == []
+    assert "survivorship bias risk" in caplog.text.lower()

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -136,9 +136,13 @@ _SECTOR_MAP_CACHE_LOCK = threading.Lock()
 def get_historical_universe(universe_type: str, date: pd.Timestamp) -> List[str]:
     """
     Attempts to load the exact constituents for a specific historical date.
-    
-    If no historical record exists for the requested universe/date, falls back 
-    to the current active universe and issues a survivorship bias warning.
+
+    Load order:
+    1) Historical parquet snapshots.
+    2) Point-in-time CSV snapshots (from historical_builder.py).
+
+    If neither source has a valid record, returns an empty list and issues
+    a survivorship-bias warning.
     """
     hist_file = f"data/historical_{universe_type}.parquet"
 
@@ -147,9 +151,8 @@ def get_historical_universe(universe_type: str, date: pd.Timestamp) -> List[str]
     if not os.path.exists(hist_file):
         if not _MISSING_PARQUET_WARNED.get(universe_type):
             logger.error(
-                "HISTORICAL PARQUET MISSING: %s — all %s backtests will use the "
-                "current universe (survivorship bias). Run the one-time historical "
-                "builder script before optimizing.",
+                "HISTORICAL PARQUET MISSING: %s — attempting point-in-time CSV fallback "
+                "for %s. Run historical_builder.py to regenerate parquet snapshots.",
                 hist_file, universe_type,
             )
             _MISSING_PARQUET_WARNED[universe_type] = True
@@ -194,19 +197,19 @@ def get_historical_universe(universe_type: str, date: pd.Timestamp) -> List[str]
                 universe_type, date.strftime("%Y-%m-%d"), exc
             )
     
-    # Warn once that we're falling back to current universe — not once per date.
-    if not _NO_RECORD_WARNED.get(universe_type):
-        logger.warning(
-            "[Universe] %s: No point-in-time historical record found. Falling back "
-            "to current universe for ALL missing dates (survivorship bias active).",
-            universe_type,
-        )
-        _NO_RECORD_WARNED[universe_type] = True
-
     # Fallback to point-in-time local CSV snapshot; never fallback to current constituents.
     csv_members = _load_pit_universe_from_csv(universe_type, date)
     if csv_members:
         return csv_members
+
+    # Warn once only when both parquet and CSV are unavailable for the date.
+    if not _NO_RECORD_WARNED.get(universe_type):
+        logger.warning(
+            "[Universe] %s: No point-in-time historical record found in parquet/CSV. "
+            "Returning empty universe (survivorship bias risk if caller falls back).",
+            universe_type,
+        )
+        _NO_RECORD_WARNED[universe_type] = True
     return []
 
 # ─── Cache Management ─────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation

- Prevent misleading survivorship-bias logging when a point-in-time CSV exists but the parquet is missing.  
- Restore lookahead-free ADV behavior on the dataset-first trading day and surface the newly computed `hit_rate`/`turnover` to console output.  
- Make `bootstrap_historical_parquet()` explicit about its 3-ticker stub to avoid silently providing tiny universes.  
- Add regression tests to guard continuity-decay scaling and other regressions introduced by recent changes.

### Description

- Updated `get_historical_universe()` to check point-in-time CSV snapshots before emitting a survivorship warning, clarified the docstring and adjusted log wording to reflect the actual fallback order (parquet → CSV → empty).  
- Changed `_build_adv_vector()` in `backtest_engine.py` so the first trading day sets `signal_date = None` (keeps ADV as 0.0 on day-0), eliminating a 1-day lookahead.  
- Extended `print_backtest_results()` to print `hit_rate` and `turnover`, which are already returned by `_compute_metrics()`.  
- Added a `logger.warning` in `bootstrap_historical_parquet()` to call out when the default 3-ticker stub is used.  
- Added/updated tests: new `test_universe_manager.py` tests CSV fallback and no-data warning, added a bootstrap-parquet warning test in `test_historical_builder.py`, and added momentum/backtest tests for continuity-decay scaling and first-day ADV no-lookahead in `test_momentum.py`.

### Testing

- Ran `pytest -q test_universe_manager.py test_historical_builder.py test_momentum.py -k "continuity_decay_scales_with_prev_weight or volume_first_day_adv_is_zero_no_lookahead or historical_universe or bootstrap_historical_parquet_warns_stub_content or volume_no_lookahead"`, which completed successfully with `6 passed, 62 deselected`.  
- Ran `pytest -q test_momentum.py -k "compute_metrics_annualisation or compute_metrics_sortino or generate_signals_continuity_bonus"`, which completed successfully with `3 passed, 60 deselected`.  
- All added and modified unit tests passed in the local test runs described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aafbe8af98832b95a9f1c12ddc61d2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated lookahead bias in ADV computation on first trading day
  * Historical universe retrieval now returns empty with warning when point-in-time data is unavailable, preventing silent fallback to current universe
  * Added warning notification when using stub universe with limited tickers

* **New Features**
  * Added HitRate and Turnover metrics display to backtest results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->