### PR TITLE
Harden historical_builder PIT generation to prevent survivorship bias

### DIFF
--- a/historical_builder.py
+++ b/historical_builder.py
@@ -8,22 +8,14 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Iterable
 
 import pandas as pd
-
-from universe_manager import get_nifty500, fetch_nse_equity_universe
 
 logger = logging.getLogger(__name__)
 
 # All paths in this module are rooted here.  Change DATA_DIR to relocate
 # the entire historical-data directory without touching individual functions.
 DATA_DIR = Path("data")
-
-
-def _monthly_dates(start: str = "2018-01-01", end: str | None = None) -> pd.DatetimeIndex:
-    end_ts = pd.Timestamp.today().normalize() if end is None else pd.Timestamp(end)
-    return pd.date_range(pd.Timestamp(start), end_ts, freq="MS")
 
 
 def _ns_ticker(sym: str) -> str:
@@ -60,10 +52,29 @@ def _load_master_archive(universe_type: str) -> pd.DataFrame:
     elif "snapshot_date" in cols and "symbol" in cols:
         out = df[[cols["snapshot_date"], cols["symbol"]]].rename(columns={cols["snapshot_date"]: "date", cols["symbol"]: "ticker"})
     else:
-        # Wide format fallback: first column is date, remaining cols are ticker buckets.
+        # Wide format fallback, supporting both common layouts:
+        # 1) first column=date, remaining columns=ticker buckets
+        # 2) first column=ticker, remaining columns=date buckets
         first_col = df.columns[0]
-        melted = df.melt(id_vars=[first_col], value_name="ticker").drop(columns=["variable"])
-        out = melted.rename(columns={first_col: "date"})
+        first_col_str = df[first_col].astype(str).str.strip()
+        first_col_date_like = first_col_str.str.match(r"^\d{4}[-/]\d{1,2}[-/]\d{1,2}$").mean() >= 0.7
+        other_cols_are_dates = pd.Index(df.columns[1:]).astype(str).str.match(
+            r"^\d{4}[-/]\d{1,2}[-/]\d{1,2}$"
+        ).mean() >= 0.7
+        first_col_is_date = first_col_date_like
+
+        if first_col_is_date or not other_cols_are_dates:
+            melted = df.melt(id_vars=[first_col], value_name="ticker").drop(columns=["variable"])
+            out = melted.rename(columns={first_col: "date"})
+        else:
+            melted = df.melt(id_vars=[first_col], var_name="date", value_name="member")
+            member = melted["member"].astype(str).str.strip().str.lower()
+            valid_member = (
+                melted["member"].notna()
+                & member.ne("")
+                & ~member.isin({"0", "false", "no", "n", "nan"})
+            )
+            out = melted.loc[valid_member, ["date", first_col]].rename(columns={first_col: "ticker"})
 
     out["date"] = pd.to_datetime(out["date"], errors="coerce").dt.strftime("%Y-%m-%d")
     out["ticker"] = out["ticker"].map(_ns_ticker)
@@ -72,54 +83,36 @@ def _load_master_archive(universe_type: str) -> pd.DataFrame:
     return out[["date", "ticker"]].drop_duplicates().sort_values(["date", "ticker"])
 
 
-def _fallback_members(universe_type: str) -> list[str]:
-    if universe_type == "nse_total":
-        base = fetch_nse_equity_universe()
-    else:
-        base = get_nifty500()
-    return sorted({_ns_ticker(x) for x in base if _ns_ticker(x)})
-
-
 def build_historical_csv(universe_type: str, output_path: str) -> Path:
     """
-    Build a PIT CSV containing monthly snapshots from 2018 to present.
+    Build a PIT CSV containing exact recorded PIT snapshots.
 
     Output columns:
     - date (YYYY-MM-DD)
     - ticker (with .NS suffix)
     """
-    month_grid = _monthly_dates()
     raw = _load_master_archive(universe_type)
 
     if raw.empty:
-        logger.warning(
-            "[HistoricalBuilder] No local archive found for %s; using stable fallback constituents for monthly grid.",
-            universe_type,
+        raise FileNotFoundError(
+            "[HistoricalBuilder] Raw archive missing. Cannot build PIT universe without "
+            f"historical source data for {universe_type}."
         )
-        fallback = _fallback_members(universe_type)
-        rows = [{"date": d.strftime("%Y-%m-%d"), "ticker": t} for d in month_grid for t in fallback]
-        out = pd.DataFrame(rows)
-    else:
-        raw_dt = pd.to_datetime(raw["date"], errors="coerce")
-        raw = raw.assign(_date=raw_dt.dt.normalize()).dropna(subset=["_date"])
 
-        # Snap each monthly point to the latest available historical snapshot at or before that month.
-        out_rows: list[dict[str, str]] = []
-        for d in month_grid:
-            eligible = raw[raw["_date"] <= d]
-            if eligible.empty:
-                continue
-            anchor = eligible["_date"].max()
-            members = sorted(set(eligible.loc[eligible["_date"] == anchor, "ticker"]))
-            for t in members:
-                out_rows.append({"date": d.strftime("%Y-%m-%d"), "ticker": _ns_ticker(t)})
+    raw_dt = pd.to_datetime(raw["date"], errors="coerce")
+    raw = raw.assign(_date=raw_dt.dt.normalize()).dropna(subset=["_date"])
 
-        out = pd.DataFrame(out_rows)
+    out_rows: list[dict[str, str]] = []
+    for snapshot_date, group in raw.groupby("_date"):
+        members = sorted(set(group["ticker"]))
+        for t in members:
+            out_rows.append({"date": snapshot_date.strftime("%Y-%m-%d"), "ticker": _ns_ticker(t)})
 
-        if out.empty:
-            fallback = _fallback_members(universe_type)
-            rows = [{"date": d.strftime("%Y-%m-%d"), "ticker": t} for d in month_grid for t in fallback]
-            out = pd.DataFrame(rows)
+    out = pd.DataFrame(out_rows)
+    if out.empty:
+        raise ValueError(
+            f"[HistoricalBuilder] Raw archive for {universe_type} did not contain any usable date/ticker rows."
+        )
 
     out = out.dropna(subset=["date", "ticker"])
     out["ticker"] = out["ticker"].map(_ns_ticker)
@@ -138,7 +131,7 @@ def build_parquet_from_csv(csv_path: str, output_path: str) -> Path:
     parquet format expected by universe_manager.get_historical_universe().
 
     Required parquet schema:
-        Index : DatetimeIndex named "date" — one row per monthly snapshot date.
+        Index : DatetimeIndex named "date" — one row per recorded snapshot date.
         Column: "tickers" — Python list of .NS-suffixed ticker strings.
 
     This is the canonical way to produce the parquet files.  Never call
@@ -170,7 +163,7 @@ def build_parquet_from_csv(csv_path: str, output_path: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     out_df.to_parquet(path)
     logger.info(
-        "[HistoricalBuilder] Wrote %d monthly PIT snapshots → %s",
+        "[HistoricalBuilder] Wrote %d PIT snapshots → %s",
         len(out_df),
         path,
     )
@@ -226,7 +219,7 @@ def main() -> None:
     Build the full set of PIT universe files needed for survivorship-safe backtests.
 
     Order matters:
-      1. Build CSVs first  (monthly PIT snapshots, 2018-present)
+      1. Build CSVs first  (recorded PIT snapshots from source archives)
       2. Convert CSVs to parquets  (schema required by universe_manager)
 
     Never call bootstrap_historical_parquet() here — it produces a single-row

--- a/test_historical_builder.py
+++ b/test_historical_builder.py
@@ -21,20 +21,35 @@ def test_build_historical_csv_from_local_master(tmp_path, monkeypatch):
 
     assert set(out.columns) == {"date", "ticker"}
     assert out["date"].min() == "2018-01-01"
+    assert out["date"].nunique() == 2
     assert out["ticker"].str.endswith(".NS").all()
 
 
-def test_build_historical_csv_uses_fallback_when_master_missing(tmp_path, monkeypatch):
+def test_build_historical_csv_raises_when_master_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(hb, "get_nifty500", lambda: ["RELIANCE", "TCS"])
-    monkeypatch.setattr(hb, "fetch_nse_equity_universe", lambda: ["SBIN", "INFY"])
 
-    out_path = hb.build_historical_csv("nifty500", "data/historical_nifty500.csv")
-    out = pd.read_csv(out_path)
+    try:
+        hb.build_historical_csv("nifty500", "data/historical_nifty500.csv")
+        assert False, "Expected FileNotFoundError when raw archive is absent"
+    except FileNotFoundError as exc:
+        assert "Raw archive missing" in str(exc)
 
-    assert not out.empty
-    assert out["date"].nunique() > 12
-    assert out["ticker"].str.endswith(".NS").all()
+
+def test_load_master_archive_supports_wide_ticker_rows(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    raw = data_dir / "raw_nifty_archives.csv"
+    raw.write_text(
+        "ticker,2020-01-31,2020-02-28\nRELIANCE,1,1\nTCS,0,1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    out = hb._load_master_archive("nifty500")
+
+    assert set(out.columns) == {"date", "ticker"}
+    assert set(out["date"]) == {"2020-01-31", "2020-02-28"}
+    assert set(out["ticker"]) == {"RELIANCE.NS", "TCS.NS"}
 
 
 def test_bootstrap_historical_parquet_warns_stub_content(tmp_path, monkeypatch, caplog):


### PR DESCRIPTION
### Motivation
- Prevent silent fabrication of point-in-time (PIT) universes that introduces survivorship bias by eliminating fallback behavior that fills missing archives with today’s constituents. 
- Preserve fidelity of historical snapshots by emitting only recorded snapshot dates and trusting `universe_manager` to resolve the latest-prior lookup at runtime. 

### Description
- Removed the synthetic monthly grid and fallback constituent generation from `build_historical_csv`; the function now `raise`s `FileNotFoundError` when no raw archive is present and `ValueError` when parsing yields no usable rows. 
- Reworked CSV construction to group by the archive’s actual snapshot `_date` values and write only those recorded dates (no monthly expansion). 
- Improved wide-format ingestion in `_load_master_archive` to support both date-first and ticker-first (membership-matrix) layouts and to filter falsey membership cells. 
- Updated logging/docstrings to reflect recorded-snapshot semantics and adjusted tests in `test_historical_builder.py` to validate the new failure modes and wide-format handling. 

### Testing
- Ran `pytest -q test_historical_builder.py` and all tests passed (`4 passed`).
- Unit tests added/updated cover: success path from a local long-form archive, error when the raw archive is missing, wide-format ticker-row parsing, and the bootstrap stub behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afed9ea82c832bb61fde3b900e627c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed historical data retrieval to use exact recorded snapshots instead of approximations.
  * Proper error handling when required data archives are unavailable.

* **Improvements**
  * Enhanced validation of dates and ticker symbols in historical data.
  * Better support for different data archive formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->