### PR TITLE
Harden cache integrity, fail-fast on provider chunk failures, and isolate halt simulation to runtime

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -11,6 +11,7 @@ to eliminate Survivorship Bias. Fixes Look-Ahead PV/ADV computation biases.
 from __future__ import annotations
 
 import logging
+import hashlib
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
@@ -38,6 +39,7 @@ from universe_manager import get_historical_universe
 
 logger = logging.getLogger(__name__)
 _REBALANCE_SNAP_WINDOW_DAYS = 5
+_SUSPENSION_GAP_DAYS = 30
 
 # ─── Results container ────────────────────────────────────────────────────────
 
@@ -442,6 +444,51 @@ def _execution_prices(
         return np.where(np.isfinite(vwap) & (vwap > 0), vwap, close_prices)
     return close_prices
 
+
+def _repair_suspension_gaps(df: pd.DataFrame, ticker: str) -> pd.DataFrame:
+    """In-memory suspension simulation used only during backtest runtime."""
+    if len(df) < 2:
+        return df
+
+    gap_days = df.index.to_series().diff().dt.days
+    max_gap = int(gap_days.max()) if not gap_days.empty else 0
+    if max_gap <= _SUSPENSION_GAP_DAYS:
+        return df
+
+    out = df.copy()
+    logger.warning(
+        "[Backtest] %s: Prolonged trading gap of %d days detected. Applying in-memory synthetic halt simulation.",
+        ticker,
+        max_gap,
+    )
+    bday_idx = pd.bdate_range(out.index[0], out.index[-1])
+
+    first_gap_positions = np.where(gap_days.values > _SUSPENSION_GAP_DAYS)[0]
+    pre_gap_close = out["Close"].iloc[: first_gap_positions[0]] if len(first_gap_positions) > 0 else out["Close"]
+    pre_gap_rets = pre_gap_close.pct_change().dropna()
+    hist_vol = float(pre_gap_rets.std()) if len(pre_gap_rets) > 10 else 0.02
+
+    out = out.reindex(bday_idx)
+    missing_mask = out["Close"].isna()
+    if not missing_mask.any():
+        return out
+
+    n_missing = int(missing_mask.sum())
+    seed = int(hashlib.sha256(ticker.encode()).hexdigest()[:8], 16) % (2**31)
+    rng = np.random.RandomState(seed)
+    noise_rets = rng.normal(0, hist_vol, n_missing)
+
+    out["Close"] = out["Close"].ffill()
+    missing_idx = out.index[missing_mask]
+    anchor_prices = out["Close"].shift(1).reindex(missing_idx).ffill().fillna(out["Close"].dropna().iloc[0])
+    walk_returns = np.cumprod(1.0 + noise_rets)
+    out.loc[missing_idx, "Close"] = anchor_prices.values * walk_returns
+    if "Adj Close" in out.columns:
+        out.loc[missing_idx, "Adj Close"] = out.loc[missing_idx, "Close"]
+    if "Volume" in out.columns:
+        out["Volume"] = out["Volume"].fillna(0)
+    return out
+
 # ─── Public API ───────────────────────────────────────────────────────────────
 
 def run_backtest(
@@ -481,6 +528,8 @@ def run_backtest(
         if key not in market_data:
             continue
         row = market_data[key]
+        if cfg.SIMULATE_HALTS:
+            row = _repair_suspension_gaps(row, key)
         close_d[sym]  = row["Close"].ffill()
         close_adj_d[sym] = row.get("Adj Close", row["Close"]).ffill()
         open_d[sym] = row.get("Open", row["Close"]).ffill()

--- a/data_cache.py
+++ b/data_cache.py
@@ -6,9 +6,7 @@ Robustly manages downloading, parsing, and persisting yfinance data.
 Features:
 - Atomic JSON manifest updates
 - Network retry logic and chunking
-- Fully DETERMINISTIC synthetic noise injection for long trading 
-  suspensions (ASM/GSM) to prevent the optimizer from misidentifying 
-  frozen assets as zero-volatility safe havens.
+- Persistent storage of raw provider data only (no synthetic mutation at cache layer)
 """
 
 from __future__ import annotations
@@ -18,14 +16,12 @@ import logging
 import os
 import random
 import time
-import hashlib
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from pathlib import Path
 
 import requests
 from datetime import datetime, time as dt_time, timedelta
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -36,7 +32,9 @@ logger = logging.getLogger(__name__)
 CACHE_DIR     = Path("data/cache")
 MANIFEST_FILE = CACHE_DIR / "_manifest.json"
 _DOWNLOAD_CHUNK_SIZE = 75
-_SUSPENSION_GAP_DAYS = 30
+
+class DataFetchError(RuntimeError):
+    """Raised when one or more requested ticker chunks cannot be fetched."""
 
 
 class DataProvider(ABC):
@@ -86,7 +84,7 @@ class SecondaryProvider(DataProvider):
                 time.sleep(self.min_interval - elapsed)
 
             try:
-                frame = self._download_single(av_symbol, self.api_key)
+                frame = self._download_single(av_symbol, self.api_key, start=start, end=end)
                 last_call_ts = time.time()
             except Exception as exc:
                 logger.warning("[Cache][Fallback] %s fetch failed: %s", ticker, exc)
@@ -95,10 +93,7 @@ class SecondaryProvider(DataProvider):
             if frame is None:
                 continue
 
-            filtered = frame.loc[(frame.index >= pd.Timestamp(start)) & (frame.index <= pd.Timestamp(end))]
-            if filtered.empty:
-                continue
-            ticker_frames[ticker] = filtered
+            ticker_frames[ticker] = frame
 
         if not ticker_frames:
             return None
@@ -110,7 +105,7 @@ class SecondaryProvider(DataProvider):
         combined = pd.concat(ticker_frames, axis=1)
         return _normalize_history_index(combined)
 
-    def _download_single(self, symbol: str, api_key: str) -> Optional[pd.DataFrame]:
+    def _download_single(self, symbol: str, api_key: str, start: str, end: str) -> Optional[pd.DataFrame]:
         params = {
             "function": "TIME_SERIES_DAILY_ADJUSTED",
             "symbol": symbol,
@@ -133,11 +128,16 @@ class SecondaryProvider(DataProvider):
             logger.warning("[Cache][Fallback] Invalid payload for %s: %s", symbol, err)
             return None
 
+        start_ts = pd.Timestamp(start)
+        end_ts = pd.Timestamp(end)
         rows = []
         for d, item in series.items():
+            date = pd.Timestamp(d)
+            if date < start_ts or date > end_ts:
+                continue
             rows.append(
                 {
-                    "Date": pd.Timestamp(d),
+                    "Date": date,
                     "Open": float(item.get("1. open", np.nan)),
                     "High": float(item.get("2. high", np.nan)),
                     "Low": float(item.get("3. low", np.nan)),
@@ -147,8 +147,11 @@ class SecondaryProvider(DataProvider):
                 }
             )
 
+        if not rows:
+            return None
+
         df = pd.DataFrame(rows).set_index("Date").sort_index()
-        return _normalize_history_index(df)
+        return _ensure_price_columns(_normalize_history_index(df))
 
     @staticmethod
     def _map_symbol(ticker: str) -> str:
@@ -184,10 +187,10 @@ def _extract_ticker_frame(raw_data: pd.DataFrame, ticker: str) -> Optional[pd.Da
             df = raw_data.xs(ticker, level=1, axis=1).copy()
         else:
             return None
-        return _normalize_history_index(df)
+        return _ensure_price_columns(_normalize_history_index(df))
 
     # Single ticker payloads often come as flat OHLCV columns
-    return _normalize_history_index(raw_data.copy())
+    return _ensure_price_columns(_normalize_history_index(raw_data.copy()))
 
 
 def _download_with_timeout(
@@ -293,93 +296,6 @@ def _is_valid_dataframe(df: pd.DataFrame) -> bool:
     if "Volume" not in df.columns or df["Volume"].isnull().all():
         return False
     return True
-
-
-def _repair_suspension_gaps(df: pd.DataFrame, ticker: str) -> Tuple[pd.DataFrame, bool, int]:
-    """
-    Detects long gaps (e.g. from ASM/GSM regulatory suspensions) and injects 
-    DETERMINISTIC synthetic noise instead of a flat forward-fill.
-    
-    A flat line has 0.0% variance. The risk engine (CVaR optimizer) will see 
-    this suspended stock as the "safest asset in the world" and over-allocate 
-    to it. This fix prevents that critical institutional flaw.
-    """
-    if len(df) < 2:
-        return df, False, 0
-        
-    # Calculate days between adjacent dates in the index
-    gap_days = df.index.to_series().diff().dt.days
-    max_gap = int(gap_days.max()) if not gap_days.empty else 0
-    is_suspended = max_gap > _SUSPENSION_GAP_DAYS
-    
-    if is_suspended:
-        logger.warning(
-            "[Cache] %s: Prolonged trading gap of %d days detected. "
-            "Injecting deterministic synthetic noise to prevent risk-engine suppression.", 
-            ticker, max_gap
-        )
-        
-        # Create a complete business day timeline covering the entire range
-        bday_idx = pd.bdate_range(df.index[0], df.index[-1])
-        
-        # FIX (Bug-B — Lookahead Bias): Compute volatility STRICTLY from price data
-        # that existed BEFORE the first detected gap.  Using the full series would
-        # leak future volatility regimes into the imputed past prices — e.g.,
-        # computing vol from 2019-2024 data to fill a 2018 suspension gap inflates
-        # apparent risk during backtests and pollutes CVaR estimates.
-        _gap_days_tmp = df.index.to_series().diff().dt.days
-        _first_gap_positions = np.where(_gap_days_tmp.values > _SUSPENSION_GAP_DAYS)[0]
-        if len(_first_gap_positions) > 0:
-            _pre_gap_close = df["Close"].iloc[: _first_gap_positions[0]]
-        else:
-            _pre_gap_close = df["Close"]
-
-        _pre_gap_rets = _pre_gap_close.pct_change().dropna()
-        if len(_pre_gap_rets) > 10:
-            hist_vol = float(_pre_gap_rets.std())
-        else:
-            hist_vol = 0.02  # fallback 2 % daily vol when insufficient pre-gap history
-            
-        # Reindex to fill the gap with NaNs
-        df = df.reindex(bday_idx)
-        missing_mask = df["Close"].isna()
-        
-        if missing_mask.any():
-            n_missing = missing_mask.sum()
-            
-            # FIX (I-07): Use a hash derived RandomState seed unique to the ticker.
-            # sha256 is used instead of md5 — not for cryptographic strength (the
-            # output is truncated to 8 hex chars and used only as an RNG seed), but
-            # to eliminate the Bandit B324 false-positive that md5 triggers in
-            # automated security scanners (SonarQube, GitHub Advanced Security, etc.).
-            seed = int(hashlib.sha256(ticker.encode()).hexdigest()[:8], 16) % (2**31)
-            rng = np.random.RandomState(seed)
-            noise_rets = rng.normal(0, hist_vol, n_missing)
-            
-            # Forward fill as a baseline
-            df["Close"] = df["Close"].ffill()
-            
-            # Build a deterministic random walk for suspended periods so variance compounds over time.
-            missing_idx = df.index[missing_mask]
-            anchor_prices = (
-                df["Close"].shift(1).reindex(missing_idx).ffill().fillna(df["Close"].dropna().iloc[0])
-            )
-            walk_returns = np.cumprod(1.0 + noise_rets)
-            df.loc[missing_idx, "Close"] = anchor_prices.values * walk_returns
-
-            # FIX (Bug-6): Sync Adj Close with the synthetic Close values on suspended days.
-            # _ensure_price_columns() copies Close→Adj Close before this function runs, but
-            # only for the original (non-reindexed) rows. After reindex(), new dates have NaN
-            # for Adj Close. Backtest uses Adj Close for returns calculation, so unsynchronised
-            # NaN values produce silent NaN returns for suspended stocks, corrupting CVaR
-            # estimates and signal generation during any period with SIMULATE_HALTS=True.
-            if "Adj Close" in df.columns:
-                df.loc[missing_idx, "Adj Close"] = df.loc[missing_idx, "Close"]
-
-            # Zero out volume for the days it didn't trade
-            df["Volume"] = df["Volume"].fillna(0)
-            
-    return df, is_suspended, max_gap
 
 
 def _ensure_price_columns(df: pd.DataFrame) -> pd.DataFrame:
@@ -500,8 +416,9 @@ def load_or_fetch(
                 if raw_data is not None and not raw_data.empty:
                     break
             if raw_data is None or raw_data.empty:
-                logger.warning("[Cache] Received empty response for chunk starting with %s", chunk[0])
-                continue
+                raise DataFetchError(
+                    f"Failed to fetch data for chunk starting with {chunk[0]} after all providers."
+                )
                 
             for ticker in chunk:
                 try:
@@ -512,8 +429,6 @@ def load_or_fetch(
                     df.dropna(how='all', inplace=True)
                     if df.empty:
                         continue
-                    df = _ensure_price_columns(df)
-
                     # Structural validation before anything touches disk.
                     # Catches non-unique/non-monotonic indexes and all-NaN Close
                     # columns that dropna(how='all') cannot detect.
@@ -525,14 +440,6 @@ def load_or_fetch(
                         )
                         continue
 
-                    simulate_halts = bool(getattr(cfg, "SIMULATE_HALTS", False))
-                    if simulate_halts:
-                        df, suspended, max_gap = _repair_suspension_gaps(df, ticker)
-                        if suspended:
-                            logger.warning("[Cache] Synthetic halt simulation applied to %s", ticker)
-                    else:
-                        suspended, max_gap = False, 0
-                    
                     parquet_path = CACHE_DIR / f"{ticker}.parquet"
                     df.to_parquet(parquet_path)
                     
@@ -540,8 +447,8 @@ def load_or_fetch(
                         "fetched_at": datetime.now().isoformat(),
                         "rows": len(df),
                         "last_date": df.index[-1].strftime("%Y-%m-%d"),
-                        "suspended": suspended,
-                        "max_gap_days": max_gap
+                        "suspended": False,
+                        "max_gap_days": 0,
                     }
                     market_data[ticker] = df
                     

--- a/test_data_cache.py
+++ b/test_data_cache.py
@@ -20,13 +20,16 @@ def test_load_or_fetch_uses_dynamic_padding_from_cfg(monkeypatch):
     monkeypatch.setattr(data_cache, "_download_with_timeout", _fake_download_with_timeout)
 
     cfg = UltimateConfig(CVAR_LOOKBACK=500)
-    data_cache.load_or_fetch(
-        tickers=["ABC"],
-        required_start="2024-01-01",
-        required_end="2024-12-31",
-        force_refresh=True,
-        cfg=cfg,
-    )
+    try:
+        data_cache.load_or_fetch(
+            tickers=["ABC"],
+            required_start="2024-01-01",
+            required_end="2024-12-31",
+            force_refresh=True,
+            cfg=cfg,
+        )
+    except data_cache.DataFetchError:
+        pass
 
     assert captured["start"] == "2021-04-06"
     assert captured["end"] == "2025-01-01"
@@ -68,3 +71,36 @@ def test_secondary_provider_returns_none_without_api_key(monkeypatch):
     sp = data_cache.SecondaryProvider()
     out = sp.download(["ABC.NS"], "2024-01-01", "2024-01-31")
     assert out is None
+
+
+def test_load_or_fetch_raises_on_chunk_failure(monkeypatch):
+    monkeypatch.setattr(data_cache, "_load_manifest", lambda: {"schema_version": 1, "entries": {}})
+    monkeypatch.setattr(data_cache, "_save_manifest", lambda _manifest: None)
+    monkeypatch.setattr(data_cache, "_download_with_timeout", lambda *args, **kwargs: pd.DataFrame())
+
+    try:
+        data_cache.load_or_fetch(
+            tickers=["ABC"],
+            required_start="2024-01-01",
+            required_end="2024-01-31",
+            force_refresh=True,
+        )
+    except data_cache.DataFetchError:
+        return
+
+    raise AssertionError("Expected DataFetchError for an empty chunk response")
+
+
+def test_extract_ticker_frame_fills_adj_close_for_multiindex_payload():
+    idx = pd.date_range("2024-01-01", periods=6, freq="D")
+    raw = pd.DataFrame(
+        {
+            ("ABC.NS", "Close"): [100, 101, 102, 103, 104, 105],
+            ("ABC.NS", "Adj Close"): [None, None, None, None, None, None],
+            ("ABC.NS", "Volume"): [1, 1, 1, 1, 1, 1],
+        },
+        index=idx,
+    )
+    out = data_cache._extract_ticker_frame(raw, "ABC.NS")
+    assert out is not None
+    assert out["Adj Close"].equals(out["Close"])

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -1344,3 +1344,31 @@ def test_compute_adv_respects_configurable_lookback():
 
     assert adv_short[0] == pytest.approx(450.0)
     assert adv_long[0] == pytest.approx(300.0)
+
+
+def test_run_backtest_simulate_halts_does_not_mutate_input_market_data():
+    cfg = UltimateConfig(HISTORY_GATE=5, INITIAL_CAPITAL=1_000_000, SIMULATE_HALTS=True)
+    dates = pd.to_datetime(["2020-01-01", "2020-01-02", "2020-03-20", "2020-03-23", "2020-03-24", "2020-03-25"])
+    raw = pd.DataFrame(
+        {
+            "Close": [100, 101, 102, 103, 104, 105],
+            "Adj Close": [100, 101, 102, 103, 104, 105],
+            "Volume": [1000, 1000, 1000, 1000, 1000, 1000],
+        },
+        index=dates,
+    )
+    market_data = {
+        "AAA.NS": raw.copy(),
+        "^NSEI": pd.DataFrame({"Close": np.linspace(10000, 11000, len(dates))}, index=dates),
+    }
+
+    _ = run_backtest(
+        market_data=market_data,
+        universe=["AAA"],
+        start_date="2020-01-01",
+        end_date="2020-03-25",
+        cfg=cfg,
+    )
+
+    assert market_data["AAA.NS"].index.equals(raw.index)
+    assert market_data["AAA.NS"]["Close"].equals(raw["Close"])


### PR DESCRIPTION
### Motivation
- Ensure the on-disk cache remains a pristine copy of provider data and cannot be polluted by synthetic/imputed values.  Cache mutation caused persistent corruption across runs.
- Fail loudly when a provider (or all providers) returns empty for a download chunk so partial `market_data` dictionaries cannot silently propagate into backtests or live execution.
- Reduce overhead when using the AlphaVantage fallback by filtering the huge `TIME_SERIES_DAILY_ADJUSTED` payload while iterating rather than materializing the full multi-thousand-row frame.
- Keep synthetic halt/noise injection strictly in-memory during backtests so `SIMULATE_HALTS` never mutates persisted Parquet files.

### Description
- `data_cache.py`: Removed on-disk synthetic mutation path and added a `DataFetchError` to enforce fail-fast chunk semantics; `load_or_fetch` now raises `DataFetchError` when a chunk fails all providers instead of silently continuing. 
- `data_cache.py`: `SecondaryProvider._download_single` now accepts `start`/`end` and filters AlphaVantage JSON while iterating to avoid building full history for every ticker, and returns `None` when no rows match the requested window. 
- `data_cache.py`: Ensure returned frames are normalized and pass `Adj Close`/price-column filling via `_ensure_price_columns` for both MultiIndex and flat payloads so structural validation is robust before writing raw provider data to disk. 
- `backtest_engine.py`: Introduced an in-memory `_repair_suspension_gaps` and apply it at runtime inside `run_backtest` only when `cfg.SIMULATE_HALTS` is true, preserving cache immutability. 
- Tests: Added/updated tests in `test_data_cache.py` and `test_momentum.py` to assert chunk-failure raises `DataFetchError`, that `Adj Close` is populated for MultiIndex payloads, and that `SIMULATE_HALTS` does not mutate the input `market_data` dictionary.

### Testing
- Ran targeted test selection: `pytest -q test_data_cache.py test_momentum.py -k "simulate_halts_does_not_mutate_input_market_data or raises_on_chunk_failure or extract_ticker_frame_fills_adj_close_for_multiindex_payload or secondary_provider_parses_alpha_vantage_payload or uses_dynamic_padding"` which completed with all tests passing (`5 passed`, `74 deselected`) and only expected warnings. 
- Ran `python -m pytest -q test_data_cache.py` which completed successfully (`5 passed`, 1 warning). 
- New/updated unit tests exercising the new behaviors passed as part of the runs above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afef71c314832ba26c5a6161a9c4f6)