### PR TITLE
Fix optimizer ADV units, NaN matrix collapse, soft-CVaR rebalance deadlock, and split/absent-position handling

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -186,6 +186,7 @@ class BacktestEngine:
         optimization_succeeded = False
         sel_idx: List[int]     = []
         _force_full_cash       = False
+        soft_cvar_breach       = False
 
         # ── Book CVaR screen ──────────────────────────────────────────────────
         # Two-tier breach architecture (see CVAR_HARD_BREACH_MULTIPLIER in UltimateConfig):
@@ -219,6 +220,7 @@ class BacktestEngine:
 
             elif book_cvar > cfg.CVAR_DAILY_LIMIT + 1e-6:
                 # SOFT breach: elevated but manageable. Let the QP handle it.
+                soft_cvar_breach = True
                 logger.info(
                     "[Backtest] Book CVaR soft breach %.4f%% (limit %.4f%%, hard %.4f%%) on %s — "
                     "running optimizer with CVaR constraint active.",
@@ -328,6 +330,7 @@ class BacktestEngine:
                 trade_log      = self.trades,
                 apply_decay    = apply_decay and not _exhaust_decay,
                 scenario_losses = None if _exhaust_decay else _L,
+                force_rebalance_trades = soft_cvar_breach,
             )
             if _exhaust_decay:
                 self.state.decay_rounds = 0

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -255,7 +255,7 @@ def detect_and_apply_splits(state: PortfolioState, market_data: dict, cfg: Ultim
     Detects splits and sweeps dividends to ensure cash ledger accuracy.
     """
     adjusted: List[str] = []
-    
+
     for sym in list(state.shares.keys()):
         ns = to_ns(sym)
         row = market_data.get(ns)
@@ -291,33 +291,34 @@ def detect_and_apply_splits(state: PortfolioState, market_data: dict, cfg: Ultim
         if last_price is None or last_price <= 0:
             continue
 
-        ratio = last_price / current_price
+        if not getattr(cfg, "AUTO_ADJUST_PRICES", True):
+            ratio = last_price / current_price
 
-        # Broader institutional ratio list with a tighter tolerance
-        split_tolerance = getattr(cfg, "SPLIT_TOLERANCE", 0.005)
-        for r in [2, 5, 10, 3, 4, 20, 1.5, 1.25, 0.666, 0.5, 0.2]:
-            if abs(ratio - r) / r <= split_tolerance:
-                old_shares     = state.shares[sym]
-                theoretical_new_shares = old_shares * r
-                new_shares     = int(np.floor(theoretical_new_shares + 1e-12))
-                old_entry      = state.entry_prices.get(sym, current_price * r)
-                new_entry      = old_entry / r
+            # Broader institutional ratio list with a tighter tolerance
+            split_tolerance = getattr(cfg, "SPLIT_TOLERANCE", 0.005)
+            for r in [2, 5, 10, 3, 4, 20, 1.5, 1.25, 0.666, 0.5, 0.2]:
+                if abs(ratio - r) / r <= split_tolerance:
+                    old_shares     = state.shares[sym]
+                    theoretical_new_shares = old_shares * r
+                    new_shares     = int(np.floor(theoretical_new_shares + 1e-12))
+                    old_entry      = state.entry_prices.get(sym, current_price * r)
+                    new_entry      = old_entry / r
 
-                # Safely sweep fractional shares
-                fractional_new_shares = max(0.0, theoretical_new_shares - new_shares)
-                fractional_value = fractional_new_shares * current_price
-                state.cash = round(state.cash + fractional_value, 10)
+                    # Safely sweep fractional shares
+                    fractional_new_shares = max(0.0, theoretical_new_shares - new_shares)
+                    fractional_value = fractional_new_shares * current_price
+                    state.cash = round(state.cash + fractional_value, 10)
 
-                logger.warning(
-                    "SPLIT DETECTED: %s ratio=%.3f (≈%gx) "
-                    "shares %d→%d entry_price ₹%.2f→₹%.2f",
-                    sym, ratio, r, old_shares, new_shares, old_entry, new_entry,
-                )
-                state.shares[sym]       = new_shares
-                state.entry_prices[sym] = round(new_entry, 4)
-                state.last_known_prices[sym] = current_price
-                adjusted.append(sym)
-                break
+                    logger.warning(
+                        "SPLIT DETECTED: %s ratio=%.3f (≈%gx) "
+                        "shares %d→%d entry_price ₹%.2f→₹%.2f",
+                        sym, ratio, r, old_shares, new_shares, old_entry, new_entry,
+                    )
+                    state.shares[sym]       = new_shares
+                    state.entry_prices[sym] = round(new_entry, 4)
+                    state.last_known_prices[sym] = current_price
+                    adjusted.append(sym)
+                    break
 
     return adjusted
 
@@ -458,13 +459,16 @@ def _run_scan(
         if _absent_sym not in active_idx:
             _fallback_px = state.last_known_prices.get(_absent_sym, 0.0)
             if _fallback_px > 0:
-                mtm_notional += state.shares[_absent_sym] * _fallback_px
+                _absent_n = int(state.absent_periods.get(_absent_sym, 0))
+                _haircut = max(0.0, 1.0 - (_absent_n / max(cfg.MAX_ABSENT_PERIODS, 1)))
+                _mtm_px = _fallback_px * _haircut
+                mtm_notional += state.shares[_absent_sym] * _mtm_px
                 logger.warning(
                     "[Scan] Held symbol '%s' absent from current market data "
-                    "(possibly delisted/suspended). Using last-known price ₹%.2f "
-                    "for PV calculation. Position will be force-closed after "
-                    "%d consecutive absent periods.",
-                    _absent_sym, _fallback_px, cfg.MAX_ABSENT_PERIODS,
+                    "(possibly delisted/suspended). Applying absence haircut %.1f%% "
+                    "to last-known price ₹%.2f for PV calculation (mark ₹%.2f). "
+                    "Position will be force-closed after %d consecutive absent periods.",
+                    _absent_sym, (1.0 - _haircut) * 100.0, _fallback_px, _mtm_px, cfg.MAX_ABSENT_PERIODS,
                 )
     pv = mtm_notional + state.cash
     initial_cash = state.cash
@@ -491,6 +495,7 @@ def _run_scan(
     trade_log: List[Trade] = []
     sel_idx: List[int]   = []
     _force_full_cash     = False
+    _soft_cvar_breach    = False
 
     # ── Book CVaR screen ──────────────────────────────────────────────────────
     if state.shares:
@@ -509,6 +514,7 @@ def _run_scan(
             _force_full_cash = True
             activate_override_on_stress(state, cfg)
         elif book_cvar > cfg.CVAR_DAILY_LIMIT + 1e-6:
+            _soft_cvar_breach = True
             logger.info(
                 "[Scan] Book CVaR soft breach %.4f%% (limit %.4f%%, hard %.4f%%) — "
                 "running optimizer with CVaR constraint active.",
@@ -590,6 +596,7 @@ def _run_scan(
             date_context=pd.Timestamp(end_date), trade_log=trade_log,
             apply_decay    = apply_decay and not _exhaust_decay,
             scenario_losses = None if _exhaust_decay else _scenario_losses,
+            force_rebalance_trades = _soft_cvar_breach,
         )
         if _exhaust_decay:
             state.decay_rounds = 0

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -221,6 +221,7 @@ class UltimateConfig:
     # New institutional flags
     DIVIDEND_SWEEP:           bool  = True
     SPLIT_TOLERANCE:          float = 0.005 # Tightened for institutional accuracy
+    AUTO_ADJUST_PRICES:       bool  = True
 
     @property
     def SLIPPAGE_BPS(self) -> float:
@@ -436,12 +437,13 @@ def execute_rebalance(
     prices:         np.ndarray,
     active_symbols: List[str],
     cfg:            UltimateConfig,
-    adv_shares:     Optional[np.ndarray] = None, # NOW REQUIRED for impact parity
+    adv_shares:     Optional[np.ndarray] = None, # ADV notional (₹/day)
     date_context=None,
     trade_log:      Optional[List[Trade]] = None,
     apply_decay:    bool = False,
     scenario_losses: Optional[np.ndarray] = None,
     conviction_scores: Optional[np.ndarray] = None,
+    force_rebalance_trades: bool = False,
 ) -> float:
     """Execute a portfolio rebalance, updating state in-place."""
     active_idx = {sym: i for i, sym in enumerate(active_symbols)}
@@ -578,7 +580,7 @@ def execute_rebalance(
             # (e.g. 1-2 shares) during periods of persistently elevated CVaR.
             # Full exits (s == 0, old_s > 0) always execute regardless of tolerance.
             # New entries (old_s == 0, s > 0) always execute.
-            if delta != 0 and old_s > 0 and s > 0:
+            if delta != 0 and old_s > 0 and s > 0 and not force_rebalance_trades:
                 drift_threshold = getattr(cfg, "DRIFT_TOLERANCE", 0.02)
                 weight_change = abs(delta * price) / max(pv, 1.0)
                 if weight_change < drift_threshold:
@@ -593,7 +595,9 @@ def execute_rebalance(
 
             # ── FIX: Institutional Impact Alignment ──
             if adv_shares is not None and adv_shares[i] > 0:
-                impact_rate = (cfg.IMPACT_COEFF * pv) / (price * adv_shares[i])
+                # ADV is passed in notional units (₹/day), so impact denominator
+                # must not multiply by price again (which would create ₹^2 units).
+                impact_rate = (cfg.IMPACT_COEFF * pv) / adv_shares[i]
                 slip_rate = max(cfg.ROUND_TRIP_SLIPPAGE_BPS / 20000.0, min(0.05, impact_rate))
             else:
                 slip_rate = cfg.ROUND_TRIP_SLIPPAGE_BPS / 20000.0
@@ -808,7 +812,14 @@ class InstitutionalRiskEngine:
                 "portfolio_value must be finite and strictly positive.", OptimizationErrorType.DATA
             )
 
-        clean_rets = historical_returns.replace([np.inf, -np.inf], np.nan).ffill().dropna()
+        # Avoid matrix collapse from DataFrame-wide dropna(): with broad universes,
+        # a single symbol NaN can otherwise delete the entire row for all symbols.
+        clean_rets = historical_returns.replace([np.inf, -np.inf], np.nan).ffill()
+        if clean_rets.empty:
+            raise OptimizationError("historical_returns is empty after sanitisation.", OptimizationErrorType.DATA)
+        # Preserve all rows and impute residual leading NaNs conservatively to 0.
+        # This keeps the sample horizon stable and avoids pathological shrinkage.
+        clean_rets = clean_rets.fillna(0.0)
         T          = len(clean_rets)
         min_rows   = self.cfg.DIMENSIONALITY_MULTIPLIER * m
         if T < min_rows:
@@ -872,9 +883,9 @@ class InstitutionalRiskEngine:
             gamma *= 0.5
             gamma = max(self.cfg.MIN_EXPOSURE_FLOOR, gamma)
 
-        adv_limit = np.clip(
-            (adv_shares * prices * self.cfg.MAX_ADV_PCT) / portfolio_value, 1e-9, 0.40
-        )
+        # adv_shares carries ADV notional (₹/day), so max tradable weight is
+        # ADV-notional budget divided by portfolio value.
+        adv_limit = np.clip((adv_shares * self.cfg.MAX_ADV_PCT) / portfolio_value, 1e-9, 0.40)
         adv_limit = np.minimum(adv_limit, self.cfg.MAX_SINGLE_NAME_WEIGHT)
         l_gamma = max(self.cfg.MIN_EXPOSURE_FLOOR, gamma * (1.0 - self.cfg.CAPITAL_ELASTICITY))
         u_gamma = min(1.0, gamma * (1.0 + self.cfg.CAPITAL_ELASTICITY))
@@ -900,7 +911,7 @@ class InstitutionalRiskEngine:
 
         impact     = np.clip(
             self.cfg.IMPACT_COEFF * portfolio_value
-            / (np.maximum(prices, 1.0) * np.maximum(adv_shares, 1.0)),
+            / np.maximum(adv_shares, 1.0),
             0.0, 1e4,
         )
         T_cvar     = min(T, self.cfg.CVAR_LOOKBACK)
@@ -914,7 +925,8 @@ class InstitutionalRiskEngine:
 
         q        = np.zeros(n_vars)
         q[:m]    = -expected_returns - 2.0 * impact * prev_w_arr
-        q[m:2*m] = self.cfg.ROUND_TRIP_SLIPPAGE_BPS / 10_000.0
+        # |w-w_prev| is one-way turnover, so use one-way cost (round-trip / 2).
+        q[m:2*m] = self.cfg.ROUND_TRIP_SLIPPAGE_BPS / 20_000.0
         q[-1]    = self.cfg.SLACK_PENALTY
 
         builder = _ConstraintBuilder(n_vars)

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -232,6 +232,27 @@ def test_optimizer_raises_data_error_on_thin_history():
     assert exc_info.value.error_type == OptimizationErrorType.DATA
 
 
+def test_optimizer_handles_sparse_nans_without_matrix_collapse():
+    n, m = 30, 3
+    log_rets = _make_log_rets(n, m)
+    # Stagger leading NaNs so at least one column is NaN on many rows.
+    log_rets.iloc[:15, 0] = np.nan
+    log_rets.iloc[:12, 1] = np.nan
+    log_rets.iloc[:9, 2] = np.nan
+
+    engine = _make_engine()
+    w = engine.optimize(
+        np.array([0.001, 0.0012, 0.0008]),
+        log_rets,
+        np.ones(m) * 2e8,
+        np.array([100.0, 500.0, 1000.0]),
+        1_000_000.0,
+        exposure_multiplier=1.0,
+    )
+    assert np.isfinite(w).all()
+    assert len(w) == m
+
+
 def test_optimizer_rejects_non_finite_inputs():
     log_rets = _make_log_rets(120, 4)
     engine   = _make_engine()
@@ -509,6 +530,69 @@ def test_execute_rebalance_pv_includes_stale_positions():
     assert "STALE" not in state.shares, "With MAX_ABSENT_PERIODS=1, one absence closes position."
 
 
+def test_execute_rebalance_uses_notional_adv_for_impact_parity():
+    cfg = UltimateConfig(IMPACT_COEFF=100.0, ROUND_TRIP_SLIPPAGE_BPS=20.0)
+
+    state_low = PortfolioState(cash=1_000_000.0)
+    slip_low = execute_rebalance(
+        state_low,
+        target_weights=np.array([1.0]),
+        prices=np.array([100.0]),
+        active_symbols=["LOW"],
+        cfg=cfg,
+        adv_shares=np.array([1e8]),
+    )
+
+    state_high = PortfolioState(cash=1_000_000.0)
+    slip_high = execute_rebalance(
+        state_high,
+        target_weights=np.array([1.0]),
+        prices=np.array([1000.0]),
+        active_symbols=["HIGH"],
+        cfg=cfg,
+        adv_shares=np.array([1e8]),
+    )
+
+    assert slip_low == pytest.approx(slip_high, rel=1e-6)
+
+
+def test_execute_rebalance_force_rebalance_trades_bypasses_drift_tolerance():
+    cfg = UltimateConfig(DRIFT_TOLERANCE=0.05, MAX_SINGLE_NAME_WEIGHT=1.0)
+
+    no_force = PortfolioState(cash=0.0)
+    no_force.shares = {"A": 100, "B": 100}
+    no_force.weights = {"A": 0.50, "B": 0.50}
+    no_force.entry_prices = {"A": 100.0, "B": 100.0}
+    no_force.last_known_prices = {"A": 100.0, "B": 100.0}
+
+    execute_rebalance(
+        no_force,
+        target_weights=np.array([0.51, 0.49]),
+        prices=np.array([100.0, 100.0]),
+        active_symbols=["A", "B"],
+        cfg=cfg,
+        force_rebalance_trades=False,
+    )
+
+    force = PortfolioState(cash=0.0)
+    force.shares = {"A": 100, "B": 100}
+    force.weights = {"A": 0.50, "B": 0.50}
+    force.entry_prices = {"A": 100.0, "B": 100.0}
+    force.last_known_prices = {"A": 100.0, "B": 100.0}
+
+    execute_rebalance(
+        force,
+        target_weights=np.array([0.51, 0.49]),
+        prices=np.array([100.0, 100.0]),
+        active_symbols=["A", "B"],
+        cfg=cfg,
+        force_rebalance_trades=True,
+    )
+
+    assert no_force.shares["A"] == 100
+    assert force.shares["A"] == 102
+
+
 def test_execute_rebalance_cash_conservation():
     cfg   = UltimateConfig()
     state = PortfolioState(cash=1_000_000.0)
@@ -526,10 +610,21 @@ def test_detect_and_apply_splits_fractional_cash():
     state.last_known_prices = {"A": 100.0}
 
     market_data = {"A": pd.DataFrame({"Close": [200.0]})}
-    detect_and_apply_splits(state, market_data, UltimateConfig())
+    detect_and_apply_splits(state, market_data, UltimateConfig(AUTO_ADJUST_PRICES=False))
 
     assert state.shares["A"] == 50, "Shares should floor correctly on splits."
     assert state.cash == 100.0, "Fractional value must be safely routed to Cash."
+
+def test_detect_and_apply_splits_skips_when_auto_adjust_enabled():
+    state = PortfolioState(cash=0.0)
+    state.shares = {"A": 100}
+    state.last_known_prices = {"A": 100.0}
+    market_data = {"A": pd.DataFrame({"Close": [50.0]})}
+
+    detect_and_apply_splits(state, market_data, UltimateConfig(AUTO_ADJUST_PRICES=True))
+
+    assert state.shares["A"] == 100
+
 
 def test_detect_and_apply_splits_dividend_sweep_idempotent():
     state = PortfolioState(cash=0.0)
@@ -538,7 +633,7 @@ def test_detect_and_apply_splits_dividend_sweep_idempotent():
     idx = pd.to_datetime(["2024-01-01", "2024-01-02"])
     market_data = {"A.NS": pd.DataFrame({"Close": [100.0, 102.0], "Dividends": [0.0, 2.0]}, index=idx)}
 
-    cfg = UltimateConfig(DIVIDEND_SWEEP=True)
+    cfg = UltimateConfig(DIVIDEND_SWEEP=True, AUTO_ADJUST_PRICES=False)
     detect_and_apply_splits(state, market_data, cfg)
     detect_and_apply_splits(state, market_data, cfg)
 


### PR DESCRIPTION
### Motivation
- Address critical data- and unit-related failures that can cause optimizer crashes or severe mis-sizing: DataFrame-wide `dropna()` causing matrix collapse and `adv` treated inconsistently as notional vs shares.
- Prevent operational fragilities that inflate portfolio value for absent/delisted positions and double-count splits with auto-adjusted price feeds.
- Ensure de-risking trades produced under a soft CVaR breach are not repeatedly suppressed by the per-symbol `DRIFT_TOLERANCE` gate, which caused oscillation and paralysis.

### Description
- Replace DataFrame-wide `.dropna()` in the optimizer with `replace(...).ffill()` plus an explicit non-empty guard and conservative `fillna(0.0)` imputation to avoid horizon shrinkage and spurious `Insufficient history` errors (`InstitutionalRiskEngine.optimize`).
- Standardize `adv_shares` as ADV notional (₹/day) and fix unit math so capacity and impact use notional correctly: `adv_limit = (adv_notional * MAX_ADV_PCT) / portfolio_value` and `impact = IMPACT_COEFF * portfolio_value / adv_notional`, removing the unintended extra `price` multiplication.
- Align linear turnover penalty with the one-way turnover variable by changing the optimizer linear-cost coefficient from round-trip to one-way (`/20_000.0` instead of `/10_000.0`).
- Add `force_rebalance_trades` flag to `execute_rebalance()` and make the drift-tolerance gate skip only when this flag is set, enabling forced de-risking during soft CVaR breaches; wire this flag from both `daily_workflow._run_scan` and `backtest_engine` when a soft breach is detected.
- Apply a progressive absence haircut to last-known prices in scan MTM valuation (`_run_scan`) so held-but-absent symbols do not unrealistically inflate PV while still being carried until `MAX_ABSENT_PERIODS` elapses.
- Introduce `AUTO_ADJUST_PRICES` config (default `True`) and make `detect_and_apply_splits()` skip ratio-based split share adjustments when auto-adjusted feeds are used, avoiding double-adjustment while preserving dividend sweep logic.
- Update/extend tests in `test_momentum.py` to cover sparse-NaN optimizer robustness, notional-ADV impact parity, forced-rebalance drift bypass behavior, and split handling under `AUTO_ADJUST_PRICES`; adjust existing split/dividend tests to explicitly set `AUTO_ADJUST_PRICES=False` where manual split handling is expected.

### Testing
- Ran targeted unit tests with `pytest -q` for the modified momentum and split workflows, including `test_optimizer_handles_sparse_nans_without_matrix_collapse`, `test_execute_rebalance_uses_notional_adv_for_impact_parity`, `test_execute_rebalance_force_rebalance_trades_bypasses_drift_tolerance`, `test_detect_and_apply_splits_fractional_cash`, `test_detect_and_apply_splits_dividend_sweep_idempotent`, and `test_detect_and_apply_splits_skips_when_auto_adjust_enabled`, and they all passed.
- Executed `python -m py_compile momentum_engine.py daily_workflow.py backtest_engine.py test_momentum.py` to validate syntax/compilation, which succeeded.
- All automated test runs executed during validation returned green for the targeted test set after the fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afde971fdc832b8e3ba22e5b768010)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added soft CVaR breach detection to trigger more responsive portfolio rebalancing when risk limits approach critical thresholds
  * Introduced haircut mechanism for handling temporarily missing market data with proportional pricing adjustments

* **Improvements**
  * Enhanced stock split detection and adjustment logic with refined conditional handling
  * Refined Average Daily Volume budget calculations for improved accuracy in turnover costing
  * Improved historical data handling for incomplete datasets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->