### PR TITLE
Fix residual cash sweep allocation and remove continuity test magic numbers

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -554,16 +554,11 @@ def execute_rebalance(
     residual_cash = max(0.0, pv - base_notional)
     if valid_targets:
         ranked = sorted(valid_targets, key=lambda x: x[3], reverse=True)
-        cheapest = min(x[2] for x in ranked)
-        while residual_cash >= cheapest:
-            bought_any = False
-            for _, sym, price, _ in ranked:
-                if residual_cash >= price:
-                    desired_shares[sym] += 1
-                    residual_cash -= price
-                    bought_any = True
-            if not bought_any:
-                break
+        for _, sym, price, _ in ranked:
+            if residual_cash >= price:
+                extra = int(residual_cash // price)
+                desired_shares[sym] += extra
+                residual_cash -= extra * price
 
     for i, sym in enumerate(active_symbols):
         w = round(float(target_weights[i]), 10)

--- a/signals.py
+++ b/signals.py
@@ -1,5 +1,5 @@
 """
-signals.py — Deterministic Regime & Momentum Kernel v11.48
+signals.py — Deterministic Regime & Momentum Kernel v11.46
 =========================================================
 Generates momentum Z-scores, handles liquidity filtering, calculates
 macro regime penalties, and implements the Dispersion-Normalized Continuity Bonus.

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -116,8 +116,13 @@ def test_generate_signals_continuity_decay_scales_with_prev_weight():
     small_bonus = float(scores[0] - scores[2])
     large_bonus = float(scores[1] - scores[2])
 
-    assert small_bonus == pytest.approx(0.00375, abs=1e-6)
-    assert large_bonus == pytest.approx(0.015, abs=1e-6)
+    raw_scores, _, _ = generate_signals(log_rets, adv, cfg)
+    finite = raw_scores[np.isfinite(raw_scores)]
+    dispersion = max(np.nanstd(finite), cfg.CONTINUITY_DISPERSION_FLOOR)
+    base_bonus = min(cfg.CONTINUITY_BONUS, cfg.CONTINUITY_MAX_SCALAR) * dispersion
+
+    assert small_bonus == pytest.approx(base_bonus * 0.25, abs=1e-9)
+    assert large_bonus == pytest.approx(base_bonus * 1.0, abs=1e-9)
 
 def test_continuity_bonus_respects_max_scalar_cap():
     """When CONTINUITY_BONUS exceeds CONTINUITY_MAX_SCALAR the cap clamps the bonus."""

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -1,5 +1,5 @@
 """
-universe_manager.py — Universe Fetching & Caching v11.48
+universe_manager.py — Universe Fetching & Caching v11.46
 ========================================================
 Robust fetching of NSE/Nifty 500 universes, sector mappings, and
 point-in-time historical constituents to eliminate backtest survivorship bias.


### PR DESCRIPTION
### Motivation
- Replace an iterative one-share residual-cash sweep with a deterministic allocation to avoid pathological loops and micro-inefficiencies during rebalance.
- Remove hardcoded expected continuity-bonus numbers from the test so it stays correct if config constants change.
- Align module header version strings to the repository canonical version to avoid confusion when searching by version.

### Description
- In `execute_rebalance`, replaced the outer `while residual_cash >= cheapest` one-share sweep with a per-ranked-symbol integer-division allocation (`extra = int(residual_cash // price)`) to assign remaining cash in larger batches.
- Updated `test_generate_signals_continuity_decay_scales_with_prev_weight` to derive `small_bonus` and `large_bonus` expectations from the same continuity formula using `CONTINUITY_DISPERSION_FLOOR`, `CONTINUITY_BONUS`, and `CONTINUITY_MAX_SCALAR` instead of hardcoded numeric literals.
- Updated module header docstrings in `signals.py` and `universe_manager.py` to `v11.46` to match the codebase versioning.

### Testing
- Ran `pytest -q test_momentum.py::test_generate_signals_continuity_decay_scales_with_prev_weight test_momentum.py::test_continuity_bonus_respects_max_scalar_cap` and both tests passed.
- Ran `pytest -q test_momentum.py::test_execute_rebalance_fractional_sweep_never_overspends` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afd2b16398832bb232d7e3320718c7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized asset rebalancing allocation process for improved efficiency while maintaining consistent ordering and cash handling.

* **Chores**
  * Updated version information across modules.

* **Tests**
  * Updated continuity bonus test calculations to use dynamic base values for more robust validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->