### PR TITLE
Fix rebalance lookahead, add historical-universe parquet cache, and harden regime breadth

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -147,10 +147,9 @@ class BacktestEngine:
 
         adv_vector = _build_adv_vector(symbols, close, volume, date)
 
-        # Use execution-date prices for portfolio valuation inputs so manual/live
-        # walk-forward replication (which rebalances on this same bar) remains
-        # byte-identical to the backtest engine state transitions.
-        valuation_close = close.loc[date]
+        # Value the pre-trade portfolio using last fully-observed prices (T-1 close).
+        # This avoids lookahead when we size orders that execute on the current bar.
+        valuation_close = close.loc[signal_date]
         
         pv = self.state.cash + sum(
             self.state.shares.get(sym, 0) * (

--- a/signals.py
+++ b/signals.py
@@ -80,9 +80,11 @@ def compute_regime_score(
     _sma_win = int(getattr(cfg, "REGIME_SMA_WINDOW", 200)) if cfg else 200
     if universe_close_hist is not None and not universe_close_hist.empty and len(universe_close_hist) >= _sma_win:
         recent = universe_close_hist.iloc[-_sma_win:]
+        min_obs = max(1, int(np.ceil(_sma_win * 0.8)))
+        obs_count = recent.notna().sum()
         sma200 = recent.mean()
         last = universe_close_hist.iloc[-1]
-        valid = (sma200 > 0) & sma200.notna() & last.notna()
+        valid = (obs_count >= min_obs) & (sma200 > 0) & sma200.notna() & last.notna()
         if valid.any():
             breadth_component = float((last[valid] > sma200[valid]).mean())
 

--- a/test_backtest_engine.py
+++ b/test_backtest_engine.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pandas as pd
+
+import backtest_engine as be
+from momentum_engine import InstitutionalRiskEngine, UltimateConfig
+
+
+def test_rebalance_values_portfolio_from_previous_close(monkeypatch):
+    cfg = UltimateConfig(CVAR_MIN_HISTORY=9999)
+    engine = InstitutionalRiskEngine(cfg)
+    bt = be.BacktestEngine(engine, initial_cash=100.0)
+    bt.state.shares["AAA"] = 10
+    bt.state.last_known_prices["AAA"] = 10.0
+
+    dates = pd.DatetimeIndex([pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")])
+    close = pd.DataFrame({"AAA": [10.0, 20.0]}, index=dates)
+    volume = pd.DataFrame({"AAA": [1_000_000, 1_000_000]}, index=dates)
+    returns = close.pct_change(fill_method=None).fillna(0.0)
+
+    captured = {}
+
+    def _fake_generate_signals(*_args, **_kwargs):
+        return np.array([0.01]), np.array([0.01]), [0]
+
+    def _fake_optimize(**kwargs):
+        captured["pv"] = kwargs["portfolio_value"]
+        return np.array([0.0])
+
+    monkeypatch.setattr(be, "generate_signals", _fake_generate_signals)
+    monkeypatch.setattr(be, "compute_regime_score", lambda *_args, **_kwargs: 0.5)
+    monkeypatch.setattr(be, "compute_book_cvar", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(be, "execute_rebalance", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(engine, "optimize", _fake_optimize)
+
+    bt._run_rebalance(
+        pd.Timestamp("2020-01-02"),
+        close,
+        volume,
+        returns,
+        ["AAA"],
+        close.loc[pd.Timestamp("2020-01-02")].values.astype(float),
+        idx_df=None,
+        sector_map=None,
+        open_px=close,
+        high_px=close,
+        low_px=close,
+    )
+
+    # cash (100) + shares (10) * previous close (10)
+    assert captured["pv"] == 200.0

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -239,6 +239,27 @@ def test_regime_score_bear_market():
     assert compute_regime_score(idx) < 0.5
 
 
+def test_regime_breadth_requires_sufficient_history_per_symbol():
+    idx = pd.DataFrame(
+        {"Close": np.linspace(100.0, 120.0, 300)},
+        index=pd.date_range("2020-01-01", periods=300),
+    )
+
+    universe_close = pd.DataFrame(
+        {
+            "OLD": np.linspace(100.0, 120.0, 300),
+            # Recent IPO-like series: only 20 observations inside a 200-day window.
+            "IPO": [np.nan] * 280 + list(np.linspace(100.0, 150.0, 20)),
+        },
+        index=idx.index,
+    )
+
+    score_with_ipo = compute_regime_score(idx, universe_close_hist=universe_close)
+    score_without_ipo = compute_regime_score(idx, universe_close_hist=universe_close[["OLD"]])
+
+    assert score_with_ipo == pytest.approx(score_without_ipo, abs=1e-12)
+
+
 # ─── momentum_engine.py ───────────────────────────────────────────────────────
 
 def test_optimizer_sector_cap_enforced():

--- a/test_universe_manager.py
+++ b/test_universe_manager.py
@@ -10,9 +10,11 @@ from universe_manager import _apply_adv_filter
 def reset_universe_warning_state():
     um._MISSING_PARQUET_WARNED.clear()
     um._NO_RECORD_WARNED.clear()
+    um._HISTORICAL_UNIVERSE_DF_CACHE.clear()
     yield
     um._MISSING_PARQUET_WARNED.clear()
     um._NO_RECORD_WARNED.clear()
+    um._HISTORICAL_UNIVERSE_DF_CACHE.clear()
 
 
 def test_get_historical_universe_uses_csv_without_survivorship_warning(tmp_path, monkeypatch, caplog):
@@ -40,6 +42,35 @@ def test_get_historical_universe_warns_when_no_parquet_or_csv(tmp_path, monkeypa
 
     assert members == []
     assert "survivorship bias risk" in caplog.text.lower()
+
+
+def test_get_historical_universe_parquet_cache_reuses_dataframe(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    df = pd.DataFrame(
+        {"tickers": [["AAA.NS", "BBB.NS"]]},
+        index=pd.DatetimeIndex([pd.Timestamp("2020-01-01")]),
+    )
+    hist_file = data_dir / "historical_nifty500.parquet"
+    df.to_parquet(hist_file)
+
+    read_calls = {"n": 0}
+    original = um.pd.read_parquet
+
+    def _spy_read_parquet(path, *args, **kwargs):
+        read_calls["n"] += 1
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(um.pd, "read_parquet", _spy_read_parquet)
+
+    first = um.get_historical_universe("nifty500", pd.Timestamp("2020-01-15"))
+    second = um.get_historical_universe("nifty500", pd.Timestamp("2020-01-20"))
+
+    assert first == ["AAA.NS", "BBB.NS"]
+    assert second == ["AAA.NS", "BBB.NS"]
+    assert read_calls["n"] == 1
 
 
 # ─── _apply_adv_filter .NS-suffix regression tests ───────────────────────────

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -129,9 +129,23 @@ def _load_pit_universe_from_csv(universe_type: str, date: pd.Timestamp) -> List[
 
 # Module-level flags so each warning fires at most once per process,
 # preventing thousands of identical lines from flooding optimizer output.
+
 _MISSING_PARQUET_WARNED: Dict[str, bool] = {}
 _NO_RECORD_WARNED: Dict[str, bool] = {}
 _SECTOR_MAP_CACHE_LOCK = threading.Lock()
+_HISTORICAL_UNIVERSE_DF_CACHE: Dict[Path, Tuple[float, pd.DataFrame]] = {}
+
+
+def _load_historical_universe_df(hist_file: Path) -> pd.DataFrame:
+    """Load historical universe parquet with mtime-based in-memory caching."""
+    mtime = hist_file.stat().st_mtime
+    cached = _HISTORICAL_UNIVERSE_DF_CACHE.get(hist_file)
+    if cached is not None and cached[0] == mtime:
+        return cached[1]
+
+    df = pd.read_parquet(hist_file)
+    _HISTORICAL_UNIVERSE_DF_CACHE[hist_file] = (mtime, df)
+    return df
 
 
 def get_historical_universe(universe_type: str, date: pd.Timestamp) -> List[str]:
@@ -159,7 +173,7 @@ def get_historical_universe(universe_type: str, date: pd.Timestamp) -> List[str]
             _MISSING_PARQUET_WARNED[universe_type] = True
     else:
         try:
-            df = pd.read_parquet(hist_file)
+            df = _load_historical_universe_df(hist_file)
             
             # Find the closest available manifest date preceding the requested date
             available_dates = df.index.unique()


### PR DESCRIPTION
### Motivation
- Eliminate a lookahead/valuation paradox where portfolio value used for sizing was taken from the execution-day close instead of a pre-trade price, which could leak future information into order sizing. 
- Remove repeated Parquet deserialization on every rebalance-date iteration to avoid catastrophic I/O during walk-forward and Bayesian optimisation loops. 
- Prevent newly-listed/IPO-like tickers with sparse history from contaminating the market-breadth signal and biasing the regime score.

### Description
- Value pre-trade positions on the prior bar by using `signal_date` (T-1 close) instead of the execution-day close in `BacktestEngine._run_rebalance` so `pv` and previous weights are computed without lookahead. 
- Add an mtime-aware in-memory cache `_HISTORICAL_UNIVERSE_DF_CACHE` and `_load_historical_universe_df` in `universe_manager.py`, and switch `get_historical_universe` to use this loader to avoid repeated calls to `pd.read_parquet`. 
- Harden `compute_regime_score` in `signals.py` to require at least 80% of the SMA window observations per symbol before including that symbol in the breadth calculation so sparse series (e.g. IPOs) are excluded. 
- Add/modify unit tests: `test_backtest_engine.py` (T-1 valuation), `test_universe_manager.py::test_get_historical_universe_parquet_cache_reuses_dataframe` (parquet cache reuse), and `test_momentum.py::test_regime_breadth_requires_sufficient_history_per_symbol` (breadth immunity to sparse history).

### Testing
- Ran `pytest -q test_backtest_engine.py test_universe_manager.py::test_get_historical_universe_parquet_cache_reuses_dataframe test_momentum.py::test_regime_breadth_requires_sufficient_history_per_symbol`. 
- Result: `3 passed` (all targeted regression tests passed in the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff1e1bf94832b899af6432dd1fb1b)