### PR TITLE
Harden live workflow state: dividends, splits, absence, and rebalance cadence

### DIFF
--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -105,6 +105,21 @@ def _print_stage_status(label: str, progress: float, detail: str) -> None:
     print(_render_meter(label, progress))
     print(f"  {C.GRY}{detail}{C.RST}")
 
+
+def _next_rebalance_due(last_rebalance_date: str, rebalance_freq: str) -> Optional[pd.Timestamp]:
+    if not last_rebalance_date:
+        return None
+    try:
+        anchor = pd.Timestamp(last_rebalance_date).normalize()
+        return anchor + pd.tseries.frequencies.to_offset(rebalance_freq)
+    except Exception:
+        logger.warning(
+            "[Scan] Invalid last_rebalance_date='%s' or REBALANCE_FREQ='%s'; disabling cadence gate this run.",
+            last_rebalance_date,
+            rebalance_freq,
+        )
+        return None
+
 # ─── Screener.in Scraper & Prompters ─────────────────────────────────────────
 
 def _scrape_screener(base_url: str) -> List[str]:
@@ -292,34 +307,35 @@ def detect_and_apply_splits(state: PortfolioState, market_data: dict, cfg: Ultim
         if last_price is None or last_price <= 0:
             continue
 
-        if not getattr(cfg, "AUTO_ADJUST_PRICES", True):
-            ratio = last_price / current_price
+        # data_cache uses auto_adjust=False, so split detection must always run
+        # against raw closes to avoid false crash marks on split dates.
+        ratio = last_price / current_price
 
-            # Broader institutional ratio list with a tighter tolerance
-            split_tolerance = getattr(cfg, "SPLIT_TOLERANCE", 0.005)
-            for r in [2, 5, 10, 3, 4, 20, 1.5, 1.25, 0.666, 0.5, 0.2]:
-                if abs(ratio - r) / r <= split_tolerance:
-                    old_shares     = state.shares[sym]
-                    theoretical_new_shares = old_shares * r
-                    new_shares     = int(np.floor(theoretical_new_shares + 1e-12))
-                    old_entry      = state.entry_prices.get(sym, current_price * r)
-                    new_entry      = old_entry / r
+        # Broader institutional ratio list with a tighter tolerance
+        split_tolerance = getattr(cfg, "SPLIT_TOLERANCE", 0.005)
+        for r in [2, 5, 10, 3, 4, 20, 1.5, 1.25, 0.666, 0.5, 0.2]:
+            if abs(ratio - r) / r <= split_tolerance:
+                old_shares     = state.shares[sym]
+                theoretical_new_shares = old_shares * r
+                new_shares     = int(np.floor(theoretical_new_shares + 1e-12))
+                old_entry      = state.entry_prices.get(sym, current_price * r)
+                new_entry      = old_entry / r
 
-                    # Safely sweep fractional shares
-                    fractional_new_shares = max(0.0, theoretical_new_shares - new_shares)
-                    fractional_value = fractional_new_shares * current_price
-                    state.cash = round(state.cash + fractional_value, 10)
+                # Safely sweep fractional shares
+                fractional_new_shares = max(0.0, theoretical_new_shares - new_shares)
+                fractional_value = fractional_new_shares * current_price
+                state.cash = round(state.cash + fractional_value, 10)
 
-                    logger.warning(
-                        "SPLIT DETECTED: %s ratio=%.3f (≈%gx) "
-                        "shares %d→%d entry_price ₹%.2f→₹%.2f",
-                        sym, ratio, r, old_shares, new_shares, old_entry, new_entry,
-                    )
-                    state.shares[sym]       = new_shares
-                    state.entry_prices[sym] = round(new_entry, 4)
-                    state.last_known_prices[sym] = current_price
-                    adjusted.append(sym)
-                    break
+                logger.warning(
+                    "SPLIT DETECTED: %s ratio=%.3f (≈%gx) "
+                    "shares %d→%d entry_price ₹%.2f→₹%.2f",
+                    sym, ratio, r, old_shares, new_shares, old_entry, new_entry,
+                )
+                state.shares[sym]       = new_shares
+                state.entry_prices[sym] = round(new_entry, 4)
+                state.last_known_prices[sym] = current_price
+                adjusted.append(sym)
+                break
 
     return adjusted
 
@@ -397,6 +413,17 @@ def _run_scan(
     engine = InstitutionalRiskEngine(cfg)
     state.equity_hist_cap = cfg.EQUITY_HIST_CAP
 
+    today = pd.Timestamp(datetime.today().date())
+    next_due = _next_rebalance_due(state.last_rebalance_date, cfg.REBALANCE_FREQ)
+    rebalance_allowed = next_due is None or today >= next_due
+    if not rebalance_allowed:
+        logger.info(
+            "[Scan] Cadence gate active: last rebalance %s, next due %s (%s). Scan will mark-to-market only.",
+            state.last_rebalance_date,
+            next_due.strftime("%Y-%m-%d"),
+            cfg.REBALANCE_FREQ,
+        )
+
     # Pass tomorrow as end_date so load_or_fetch's required_end covers today.
     # yfinance end= is exclusive, so +1 day ensures today's close is fetched.
     end_date   = (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d")
@@ -438,6 +465,9 @@ def _run_scan(
 
     if not close_d:
         logger.warning("[Scan] No data available for any universe symbol.")
+        for held_sym in list(state.shares.keys()):
+            if held_sym not in close_d:
+                state.absent_periods[held_sym] = int(state.absent_periods.get(held_sym, 0)) + 1
         return state, market_data
 
     _print_stage_status("Analysis", 0.35, f"Built close-price matrix for {len(close_d):,} active symbols.")
@@ -500,6 +530,7 @@ def _run_scan(
     sel_idx: List[int]   = []
     _force_full_cash     = False
     _soft_cvar_breach    = False
+    rebalanced_this_scan = False
 
     # ── Book CVaR screen ──────────────────────────────────────────────────────
     if state.shares:
@@ -525,7 +556,7 @@ def _run_scan(
                 book_cvar * 100, cfg.CVAR_DAILY_LIMIT * 100, hard_breach_threshold * 100,
             )
 
-    if not _force_full_cash:
+    if rebalance_allowed and not _force_full_cash:
         try:
             raw_daily, adj_scores, sel_idx = generate_signals(
                 log_rets, adv_arr, cfg, prev_weights=state.weights
@@ -587,7 +618,7 @@ def _run_scan(
         else:
             weights = compute_decay_targets(state, sel_idx, active, cfg)
 
-    if optimization_succeeded or apply_decay:
+    if rebalance_allowed and (optimization_succeeded or apply_decay):
         _T_cvar = min(len(log_rets), cfg.CVAR_LOOKBACK)
         _scenario_losses = -(
             log_rets.iloc[-_T_cvar:]
@@ -597,11 +628,13 @@ def _run_scan(
         total_slippage = execute_rebalance(
             state, weights, prices, active, cfg,
             adv_shares=adv_arr,
-            date_context=pd.Timestamp(end_date), trade_log=trade_log,
+            date_context=today, trade_log=trade_log,
             apply_decay    = apply_decay and not _exhaust_decay,
             scenario_losses = None if _exhaust_decay else _scenario_losses,
             force_rebalance_trades = _soft_cvar_breach,
         )
+        state.last_rebalance_date = today.strftime("%Y-%m-%d")
+        rebalanced_this_scan = True
         if _exhaust_decay:
             state.decay_rounds = 0
             state.consecutive_failures = 0
@@ -610,6 +643,14 @@ def _run_scan(
 
     price_dict = {sym: prices[active_idx[sym]] for sym in active}
     state.record_eod(price_dict)
+
+    if not rebalanced_this_scan:
+        for held_sym in list(state.shares.keys()):
+            if held_sym not in active_idx:
+                state.absent_periods[held_sym] = int(state.absent_periods.get(held_sym, 0)) + 1
+            else:
+                state.absent_periods.pop(held_sym, None)
+
     final_pv = state.equity_hist[-1] if state.equity_hist else pv
 
     logger.info(

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -276,6 +276,7 @@ class PortfolioState:
     last_known_volatility:Dict[str, float] = field(default_factory=dict)
     decay_rounds:         int              = 0
     dividend_ledger:      Dict[str, str]   = field(default_factory=dict)
+    last_rebalance_date:  str              = ""
 
     def update_exposure(
         self,
@@ -384,6 +385,7 @@ class PortfolioState:
             "last_known_volatility":_r(self.last_known_volatility),
             "decay_rounds":         self.decay_rounds,
             "dividend_ledger":      dict(sorted(self.dividend_ledger.items())),
+            "last_rebalance_date":  self.last_rebalance_date,
         }
 
     @classmethod
@@ -430,6 +432,7 @@ class PortfolioState:
         ps.last_known_volatility= _get("last_known_volatility",lambda v: {k: float(x) for k, x in v.items()}, {})
         ps.decay_rounds         = _get("decay_rounds",         int,                                             0)
         ps.dividend_ledger      = _get("dividend_ledger",      lambda v: {k: str(x) for k, x in v.items()},     {})
+        ps.last_rebalance_date  = _get("last_rebalance_date",  str,                                             "")
 
         if errors:
             logger.error(
@@ -650,6 +653,11 @@ def execute_rebalance(
                 if delta > 0:
                     if old_s == 0:
                         new_entry_prices[sym] = price * (1.0 + slip_rate)
+                        marker_date = (
+                            pd.Timestamp(date_context).strftime("%Y-%m-%d")
+                            if date_context is not None else pd.Timestamp.utcnow().strftime("%Y-%m-%d")
+                        )
+                        state.dividend_ledger[sym] = f"{marker_date}:0.00000000"
                     else:
                         old_basis = new_entry_prices.get(sym, price)
                         new_entry_prices[sym] = (old_basis * old_s + price * (1.0 + slip_rate) * delta) / s

--- a/test_daily_workflow.py
+++ b/test_daily_workflow.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
 import daily_workflow as dw
-from momentum_engine import PortfolioState, UltimateConfig
+from momentum_engine import PortfolioState, UltimateConfig, execute_rebalance
 
 
 def test_prompt_menu_choice_retries_until_valid(monkeypatch):
@@ -83,3 +84,97 @@ def test_load_portfolio_state_raises_when_all_backups_corrupted(tmp_path: Path, 
 
     with pytest.raises(RuntimeError, match="all discovered state files are corrupted"):
         dw.load_portfolio_state("main")
+
+
+def test_detect_and_apply_splits_runs_on_raw_prices_even_when_auto_adjust_flag_true():
+    cfg = UltimateConfig(AUTO_ADJUST_PRICES=True, SPLIT_TOLERANCE=0.01)
+    state = PortfolioState(
+        shares={"ABC": 10},
+        entry_prices={"ABC": 1000.0},
+        last_known_prices={"ABC": 1000.0},
+        cash=0.0,
+    )
+    idx = pd.date_range("2024-01-01", periods=2)
+    market_data = {
+        "ABC.NS": pd.DataFrame({"Close": [1000.0, 100.0], "Dividends": [0.0, 0.0]}, index=idx)
+    }
+
+    adjusted = dw.detect_and_apply_splits(state, market_data, cfg)
+
+    assert adjusted == ["ABC"]
+    assert state.shares["ABC"] == 100
+    assert state.entry_prices["ABC"] == 100.0
+
+
+def test_run_scan_cadence_gate_skips_rebalance(monkeypatch):
+    idx = pd.date_range("2024-01-01", periods=6)
+    md = {
+        "ABC.NS": pd.DataFrame({"Close": [100, 101, 102, 103, 104, 105], "Dividends": [0, 0, 0, 0, 0, 0]}, index=idx),
+        "^NSEI": pd.DataFrame({"Close": [100] * 6}, index=idx),
+        "^CRSLDX": pd.DataFrame({"Close": [100] * 6}, index=idx),
+    }
+    monkeypatch.setattr(dw, "load_or_fetch", lambda *_args, **_kwargs: md)
+    monkeypatch.setattr(dw, "_print_stage_status", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(dw, "detect_and_apply_splits", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(dw, "compute_regime_score", lambda *_args, **_kwargs: 0.5)
+
+    called = {"n": 0}
+
+    def _boom(*_args, **_kwargs):
+        called["n"] += 1
+        raise AssertionError("execute_rebalance should not be called when cadence gate blocks")
+
+    monkeypatch.setattr(dw, "execute_rebalance", _boom)
+
+    state = PortfolioState(
+        shares={"ABC": 10},
+        entry_prices={"ABC": 100.0},
+        last_known_prices={"ABC": 100.0},
+        last_rebalance_date=datetime.today().strftime("%Y-%m-%d"),
+    )
+    cfg = UltimateConfig(REBALANCE_FREQ="W-FRI")
+
+    out_state, _ = dw._run_scan(["ABC"], state, "TEST", cfg_override=cfg)
+
+    assert called["n"] == 0
+    assert out_state.absent_periods == {}
+
+
+def test_run_scan_increments_absent_periods_when_symbol_missing(monkeypatch):
+    idx = pd.date_range("2024-01-01", periods=6)
+    md = {
+        "^NSEI": pd.DataFrame({"Close": [100] * 6}, index=idx),
+        "^CRSLDX": pd.DataFrame({"Close": [100] * 6}, index=idx),
+    }
+    monkeypatch.setattr(dw, "load_or_fetch", lambda *_args, **_kwargs: md)
+    monkeypatch.setattr(dw, "_print_stage_status", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(dw, "detect_and_apply_splits", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(dw, "compute_regime_score", lambda *_args, **_kwargs: 0.5)
+
+    state = PortfolioState(
+        shares={"MISSING": 5},
+        last_known_prices={"MISSING": 10.0},
+        absent_periods={"MISSING": 2},
+        last_rebalance_date=datetime.today().strftime("%Y-%m-%d"),
+    )
+    cfg = UltimateConfig(REBALANCE_FREQ="W-FRI", MAX_ABSENT_PERIODS=10)
+
+    out_state, _ = dw._run_scan(["ABC"], state, "TEST", cfg_override=cfg)
+
+    assert out_state.absent_periods["MISSING"] == 3
+
+
+def test_execute_rebalance_initializes_dividend_marker_on_new_position():
+    cfg = UltimateConfig()
+    state = PortfolioState(cash=10_000.0)
+    execute_rebalance(
+        state=state,
+        target_weights=pd.Series([1.0]).values,
+        prices=pd.Series([100.0]).values,
+        active_symbols=["ABC"],
+        cfg=cfg,
+        date_context=pd.Timestamp("2025-01-15"),
+    )
+
+    assert state.shares.get("ABC", 0) > 0
+    assert state.dividend_ledger["ABC"].startswith("2025-01-15:")

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -685,15 +685,15 @@ def test_detect_and_apply_splits_fractional_cash():
     assert state.shares["A"] == 50, "Shares should floor correctly on splits."
     assert state.cash == 100.0, "Fractional value must be safely routed to Cash."
 
-def test_detect_and_apply_splits_skips_when_auto_adjust_enabled():
+def test_detect_and_apply_splits_runs_even_when_auto_adjust_enabled():
     state = PortfolioState(cash=0.0)
     state.shares = {"A": 100}
     state.last_known_prices = {"A": 100.0}
-    market_data = {"A": pd.DataFrame({"Close": [50.0]})}
+    market_data = {"A": pd.DataFrame({"Close": [50.0], "Dividends": [0.0]})}
 
     detect_and_apply_splits(state, market_data, UltimateConfig(AUTO_ADJUST_PRICES=True))
 
-    assert state.shares["A"] == 100
+    assert state.shares["A"] == 200
 
 
 def test_detect_and_apply_splits_dividend_sweep_idempotent():


### PR DESCRIPTION
### Motivation
- Prevent catastrophic financial state corruption caused by sweeping historical dividends into cash for newly opened positions.  
- Ensure split detection aligns with the raw-price ingestion pipeline to avoid interpreting legitimate corporate splits as market crashes.  
- Make absent/delisted holdings advance through an absence counter so dead equity is force-closed after the configured threshold.  
- Stop ad-hoc off-cycle rebalances by enforcing the configured `REBALANCE_FREQ` calendar gate so scans can be mark-to-market only.

### Description
- Detect-and-apply-splits now always evaluates raw close ratios (no longer gated by `AUTO_ADJUST_PRICES`) so split detection runs against the unadjusted data used by `data_cache.py`.  
- `execute_rebalance` initializes a dividend ledger marker for newly opened positions (using `date_context`) to prevent back-sweeping of historical dividends.  
- Added persistent `last_rebalance_date` to `PortfolioState` (`to_dict`/`from_dict`) and a helper `_next_rebalance_due(...)` to compute the next allowed rebalance date; `_run_scan` now checks `rebalance_allowed` and runs mark-to-market-only when off-cadence.  
- `_run_scan` increments `state.absent_periods` for held symbols missing from active market data (including the early no-data return path), and only skips absent increments for symbols updated during a rebalance.  
- Tests added/updated to cover split detection behavior under raw pricing, cadence gating behavior, absent-period increments when symbols are missing, and dividend marker initialization on first buy.

### Testing
- Compiled the modified modules with `python -m py_compile daily_workflow.py momentum_engine.py` and the compile step succeeded.  
- Ran focused unit tests: `pytest -q test_daily_workflow.py` (all tests in that file passed) and targeted momentum tests around split behavior (the updated split test passed).  
- The full test suite was exercised but still exposes an unrelated e2e parity assertion in this environment; the changes introduced here do not regress the focused tests but the full-suite parity discrepancy is pre-existing and surfaced during integration runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff54ab604832b8f0f7dd27d97bbcb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cadence-based rebalance scheduling to control portfolio rebalancing frequency.
  * Enhanced corporate action detection for more reliable split handling across all configurations.
  * Improved tracking of absent holdings with period-based monitoring.

* **Tests**
  * Expanded test coverage for rebalance cadence, split detection, and dividend initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->