### PR TITLE
Gate continuity bonus on staleness and liquidity

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -184,6 +184,11 @@ class UltimateConfig:
     CONTINUITY_DISPERSION_FLOOR: float = 0.1
     CONTINUITY_MAX_SCALAR:    float = 0.20
     CONTINUITY_MAX_HOLD_WEIGHT: float = 0.10
+    CONTINUITY_ACTIVITY_WINDOW: int = 5
+    CONTINUITY_MIN_NONZERO_DAYS: int = 1
+    CONTINUITY_STALE_SESSIONS: int = 10
+    CONTINUITY_FLAT_RET_EPS: float = 1e-12
+    CONTINUITY_MIN_ADV_NOTIONAL: float = 0.0
     KNIFE_WINDOW:             int   = 20
     KNIFE_THRESHOLD:          float = -0.15
 

--- a/signals.py
+++ b/signals.py
@@ -241,11 +241,48 @@ def generate_signals(
         cap = float(getattr(cfg, "CONTINUITY_MAX_SCALAR", 0.20))
         base_bonus = min(cfg.CONTINUITY_BONUS, cap) * current_dispersion
 
+        activity_window = max(int(getattr(cfg, "CONTINUITY_ACTIVITY_WINDOW", 5)), 1)
+        stale_sessions = max(int(getattr(cfg, "CONTINUITY_STALE_SESSIONS", 10)), 1)
+        min_nonzero_days = max(int(getattr(cfg, "CONTINUITY_MIN_NONZERO_DAYS", 1)), 1)
+        flat_ret_eps = float(getattr(cfg, "CONTINUITY_FLAT_RET_EPS", 1e-12))
+        continuity_min_adv = float(getattr(cfg, "CONTINUITY_MIN_ADV_NOTIONAL", 0.0))
+
+        stale_denied = 0
+        liquidity_denied = 0
+
         for i, sym in enumerate(active_symbols):
             prev_w = float(prev_weights.get(sym, 0.0))
             if valid_mask[i] and prev_w > 0.001:
+                recent_rets = log_rets[sym].tail(activity_window)
+                nonzero_days = int((recent_rets.abs() > flat_ret_eps).sum()) if len(recent_rets) else 0
+                has_recent_activity = nonzero_days >= min_nonzero_days
+
+                stale_rets = log_rets[sym].tail(stale_sessions)
+                is_stale = (
+                    len(stale_rets) == stale_sessions
+                    and stale_rets.notna().all()
+                    and bool((stale_rets.abs() <= flat_ret_eps).all())
+                )
+
+                passes_continuity_liquidity = np.isfinite(adv_arr[i]) and adv_arr[i] >= continuity_min_adv
+                continuity_eligible = has_recent_activity or passes_continuity_liquidity
+
+                if is_stale:
+                    stale_denied += 1
+                if not passes_continuity_liquidity:
+                    liquidity_denied += 1
+                if is_stale or not passes_continuity_liquidity or not continuity_eligible:
+                    continue
+
                 decay = float(np.clip(prev_w / max(getattr(cfg, "CONTINUITY_MAX_HOLD_WEIGHT", 0.10), 1e-6), 0.25, 1.0))
                 adj_scores[i] += base_bonus * decay
+
+        if stale_denied or liquidity_denied:
+            logger.debug(
+                "[Signals] Continuity denied for %d stale and %d illiquid symbols.",
+                stale_denied,
+                liquidity_denied,
+            )
 
     # 4. Final Selection
     # Sort and pick the top N elements (ignoring those assigned -inf)

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -124,6 +124,54 @@ def test_generate_signals_continuity_decay_scales_with_prev_weight():
     assert small_bonus == pytest.approx(base_bonus * 0.25, abs=1e-9)
     assert large_bonus == pytest.approx(base_bonus * 1.0, abs=1e-9)
 
+
+
+def test_generate_signals_continuity_bonus_blocked_for_flatlined_symbol():
+    """Flatlined names must not receive continuity bonus even with prior weight."""
+    n_days = 120
+    live = np.linspace(-0.01, 0.01, n_days)
+    flat = np.zeros(n_days)
+    log_rets = pd.DataFrame({"LIVE": live, "FLAT": flat})
+    adv = np.array([1e6, 1e6], dtype=float)
+    cfg = UltimateConfig(HISTORY_GATE=10, MAX_POSITIONS=2, CONTINUITY_STALE_SESSIONS=10)
+
+    _, scores_with_hold, _ = generate_signals(
+        log_rets,
+        adv,
+        cfg,
+        prev_weights={"FLAT": 0.10, "LIVE": 0.0},
+    )
+    _, scores_no_hold, _ = generate_signals(log_rets, adv, cfg)
+
+    assert scores_with_hold[1] == pytest.approx(scores_no_hold[1], abs=1e-12)
+    assert scores_with_hold[0] > scores_with_hold[1], "Flatlined held name must not outrank active name via continuity."
+
+
+def test_generate_signals_continuity_denial_logging_counts(caplog):
+    """Continuity denial logging should report stale and liquidity counter totals."""
+    n_days = 60
+    live = np.linspace(-0.01, 0.01, n_days)
+    stale = np.zeros(n_days)
+    illiquid = np.concatenate([np.zeros(n_days - 5), np.array([0.01, -0.01, 0.01, -0.01, 0.01])])
+    log_rets = pd.DataFrame({"LIVE": live, "STALE": stale, "ILLIQ": illiquid})
+    adv = np.array([1e6, 1e6, 1e3], dtype=float)
+    cfg = UltimateConfig(
+        HISTORY_GATE=10,
+        MAX_POSITIONS=3,
+        CONTINUITY_STALE_SESSIONS=10,
+        CONTINUITY_MIN_ADV_NOTIONAL=1e5,
+    )
+
+    with caplog.at_level("DEBUG"):
+        generate_signals(
+            log_rets,
+            adv,
+            cfg,
+            prev_weights={"STALE": 0.10, "ILLIQ": 0.10, "LIVE": 0.0},
+        )
+
+    assert "Continuity denied for 1 stale and 1 illiquid symbols." in caplog.text
+
 def test_continuity_bonus_respects_max_scalar_cap():
     """When CONTINUITY_BONUS exceeds CONTINUITY_MAX_SCALAR the cap clamps the bonus."""
     base_col = np.linspace(-0.01, 0.01, 120)


### PR DESCRIPTION
### Motivation
- Prevent stale or illiquid names from receiving the continuity bonus which can artificially inflate rankings and increase turnover risk.
- Make continuity behavior configurable via the global config so thresholds and windows are tunable for different universes and tests.
- Emit debug counters so we can monitor how often continuity is being suppressed for staleness or liquidity reasons.

### Description
- Added new config knobs in `UltimateConfig` to control continuity gating: `CONTINUITY_ACTIVITY_WINDOW`, `CONTINUITY_MIN_NONZERO_DAYS`, `CONTINUITY_STALE_SESSIONS`, `CONTINUITY_FLAT_RET_EPS`, and `CONTINUITY_MIN_ADV_NOTIONAL` (file: `momentum_engine.py`).
- Extended `generate_signals` (file: `signals.py`) to require per-symbol eligibility before applying the dispersion-normalized continuity bonus by checking recent non-zero return activity and a continuity-specific ADV/liquidity threshold, and treating fully flat recent closes as stale (skips bonus application for such symbols).
- Suppressed the continuity bonus for symbols that are stale or fail the continuity liquidity gate by skipping the bonus addition (effectively `decay = 0` for those names), and added debug counters that log counts of stale and illiquid denials once per call.
- Added two signal-focused tests (file: `test_momentum.py`) that (1) verify a synthetic flatlined symbol with prior weight does not get continuity uplift and (2) assert the debug log contains the expected denial counts for stale and illiquid names.

### Testing
- Ran the continuity-focused test subset with `pytest -q test_momentum.py -k "continuity"` and all tests passed: `5 passed, 67 deselected`.
- The new tests exercise the flatlined symbol and logging behaviour and succeeded under the default and adjusted continuity config values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe53985bc832b85c0a56fe2bbd085)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuity and liquidity gating to signal filtering. Symbols now require recent activity or minimum average daily volume to remain eligible.
  * New configurable parameters to control activity windows, stale session thresholds, and liquidity minimums.
  * Flatlined or stale symbols are now excluded from continuity bonuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->