### PR TITLE
Raise UniverseFetchError when ADV chunk fetch fails

### DIFF
--- a/test_universe_manager.py
+++ b/test_universe_manager.py
@@ -161,3 +161,33 @@ def test_apply_adv_filter_excludes_below_adv_threshold(monkeypatch):
 
     assert "LIQUID.NS" in result,   "LIQUID must pass the ADV filter."
     assert "ILLIQUID.NS" not in result, "ILLIQUID must be excluded by the ADV filter."
+
+
+def test_apply_adv_filter_raises_on_any_chunk_failure(monkeypatch):
+    """
+    If any chunk fetch fails, _apply_adv_filter must raise UniverseFetchError
+    rather than silently returning a partial filtered list.
+    """
+    import data_cache
+    import numpy as np
+    from momentum_engine import UltimateConfig
+
+    tickers = [f"SYM{i:03d}" for i in range(76)]
+
+    def _fake_load_or_fetch(chunk, start, end, cfg=None):
+        if "SYM075" in chunk:
+            raise RuntimeError("chunk boom")
+
+        idx = pd.date_range("2024-01-01", periods=30, freq="B")
+        return {
+            f"{sym}.NS": pd.DataFrame(
+                {"Close": np.ones(30) * 500.0, "Volume": np.ones(30) * 1e6},
+                index=idx,
+            )
+            for sym in chunk
+        }
+
+    monkeypatch.setattr(data_cache, "load_or_fetch", _fake_load_or_fetch)
+
+    with pytest.raises(um.UniverseFetchError, match="ADV filter failed for 1 chunk"):
+        _apply_adv_filter(tickers, UltimateConfig(MIN_ADV_CRORES=1))

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -292,7 +292,9 @@ def _apply_adv_filter(tickers: List[str], cfg=None) -> List[str]:
     # "Invalid Crumb"), causing entire chunks to return empty and incorrectly
     # disqualifying hundreds of valid liquid stocks.  Sequential processing
     # (~30s for 500 tickers) produces reliable, complete ADV results.
-    for chunk in chunks:
+    chunk_failures: List[Dict[str, object]] = []
+
+    for chunk_idx, chunk in enumerate(chunks):
         try:
             data = load_or_fetch(chunk, start_date, end_date, cfg=cfg)
             for symbol in chunk:
@@ -309,7 +311,30 @@ def _apply_adv_filter(tickers: List[str], cfg=None) -> List[str]:
                         # causing downstream cache-key mismatches.
                         filtered_tickers.append(ns_sym)
         except Exception as exc:
-            logger.error("[Universe] Error processing ADV chunk: %s", exc)
+            failure = {
+                "chunk_index": chunk_idx,
+                "symbols": list(chunk),
+                "error": str(exc),
+            }
+            chunk_failures.append(failure)
+            logger.error(
+                "[Universe] Error processing ADV chunk %d (size=%d): %s",
+                chunk_idx,
+                len(chunk),
+                exc,
+            )
+
+    if chunk_failures:
+        failed_symbol_preview = [
+            symbol
+            for failure in chunk_failures
+            for symbol in failure["symbols"][:3]
+        ][:6]
+        preview_txt = ", ".join(failed_symbol_preview) if failed_symbol_preview else "n/a"
+        raise UniverseFetchError(
+            "ADV filter failed for "
+            f"{len(chunk_failures)} chunk(s); sample symbols: {preview_txt}"
+        )
 
     return filtered_tickers
 
@@ -359,6 +384,14 @@ def fetch_nse_equity_universe(cfg=None) -> List[str]:
         _save_universe_cache(cache)
         return liquid_tickers
         
+    except UniverseFetchError as exc:
+        logger.error("[Universe] NSE master fetch failed during ADV filtering: %s", exc)
+        if entry:
+            logger.warning("[Universe] Using stale cache for NSE Total Equity.")
+            return entry["tickers"]
+
+        exc.fallback_universe = list(_HARD_FLOOR_UNIVERSE)
+        raise
     except Exception as exc:
         logger.error("[Universe] NSE master fetch failed: %s", exc)
         if entry:


### PR DESCRIPTION
### Motivation
- Prevent silent partial universe returns when ADV market-data chunk fetches fail and ensure callers fall back to stale cache or hard-coded universe instead of accepting incomplete results.

### Description
- Record per-chunk failures (index, symbols, error text) inside `_apply_adv_filter` and raise `UniverseFetchError` with a summary including failed chunk count and sample symbols when any chunk fails.
- Update `fetch_nse_equity_universe` to catch `UniverseFetchError`, log the failure, use a stale cache when available, and set `fallback_universe` on final failure instead of accepting partial filtered output.
- Add `test_apply_adv_filter_raises_on_any_chunk_failure` to `test_universe_manager.py` which mocks `load_or_fetch` to fail one chunk and asserts `_apply_adv_filter` raises `UniverseFetchError`.
- Changes made in `universe_manager.py` and `test_universe_manager.py`.

### Testing
- Ran `pytest -q test_universe_manager.py` and the test suite passed (`6 passed`), validating the new failure handling and existing regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe5457acc832b8262ba553bfcac4a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test for error handling in data filtering to verify proper exception behavior during processing failures.

* **Bug Fixes**
  * Improved error handling for data fetch failures with enhanced error messages and detailed failure tracking.
  * Added fallback to use cached data when fetch operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->