### PR TITLE
Use stdout capability check for rupee symbol in OOS summary

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -125,6 +125,20 @@ if "OPTUNA_N_JOBS" not in os.environ and _sqlite_storage:
     )
 
 
+def _stdout_supports_rupee(stdout=None) -> bool:
+    stream = stdout if stdout is not None else getattr(sys, "stdout", None)
+    if stream is None:
+        return False
+
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    errors = getattr(stream, "errors", None) or "strict"
+    try:
+        "\u20b9".encode(encoding, errors=errors)
+    except (LookupError, TypeError, UnicodeEncodeError):
+        return False
+    return True
+
+
 def _build_sampler() -> TPESampler:
     if OPTUNA_SEED in (None, ""):
         return TPESampler()
@@ -452,11 +466,7 @@ def run_optimization(universe_type: str = "nifty500", in_memory: bool = False):
         )
         
         m = oos_results.metrics
-        # Encoding-safe currency prefix: cp1252/charmap Windows consoles cannot
-        # render ₹ (U+20B9) and raise UnicodeEncodeError, crashing the entire
-        # OOS validation block even though the backtest succeeded.
-        _enc = getattr(sys.stdout, "encoding", "utf-8") or "utf-8"
-        _rs = "\u20b9" if _enc.lower().replace("-", "") in ("utf8", "utf16", "utf32") else "Rs."
+        _rs = "\u20b9" if _stdout_supports_rupee() else "Rs."
         print(f"\n\033[1mOOS Final Equity:\033[0m \033[32m{_rs}{m.get('final', 0):,.0f}\033[0m")
         print(f"\033[1mOOS CAGR:\033[0m {m.get('cagr', 0):.2f}%")
         print(f"\033[1mOOS MaxDD:\033[0m {m.get('max_dd', 0):.2f}%")

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -392,3 +392,25 @@ def test_objective_allows_equal_halflife_values(monkeypatch):
     )
 
     assert objective(trial) != 0.0
+
+
+def test_stdout_supports_rupee_with_utf8_stream():
+    class _Stream:
+        encoding = "utf-8"
+        errors = "strict"
+
+    assert optimizer._stdout_supports_rupee(_Stream()) is True
+
+
+def test_stdout_supports_rupee_falls_back_for_cp1252_stream():
+    class _Stream:
+        encoding = "cp1252"
+        errors = "strict"
+
+    assert optimizer._stdout_supports_rupee(_Stream()) is False
+
+
+def test_stdout_supports_rupee_false_when_stdout_missing(monkeypatch):
+    monkeypatch.setattr(optimizer.sys, "stdout", None)
+
+    assert optimizer._stdout_supports_rupee() is False


### PR DESCRIPTION
### Motivation
- Avoid guessing stdout encoding names when deciding whether to print the rupee symbol, since the previous heuristic could still raise `UnicodeEncodeError` on some consoles. 
- Prefer a capability-based probe that attempts to encode the rupee symbol with the active stdout codec and error handler to decide whether to print `₹` or fall back to `Rs.`. 
- Improve testability by placing the check next to other output/logging helpers so it can be unit-tested without writing to real stdout. 

### Description
- Added a helper `
_stdout_supports_rupee(stdout=None)
` which attempts to encode `"\u20b9"` using the stream's `encoding` and `errors` attributes and returns a boolean. 
- Replaced the prior encoding-name heuristic in the OOS final equity summary with `_stdout_supports_rupee()` while keeping the final print statements and formatting unchanged. 
- Added focused unit tests in `test_optimizer.py` validating UTF-8 success, `cp1252` failure, and the behavior when `stdout` is missing. 

### Testing
- Ran `pytest -q test_optimizer.py` which executed the test suite including the new tests. 
- All tests passed: `22 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afdb9cde58832b9b45480313e0d34e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced currency display: Output now intelligently adapts to terminal capabilities, displaying the Rupee symbol (₹) when supported, with automatic fallback to "Rs." for compatibility with terminals lacking Unicode support.

* **Tests**
  * Added test coverage for currency symbol detection across multiple terminal encoding configurations, ensuring reliable display across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->