### PR TITLE
Add autouse fixture to reset universe_manager warning dicts in tests

### DIFF
--- a/test_universe_manager.py
+++ b/test_universe_manager.py
@@ -1,7 +1,18 @@
 import logging
+
 import pandas as pd
+import pytest
 import universe_manager as um
 from universe_manager import _apply_adv_filter
+
+
+@pytest.fixture(autouse=True)
+def reset_universe_warning_state():
+    um._MISSING_PARQUET_WARNED.clear()
+    um._NO_RECORD_WARNED.clear()
+    yield
+    um._MISSING_PARQUET_WARNED.clear()
+    um._NO_RECORD_WARNED.clear()
 
 
 def test_get_historical_universe_uses_csv_without_survivorship_warning(tmp_path, monkeypatch, caplog):
@@ -13,9 +24,6 @@ def test_get_historical_universe_uses_csv_without_survivorship_warning(tmp_path,
         encoding="utf-8",
     )
 
-    um._MISSING_PARQUET_WARNED.clear()
-    um._NO_RECORD_WARNED.clear()
-
     caplog.set_level(logging.WARNING)
     members = um.get_historical_universe("nifty500", pd.Timestamp("2020-02-01"))
 
@@ -26,9 +34,6 @@ def test_get_historical_universe_uses_csv_without_survivorship_warning(tmp_path,
 def test_get_historical_universe_warns_when_no_parquet_or_csv(tmp_path, monkeypatch, caplog):
     monkeypatch.chdir(tmp_path)
     (tmp_path / "data").mkdir()
-
-    um._MISSING_PARQUET_WARNED.clear()
-    um._NO_RECORD_WARNED.clear()
 
     caplog.set_level(logging.WARNING)
     members = um.get_historical_universe("nifty500", pd.Timestamp("2020-02-01"))


### PR DESCRIPTION
### Motivation
- Ensure tests do not leak or depend on prior runs by centrally resetting `universe_manager` warning state so each test runs with a clean `_MISSING_PARQUET_WARNED` and `_NO_RECORD_WARNED` mapping.

### Description
- Added `import pytest` and an `@pytest.fixture(autouse=True)` named `reset_universe_warning_state` that clears `um._MISSING_PARQUET_WARNED` and `um._NO_RECORD_WARNED` before each test and again after `yield` for teardown hygiene in `test_universe_manager.py`.
- Removed duplicated per-test `um._MISSING_PARQUET_WARNED.clear()` / `um._NO_RECORD_WARNED.clear()` calls since the autouse fixture covers setup and teardown, leaving test assertions unchanged.

### Testing
- Ran `pytest -q test_universe_manager.py` which completed successfully with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afdbb16d20832b8bb54646f843b87e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure by implementing automatic warning state reset between test runs, ensuring test isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->