### PR TITLE
Unify absent-asset pricing between MTM and force-close paths

### DIFF
--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -32,6 +32,7 @@ from momentum_engine import (
     execute_rebalance,
     compute_book_cvar,
     compute_decay_targets,
+    absent_symbol_effective_price,
     to_ns,
     to_bare,
     Trade,
@@ -460,15 +461,18 @@ def _run_scan(
             _fallback_px = state.last_known_prices.get(_absent_sym, 0.0)
             if _fallback_px > 0:
                 _absent_n = int(state.absent_periods.get(_absent_sym, 0))
-                _haircut = max(0.0, 1.0 - (_absent_n / max(cfg.MAX_ABSENT_PERIODS, 1)))
-                _mtm_px = _fallback_px * _haircut
+                _mtm_px = absent_symbol_effective_price(_fallback_px, _absent_n, cfg.MAX_ABSENT_PERIODS)
                 mtm_notional += state.shares[_absent_sym] * _mtm_px
                 logger.warning(
                     "[Scan] Held symbol '%s' absent from current market data "
                     "(possibly delisted/suspended). Applying absence haircut %.1f%% "
                     "to last-known price ₹%.2f for PV calculation (mark ₹%.2f). "
                     "Position will be force-closed after %d consecutive absent periods.",
-                    _absent_sym, (1.0 - _haircut) * 100.0, _fallback_px, _mtm_px, cfg.MAX_ABSENT_PERIODS,
+                    _absent_sym,
+                    (1.0 - (_mtm_px / _fallback_px if _fallback_px > 0 else 0.0)) * 100.0,
+                    _fallback_px,
+                    _mtm_px,
+                    cfg.MAX_ABSENT_PERIODS,
                 )
     pv = mtm_notional + state.cash
     initial_cash = state.cash

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -50,6 +50,17 @@ def to_bare(sym: str) -> str:
     return sym[:-3] if sym.endswith(".NS") else sym
 
 
+def absent_symbol_effective_price(last_known_price: float, absent_periods: int, max_absent_periods: int) -> float:
+    """Mark absent symbols with a linear haircut that reaches zero at the absence threshold."""
+    px = float(last_known_price)
+    if not np.isfinite(px) or px <= 0:
+        return 0.0
+    n_absent = max(0, int(absent_periods))
+    max_absent = max(1, int(max_absent_periods))
+    haircut = max(0.0, 1.0 - (n_absent / max_absent))
+    return px * haircut
+
+
 # ─── Enumerations & exceptions ────────────────────────────────────────────────
 
 class OptimizationErrorType(Enum):
@@ -473,9 +484,13 @@ def execute_rebalance(
             else:
                 logger.info(
                     "execute_rebalance: %s absent from data feed (period %d/%d); "
-                    "carrying position at last known price ₹%.2f.",
+                    "carrying position at effective marked price ₹%.2f.",
                     sym, count, cfg.MAX_ABSENT_PERIODS,
-                    state.last_known_prices.get(sym, 0.0),
+                    absent_symbol_effective_price(
+                        state.last_known_prices.get(sym, 0.0),
+                        count,
+                        cfg.MAX_ABSENT_PERIODS,
+                    ),
                 )
 
     pv = state.cash
@@ -483,7 +498,11 @@ def execute_rebalance(
         if sym in active_idx:
             pv += n_shares * float(local_prices[active_idx[sym]])
         elif sym not in symbols_to_force_close:
-            pv += n_shares * state.last_known_prices.get(sym, 0.0)
+            pv += n_shares * absent_symbol_effective_price(
+                state.last_known_prices.get(sym, 0.0),
+                state.absent_periods.get(sym, 0),
+                cfg.MAX_ABSENT_PERIODS,
+            )
 
     if apply_decay:
         state.decay_rounds += 1
@@ -627,10 +646,18 @@ def execute_rebalance(
             new_shares[sym]       = state.shares[sym]
             new_weights[sym]      = state.weights.get(sym, 0.0)
             new_entry_prices[sym] = state.entry_prices.get(sym, 0.0)
-            actual_notional      += new_shares[sym] * state.last_known_prices.get(sym, 0.0)
+            actual_notional      += new_shares[sym] * absent_symbol_effective_price(
+                state.last_known_prices.get(sym, 0.0),
+                state.absent_periods.get(sym, 0),
+                cfg.MAX_ABSENT_PERIODS,
+            )
 
     for sym in symbols_to_force_close:
-        close_price = state.last_known_prices.get(sym, 0.0)
+        close_price = absent_symbol_effective_price(
+            state.last_known_prices.get(sym, 0.0),
+            max(0, state.absent_periods.get(sym, 0) - 1),
+            cfg.MAX_ABSENT_PERIODS,
+        )
         n_shares    = state.shares.get(sym, 0)
         if n_shares > 0:
             if close_price > 0:

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -24,6 +24,7 @@ from momentum_engine import (
     execute_rebalance,
     compute_book_cvar,
     compute_decay_targets,
+    absent_symbol_effective_price,
     _ConstraintBuilder,
 )
 from backtest_engine import BacktestEngine, run_backtest, _compute_metrics, _build_adv_vector
@@ -982,6 +983,33 @@ def test_ghost_position_single_day_absence_is_preserved():
     assert state.absent_periods.get("GHOST", 0) == 1, "Absent counter must increment."
 
 
+
+
+def test_force_close_uses_prior_marked_value_without_pv_spike():
+    cfg = UltimateConfig(MAX_ABSENT_PERIODS=4, ROUND_TRIP_SLIPPAGE_BPS=0.0)
+    state = PortfolioState(cash=0.0)
+    state.shares = {"GHOST": 10}
+    state.entry_prices = {"GHOST": 100.0}
+    state.last_known_prices = {"GHOST": 100.0}
+    state.weights = {"GHOST": 1.0}
+
+    target_empty = np.array([], dtype=float)
+
+    for _ in range(cfg.MAX_ABSENT_PERIODS - 1):
+        execute_rebalance(state, target_empty, np.array([]), [], cfg)
+        absent_n = state.absent_periods.get("GHOST", 0)
+        expected_mtm = 10 * absent_symbol_effective_price(100.0, absent_n, cfg.MAX_ABSENT_PERIODS)
+        current_mtm = state.shares.get("GHOST", 0) * absent_symbol_effective_price(
+            state.last_known_prices.get("GHOST", 0.0), absent_n, cfg.MAX_ABSENT_PERIODS
+        )
+        assert state.cash + current_mtm == pytest.approx(expected_mtm)
+
+    marked_before_close = 10 * absent_symbol_effective_price(100.0, cfg.MAX_ABSENT_PERIODS - 1, cfg.MAX_ABSENT_PERIODS)
+    execute_rebalance(state, target_empty, np.array([]), [], cfg)
+
+    assert "GHOST" not in state.shares
+    assert state.cash == pytest.approx(marked_before_close)
+
 def test_ghost_position_delists_after_max_absent_periods():
     cfg   = UltimateConfig(MAX_ABSENT_PERIODS=12)
     state = PortfolioState(cash=500_000.0)
@@ -1003,8 +1031,9 @@ def test_ghost_position_delists_after_max_absent_periods():
     assert "DELISTED" not in state.shares, "Position must be closed after MAX_ABSENT_PERIODS."
     sell_trades = [t for t in trade_log if t.symbol == "DELISTED" and t.direction == "SELL"]
     assert sell_trades, "A SELL trade must be logged for the delisted position."
-    assert sell_trades[-1].exec_price == pytest.approx(900.0, rel=1e-4), \
-        "Delisted position must be closed at last known price, not ₹0."
+    expected_close = absent_symbol_effective_price(900.0, cfg.MAX_ABSENT_PERIODS - 1, cfg.MAX_ABSENT_PERIODS)
+    assert sell_trades[-1].exec_price == pytest.approx(expected_close, rel=1e-4), \
+        "Delisted position must be closed at the same prior marked value used for PV."
 
 
 def test_decay_rounds_increment_and_counter_reset():


### PR DESCRIPTION
### Motivation
- Eliminate a mismatch between scan-time MTM marks and rebalance-time forced-close cash by centralizing absent-asset pricing logic. 
- Prevent a discontinuous PV spike on the day an absent (ghost/delisted) position is force-closed. 
- Ensure realized cash from forced liquidation cannot exceed the same marked value used earlier for PV calculations.

### Description
- Add a shared helper `absent_symbol_effective_price(last_known_price, absent_periods, max_absent_periods)` in `momentum_engine.py` to compute a linear haircuted mark that reaches zero at the absence threshold. 
- Replace inline `_haircut` logic in `daily_workflow.py` MTM valuation with the new `absent_symbol_effective_price` helper. 
- Update `execute_rebalance` in `momentum_engine.py` to use `absent_symbol_effective_price` when carrying absent positions in `pv`, when accounting `actual_notional` for retained absent positions, and to compute the `close_price` for forced closes using the prior-day mark (`absent_periods - 1`) so closure cash matches the previously marked PV. 
- Update tests by adding a deterministic regression `test_force_close_uses_prior_marked_value_without_pv_spike()` and adjusting the existing delist assertion to expect the prior marked close; also import the helper where needed.

### Testing
- Ran targeted unit tests: `pytest -q test_momentum.py -k "ghost_position_delists_after_max_absent_periods or force_close_uses_prior_marked_value_without_pv_spike"`. 
- Result: both selected tests passed (`2 passed`).
- Changes touched `momentum_engine.py`, `daily_workflow.py`, and `test_momentum.py` and were validated by the above test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe52f47a4832ba5f98a558f21d33f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Refined valuation calculations for symbols with missing data by applying a linear price adjustment that gradually reduces values as absence periods extend.
  * Updated valuation reports to more accurately reflect price impacts from prolonged data unavailability, with prices declining steadily toward zero over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->