### PR TITLE
Handle missing CVAR_LOOKBACK in FixedTrial and add unit test

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -241,9 +241,14 @@ class MomentumObjective:
         # dragging crash returns forward for months after the event has passed.
         cvar_lb_bounds = self.search_space.get("CVAR_LOOKBACK", (60, 150, 10))
         cvar_lb_min, cvar_lb_max, cvar_lb_step = cvar_lb_bounds
-        cfg.CVAR_LOOKBACK = trial.suggest_int(
-            "CVAR_LOOKBACK", cvar_lb_min, cvar_lb_max, step=cvar_lb_step
-        )
+        if isinstance(trial, optuna.trial.FixedTrial) and "CVAR_LOOKBACK" not in trial.params:
+            # Backward-compatible fallback for manually constructed FixedTrial
+            # objects that predate the CVAR_LOOKBACK search dimension.
+            cfg.CVAR_LOOKBACK = UltimateConfig().CVAR_LOOKBACK
+        else:
+            cfg.CVAR_LOOKBACK = trial.suggest_int(
+                "CVAR_LOOKBACK", cvar_lb_min, cvar_lb_max, step=cvar_lb_step
+            )
         # Prune if lookback is shorter than LedoitWolf minimum row requirement.
         if cfg.CVAR_LOOKBACK < cfg.DIMENSIONALITY_MULTIPLIER * cfg.MAX_POSITIONS:
             raise optuna.TrialPruned()

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -179,6 +179,37 @@ def test_build_sampler_returns_tpe_sampler(monkeypatch):
     assert isinstance(sampler_seeded, optimizer.TPESampler)
 
 
+
+
+def test_objective_suggests_cvar_lookback_for_non_fixed_trials(monkeypatch):
+    class _Result:
+        metrics = {"cagr": 10.0, "max_dd": 10.0, "turnover": 0.0}
+        rebal_log = None
+
+    class _DummyTrial:
+        params = {}
+
+        def __init__(self):
+            self.suggested = []
+
+        def suggest_int(self, name, low, high, step=1):
+            self.suggested.append(name)
+            return low
+
+        def suggest_float(self, name, low, high, step=None):
+            self.suggested.append(name)
+            return low
+
+    monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
+
+    objective = optimizer.MomentumObjective(market_data={}, universe_type="nifty500")
+    trial = _DummyTrial()
+
+    objective(trial)
+
+    assert "CVAR_LOOKBACK" in trial.suggested
+
+
 def test_objective_uses_configurable_search_space(monkeypatch):
     class _Result:
         metrics = {"cagr": 10.0, "max_dd": 5.0, "turnover": 0.0}


### PR DESCRIPTION
### Motivation

- Ensure backward compatibility when `optuna.trial.FixedTrial` instances that predate the `CVAR_LOOKBACK` search dimension are used with the optimizer. 
- Avoid raising or failing when a manually-constructed `FixedTrial` does not contain `CVAR_LOOKBACK` while preserving normal suggestion behavior for other trial types.

### Description

- Add a conditional in `MomentumObjective` that checks if `trial` is an instance of `optuna.trial.FixedTrial` and lacks a `CVAR_LOOKBACK` parameter, and in that case set `cfg.CVAR_LOOKBACK` to `UltimateConfig().CVAR_LOOKBACK` as a backward-compatible fallback. 
- Preserve the original behavior of calling `trial.suggest_int("CVAR_LOOKBACK", ...)` for non-`FixedTrial` trials. 
- Add `test_objective_suggests_cvar_lookback_for_non_fixed_trials` to `test_optimizer.py` which asserts that non-fixed trials invoke `suggest_int` for `CVAR_LOOKBACK` by using a dummy trial and monkeypatched `run_backtest`.

### Testing

- Ran the new unit test `test_objective_suggests_cvar_lookback_for_non_fixed_trials` with `pytest` and it passed. 
- Ran existing optimizer tests in `test_optimizer.py` including `test_objective_uses_configurable_search_space` and they passed. 
- Overall modified test suite for `test_optimizer.py` passed when executed locally with `pytest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afc95e7ab0832bac10d9fc10dcf8ff)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced backward compatibility for existing trial configurations that lack specific parameters, ensuring legacy data structures continue to work correctly.

* **Tests**
  * Added test coverage for parameter suggestion behavior during optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->