### PR TITLE
Fix lookahead PV bias, cache historical-universe parquet reads, and harden SMA breadth

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -145,15 +145,13 @@ class BacktestEngine:
 
         adv_vector = _build_adv_vector(symbols, close, volume, date)
 
-        # Use execution-date prices for portfolio valuation inputs so manual/live
-        # walk-forward replication (which rebalances on this same bar) remains
-        # byte-identical to the backtest engine state transitions.
-        valuation_close = close.loc[date]
+        exec_prices = _execution_prices(symbols, date, prices_t, open_px, high_px, low_px)
+        exec_price_map = {sym: float(exec_prices[i]) for i, sym in enumerate(symbols)}
         
         pv = self.state.cash + sum(
             self.state.shares.get(sym, 0) * (
-                float(valuation_close[sym])
-                if (sym in close.columns and pd.notna(valuation_close[sym]))
+                exec_price_map[sym]
+                if (sym in exec_price_map and np.isfinite(exec_price_map[sym]) and exec_price_map[sym] > 0)
                 else _ffill_price(self.state, sym)
             )
             for sym in self.state.shares
@@ -171,8 +169,8 @@ class BacktestEngine:
 
         gross_exposure = sum(
             self.state.shares.get(sym, 0) * (
-                float(valuation_close[sym])
-                if pd.notna(valuation_close[sym])
+                exec_price_map[sym]
+                if (sym in exec_price_map and np.isfinite(exec_price_map[sym]) and exec_price_map[sym] > 0)
                 else _ffill_price(self.state, sym)
             )
             for sym in self.state.shares
@@ -322,7 +320,6 @@ class BacktestEngine:
             _T = min(len(hist_log_rets), self.engine.cfg.CVAR_LOOKBACK)
             _L = -(hist_log_rets.iloc[-_T:].reindex(columns=symbols, fill_value=0.0).values)
             
-            exec_prices = _execution_prices(symbols, date, prices_t, open_px, high_px, low_px)
             execute_rebalance(
                 self.state, target_weights, exec_prices, symbols, cfg,
                 adv_shares     = adv_vector,

--- a/signals.py
+++ b/signals.py
@@ -80,9 +80,11 @@ def compute_regime_score(
     _sma_win = int(getattr(cfg, "REGIME_SMA_WINDOW", 200)) if cfg else 200
     if universe_close_hist is not None and not universe_close_hist.empty and len(universe_close_hist) >= _sma_win:
         recent = universe_close_hist.iloc[-_sma_win:]
+        min_periods = max(1, int(np.ceil(_sma_win * 0.8)))
         sma200 = recent.mean()
+        valid_hist = recent.count() >= min_periods
         last = universe_close_hist.iloc[-1]
-        valid = (sma200 > 0) & sma200.notna() & last.notna()
+        valid = valid_hist & (sma200 > 0) & sma200.notna() & last.notna()
         if valid.any():
             breadth_component = float((last[valid] > sma200[valid]).mean())
 

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -1344,3 +1344,63 @@ def test_compute_adv_respects_configurable_lookback():
 
     assert adv_short[0] == pytest.approx(450.0)
     assert adv_long[0] == pytest.approx(300.0)
+
+def test_regime_breadth_requires_min_history_for_sma_window():
+    idx = pd.DataFrame(
+        {"Close": np.linspace(100.0, 130.0, 260)},
+        index=pd.date_range("2020-01-01", periods=260),
+    )
+    cols = ["OLD", "IPO"]
+    universe = pd.DataFrame(index=idx.index, columns=cols, dtype=float)
+    universe["OLD"] = np.linspace(100.0, 120.0, len(idx))
+    universe["IPO"] = np.nan
+    universe.loc[idx.index[-15:], "IPO"] = np.linspace(50.0, 80.0, 15)
+
+    cfg = UltimateConfig()
+    cfg.REGIME_SMA_WINDOW = 200
+    score_with_ipo = compute_regime_score(idx, cfg=cfg, universe_close_hist=universe)
+
+    universe_without_ipo = universe[["OLD"]]
+    score_without_ipo = compute_regime_score(idx, cfg=cfg, universe_close_hist=universe_without_ipo)
+
+    assert score_with_ipo == pytest.approx(score_without_ipo, abs=1e-12)
+
+
+def test_rebalance_portfolio_value_uses_execution_prices_not_close(monkeypatch):
+    cfg = UltimateConfig(HISTORY_GATE=5)
+    engine = InstitutionalRiskEngine(cfg)
+    bt = BacktestEngine(engine, initial_cash=cfg.INITIAL_CAPITAL)
+
+    dates = pd.date_range("2021-01-01", periods=30, freq="B")
+    close = pd.DataFrame({"SYM00": np.linspace(100.0, 200.0, len(dates))}, index=dates)
+    open_px = pd.DataFrame({"SYM00": np.linspace(100.0, 105.0, len(dates))}, index=dates)
+    volume = pd.DataFrame({"SYM00": np.ones(len(dates)) * 1e6}, index=dates)
+    returns = close.pct_change(fill_method=None).fillna(0.0)
+
+    rebalance_day = dates[-1]
+    bt.state.shares = {"SYM00": 10}
+    bt.state.last_known_prices = {"SYM00": 150.0}
+
+    captured = {}
+
+    def _fake_generate_signals(*args, **kwargs):
+        return np.array([0.001]), np.array([1.0]), [0]
+
+    def _fake_optimize(*args, **kwargs):
+        captured["portfolio_value"] = kwargs.get("portfolio_value")
+        return np.array([0.0])
+
+    monkeypatch.setattr("backtest_engine.generate_signals", _fake_generate_signals)
+    monkeypatch.setattr(bt.engine, "optimize", _fake_optimize)
+
+    bt.run(
+        close,
+        volume,
+        returns,
+        pd.DatetimeIndex([rebalance_day]),
+        dates[0].strftime("%Y-%m-%d"),
+        open_px=open_px,
+    )
+
+    expected_pv = cfg.INITIAL_CAPITAL + 10 * float(open_px.loc[rebalance_day, "SYM00"])
+    assert captured["portfolio_value"] == pytest.approx(expected_pv)

--- a/test_universe_manager.py
+++ b/test_universe_manager.py
@@ -191,3 +191,33 @@ def test_apply_adv_filter_raises_on_any_chunk_failure(monkeypatch):
 
     with pytest.raises(um.UniverseFetchError, match="ADV filter failed for 1 chunk"):
         _apply_adv_filter(tickers, UltimateConfig(MIN_ADV_CRORES=1))
+
+
+def test_historical_universe_parquet_cache_reuses_dataframe(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "historical_nifty500.parquet").write_text("stub", encoding="utf-8")
+
+    hist_df = pd.DataFrame(
+        {"tickers": [["AAA.NS", "BBB.NS"]]},
+        index=pd.DatetimeIndex([pd.Timestamp("2020-01-01")]),
+    )
+
+    monkeypatch.setattr(um, "_HIST_UNIVERSE_CACHE", {})
+
+    read_calls = {"count": 0}
+
+    def _fake_read_parquet(path):
+        read_calls["count"] += 1
+        return hist_df
+
+    monkeypatch.setattr(pd, "read_parquet", _fake_read_parquet)
+
+    target = pd.Timestamp("2020-02-01")
+    first = um.get_historical_universe("nifty500", target)
+    second = um.get_historical_universe("nifty500", target)
+
+    assert first == ["AAA.NS", "BBB.NS"]
+    assert second == first
+    assert read_calls["count"] == 1

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -132,6 +132,24 @@ def _load_pit_universe_from_csv(universe_type: str, date: pd.Timestamp) -> List[
 _MISSING_PARQUET_WARNED: Dict[str, bool] = {}
 _NO_RECORD_WARNED: Dict[str, bool] = {}
 _SECTOR_MAP_CACHE_LOCK = threading.Lock()
+_HIST_UNIVERSE_CACHE_LOCK = threading.Lock()
+_HIST_UNIVERSE_CACHE: Dict[Path, Tuple[float, pd.DataFrame]] = {}
+
+
+def _read_historical_universe_parquet(hist_file: Path) -> pd.DataFrame:
+    """Read historical constituents parquet with mtime-aware in-memory cache."""
+    mtime = hist_file.stat().st_mtime
+    with _HIST_UNIVERSE_CACHE_LOCK:
+        cached = _HIST_UNIVERSE_CACHE.get(hist_file)
+        if cached is not None:
+            cached_mtime, cached_df = cached
+            if cached_mtime == mtime:
+                return cached_df
+
+    df = pd.read_parquet(hist_file)
+    with _HIST_UNIVERSE_CACHE_LOCK:
+        _HIST_UNIVERSE_CACHE[hist_file] = (mtime, df)
+    return df
 
 
 def get_historical_universe(universe_type: str, date: pd.Timestamp) -> List[str]:
@@ -159,7 +177,7 @@ def get_historical_universe(universe_type: str, date: pd.Timestamp) -> List[str]
             _MISSING_PARQUET_WARNED[universe_type] = True
     else:
         try:
-            df = pd.read_parquet(hist_file)
+            df = _read_historical_universe_parquet(hist_file)
             
             # Find the closest available manifest date preceding the requested date
             available_dates = df.index.unique()


### PR DESCRIPTION
### Motivation
- Remove the fatal same-bar valuation/execution paradox where portfolio value (`pv`) was computed from EOD `close` while trades execute at Open/VWAP, introducing lookahead bias.  
- Eliminate redundant Parquet disk reads inside date loops which convert optimizer runs into I/O-bound operations.  
- Prevent IPO/thin-history symbols from contaminating the 200-day SMA breadth component by ensuring symbols contribute only when enough history exists.

### Description
- Use a single execution-price vector produced by `_execution_prices` at the start of `_run_rebalance` and use that same vector for `pv` and `gross_exposure` calculations so sizing is aligned with order-time prices (`backtest_engine.py`).  
- Add an mtime-aware in-memory cache with a lock and helper `_read_historical_universe_parquet` to reuse deserialized DataFrames for repeated `get_historical_universe` calls and avoid repeated `pd.read_parquet` deserialization (`universe_manager.py`).  
- Harden `compute_regime_score` breadth logic so per-symbol SMA contribution requires at least ~80% of the SMA window observations (`recent.count() >= min_periods`) before being included in the breadth component (`signals.py`).  
- Add regression tests covering: IPO-thin exclusion from breadth, portfolio-value using execution prices passed to the optimizer, and parquet-read caching behavior, and update tests accordingly (`test_momentum.py`, `test_universe_manager.py`).

### Testing
- Ran `pytest -q test_momentum.py::test_regime_breadth_requires_min_history_for_sma_window test_momentum.py::test_rebalance_portfolio_value_uses_execution_prices_not_close test_universe_manager.py::test_historical_universe_parquet_cache_reuses_dataframe` and all 3 tests passed.  
- Ran `pytest -q test_momentum.py::test_volume_no_lookahead test_momentum.py::test_regime_score_bull_market test_momentum.py::test_regime_score_bear_market test_universe_manager.py::test_get_historical_universe_uses_csv_without_survivorship_warning` and all 4 tests passed.  
- Additional related unit tests in the suite were exercised during iteration; the targeted regression tests validating the three fixes succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff060532c832b955c2187309c9392)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Portfolio valuation during rebalancing now correctly uses execution prices instead of close prices for more accurate portfolio value calculations.

* **New Features**
  * Added in-memory caching for historical universe data to improve performance when loading universe definitions.
  * Regime signals now require minimum historical data for validation, improving signal reliability.

* **Tests**
  * Added tests to verify execution price usage in portfolio valuation and cache functionality for universe data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->