### PR TITLE
Align optimizer turnover costs with execution impact model

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -429,6 +429,22 @@ def activate_override_on_stress(state: PortfolioState, cfg: UltimateConfig) -> N
     state.exposure_multiplier = float(max(cfg.MIN_EXPOSURE_FLOOR, state.exposure_multiplier * 0.5))
 
 
+def compute_one_way_slip_rate(
+    cfg: UltimateConfig,
+    portfolio_value: float,
+    adv_notional: Optional[float],
+) -> float:
+    """Compute per-name one-way slippage rate with execution-aligned floor/cap semantics."""
+    base_rate = cfg.ROUND_TRIP_SLIPPAGE_BPS / 20_000.0
+    if adv_notional is None or not np.isfinite(adv_notional) or adv_notional <= 0:
+        return base_rate
+
+    # ADV is notional (₹/day); retain execution semantics exactly:
+    # impact = coeff * PV / ADV, then clamp [base_rate, 5%].
+    impact_rate = (cfg.IMPACT_COEFF * portfolio_value) / float(adv_notional)
+    return max(base_rate, min(0.05, impact_rate))
+
+
 # ─── Execution ────────────────────────────────────────────────────────────────
 
 def execute_rebalance(
@@ -594,13 +610,11 @@ def execute_rebalance(
                     continue
 
             # ── FIX: Institutional Impact Alignment ──
-            if adv_shares is not None and adv_shares[i] > 0:
-                # ADV is passed in notional units (₹/day), so impact denominator
-                # must not multiply by price again (which would create ₹^2 units).
-                impact_rate = (cfg.IMPACT_COEFF * pv) / adv_shares[i]
-                slip_rate = max(cfg.ROUND_TRIP_SLIPPAGE_BPS / 20000.0, min(0.05, impact_rate))
-            else:
-                slip_rate = cfg.ROUND_TRIP_SLIPPAGE_BPS / 20000.0
+            slip_rate = compute_one_way_slip_rate(
+                cfg=cfg,
+                portfolio_value=pv,
+                adv_notional=float(adv_shares[i]) if adv_shares is not None else None,
+            )
 
             slip = abs(delta) * price * slip_rate
             total_slippage += slip
@@ -923,10 +937,17 @@ class InstitutionalRiskEngine:
         P_aux = sp.eye(n_vars - m, format="csc") * 1e-6
         P     = sp.block_diag([sp.csc_matrix(P_w), P_aux], format="csc")
 
+        turnover_costs = np.array(
+            [
+                compute_one_way_slip_rate(self.cfg, portfolio_value, float(adv))
+                for adv in adv_shares
+            ],
+            dtype=float,
+        )
+
         q        = np.zeros(n_vars)
         q[:m]    = -expected_returns - 2.0 * impact * prev_w_arr
-        # |w-w_prev| is one-way turnover, so use one-way cost (round-trip / 2).
-        q[m:2*m] = self.cfg.ROUND_TRIP_SLIPPAGE_BPS / 20_000.0
+        q[m:2*m] = turnover_costs
         q[-1]    = self.cfg.SLACK_PENALTY
 
         builder = _ConstraintBuilder(n_vars)

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -2,10 +2,14 @@ import importlib
 import json
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
 import pytest
 
 optuna = pytest.importorskip("optuna")
 optimizer = pytest.importorskip("optimizer")
+
+from momentum_engine import InstitutionalRiskEngine, UltimateConfig
 
 
 def test_save_optimal_config_allows_plain_filename(tmp_path: Path):
@@ -414,3 +418,103 @@ def test_stdout_supports_rupee_false_when_stdout_missing(monkeypatch):
     monkeypatch.setattr(optimizer.sys, "stdout", None)
 
     assert optimizer._stdout_supports_rupee() is False
+
+
+def test_optimizer_uses_higher_turnover_penalty_for_illiquid_name(monkeypatch):
+    cfg = UltimateConfig()
+    engine = InstitutionalRiskEngine(cfg)
+
+    captured = {}
+
+    class _FakeResInfo:
+        status = "solved"
+
+    class _FakeRes:
+        def __init__(self, n_vars):
+            self.info = _FakeResInfo()
+            self.x = np.zeros(n_vars, dtype=float)
+
+    class _FakeOSQP:
+        def setup(self, P, q, A, l, u, **kwargs):
+            captured["q"] = np.array(q, dtype=float)
+            captured["n_vars"] = len(q)
+
+        def solve(self):
+            return _FakeRes(captured["n_vars"])
+
+    monkeypatch.setattr("momentum_engine.osqp.OSQP", _FakeOSQP)
+
+    expected_returns = np.array([0.01, 0.01], dtype=float)
+    prices = np.array([100.0, 100.0], dtype=float)
+    adv_shares = np.array([1e9, 1e5], dtype=float)
+    hist = pd.DataFrame(
+        np.array([
+            [0.0010, 0.0015],
+            [0.0005, -0.0002],
+            [-0.0003, 0.0001],
+            [0.0008, -0.0004],
+            [0.0001, 0.0002],
+            [0.0004, -0.0001],
+            [0.0006, 0.0003],
+            [-0.0002, 0.0005],
+            [0.0003, -0.0002],
+            [0.0007, 0.0004],
+        ]),
+        columns=["LIQUID", "ILLIQUID"],
+    )
+
+    engine.optimize(
+        expected_returns=expected_returns,
+        historical_returns=hist,
+        adv_shares=adv_shares,
+        prices=prices,
+        portfolio_value=1_000_000.0,
+        prev_w=np.array([0.0, 0.0], dtype=float),
+    )
+
+    turnover_q = captured["q"][2:4]
+    assert turnover_q[1] > turnover_q[0]
+
+
+def test_optimizer_turnover_penalty_respects_execution_floor_and_cap(monkeypatch):
+    cfg = UltimateConfig(IMPACT_COEFF=1.0, ROUND_TRIP_SLIPPAGE_BPS=20.0)
+    engine = InstitutionalRiskEngine(cfg)
+
+    captured = {}
+
+    class _FakeResInfo:
+        status = "solved"
+
+    class _FakeRes:
+        def __init__(self, n_vars):
+            self.info = _FakeResInfo()
+            self.x = np.zeros(n_vars, dtype=float)
+
+    class _FakeOSQP:
+        def setup(self, P, q, A, l, u, **kwargs):
+            captured["q"] = np.array(q, dtype=float)
+            captured["n_vars"] = len(q)
+
+        def solve(self):
+            return _FakeRes(captured["n_vars"])
+
+    monkeypatch.setattr("momentum_engine.osqp.OSQP", _FakeOSQP)
+
+    expected_returns = np.array([0.01, 0.01], dtype=float)
+    prices = np.array([100.0, 100.0], dtype=float)
+    adv_shares = np.array([1e12, 1.0], dtype=float)
+    hist = pd.DataFrame(np.tile([0.001, -0.001], (10, 1)), columns=["A", "B"])
+
+    engine.optimize(
+        expected_returns=expected_returns,
+        historical_returns=hist,
+        adv_shares=adv_shares,
+        prices=prices,
+        portfolio_value=1_000_000.0,
+        prev_w=np.array([0.0, 0.0], dtype=float),
+    )
+
+    turnover_q = captured["q"][2:4]
+    base_one_way = cfg.ROUND_TRIP_SLIPPAGE_BPS / 20_000.0
+    assert turnover_q[0] == pytest.approx(base_one_way)
+    assert turnover_q[1] == pytest.approx(0.05)


### PR DESCRIPTION
### Motivation

- Prevent divergence between execution-time slippage and optimizer turnover penalties by reusing a single slip-rate computation. 
- Replace the optimizer-wide scalar turnover cost with a per-asset one-way turnover vector so illiquid names incur higher penalties automatically. 
- Preserve the existing execution semantics (one-way floor derived from round-trip bps and a 5% cap) to avoid model drift. 
- Add regression tests to guard against regressions for assets with very different ADV.

### Description

- Added `compute_one_way_slip_rate(cfg, portfolio_value, adv_notional)` in `momentum_engine.py` to centralize one-way slip-rate computation and apply the same floor/cap semantics used by execution. 
- Updated `execute_rebalance` to call the new helper so execution and optimizer share identical slip-rate logic. 
- In the optimizer (`InstitutionalRiskEngine.optimize`) built a per-asset `turnover_costs` vector from ADV notional and portfolio value and assigned it to `q[m:2*m]` instead of a scalar. 
- Added two regression tests in `test_optimizer.py`: one asserting an illiquid name receives a higher turnover penalty than a liquid name, and another asserting the optimizer turnover penalties respect the execution floor and 5% cap.

### Testing

- Ran the focused tests with `pytest -q test_optimizer.py -k "turnover_penalty or illiquid_name"` and both new tests passed. 
- Ran the full optimizer test file with `pytest -q test_optimizer.py` and the suite passed (`24 passed`, `1 warning`). 
- Tests exercised the optimizer QP setup by monkeypatching `osqp.OSQP` to capture the constructed `q` vector and verify per-asset turnover entries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe5255524832b9e0f388dc71c0103)