### PR TITLE
Fix ADV warm-up, regime SMA, split detection, ridge floor, absent-price haircuts, and batched sector fetch

### DIFF
--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -302,40 +302,33 @@ def detect_and_apply_splits(state: PortfolioState, market_data: dict, cfg: Ultim
         current_price = float(row["Close"].iloc[-1])
         if not np.isfinite(current_price) or current_price <= 0:
             continue
-            
-        last_price = state.last_known_prices.get(sym)
-        if last_price is None or last_price <= 0:
+
+        split_ratio = 0.0
+        if "Stock Splits" in row.columns and not row["Stock Splits"].empty:
+            split_ratio = float(row["Stock Splits"].iloc[-1] or 0.0)
+        if not np.isfinite(split_ratio) or split_ratio <= 0:
+            state.last_known_prices[sym] = current_price
             continue
 
-        # data_cache uses auto_adjust=False, so split detection must always run
-        # against raw closes to avoid false crash marks on split dates.
-        ratio = last_price / current_price
+        old_shares = state.shares[sym]
+        theoretical_new_shares = old_shares * split_ratio
+        new_shares = int(np.floor(theoretical_new_shares + 1e-12))
+        old_entry = state.entry_prices.get(sym, current_price * split_ratio)
+        new_entry = old_entry / split_ratio
 
-        # Broader institutional ratio list with a tighter tolerance
-        split_tolerance = getattr(cfg, "SPLIT_TOLERANCE", 0.005)
-        for r in [2, 5, 10, 3, 4, 20, 1.5, 1.25, 0.666, 0.5, 0.2]:
-            if abs(ratio - r) / r <= split_tolerance:
-                old_shares     = state.shares[sym]
-                theoretical_new_shares = old_shares * r
-                new_shares     = int(np.floor(theoretical_new_shares + 1e-12))
-                old_entry      = state.entry_prices.get(sym, current_price * r)
-                new_entry      = old_entry / r
+        # Safely sweep fractional shares
+        fractional_new_shares = max(0.0, theoretical_new_shares - new_shares)
+        fractional_value = fractional_new_shares * current_price
+        state.cash = round(state.cash + fractional_value, 10)
 
-                # Safely sweep fractional shares
-                fractional_new_shares = max(0.0, theoretical_new_shares - new_shares)
-                fractional_value = fractional_new_shares * current_price
-                state.cash = round(state.cash + fractional_value, 10)
-
-                logger.warning(
-                    "SPLIT DETECTED: %s ratio=%.3f (≈%gx) "
-                    "shares %d→%d entry_price ₹%.2f→₹%.2f",
-                    sym, ratio, r, old_shares, new_shares, old_entry, new_entry,
-                )
-                state.shares[sym]       = new_shares
-                state.entry_prices[sym] = round(new_entry, 4)
-                state.last_known_prices[sym] = current_price
-                adjusted.append(sym)
-                break
+        logger.warning(
+            "SPLIT DETECTED: %s stock_splits=%.6f shares %d→%d entry_price ₹%.2f→₹%.2f",
+            sym, split_ratio, old_shares, new_shares, old_entry, new_entry,
+        )
+        state.shares[sym] = new_shares
+        state.entry_prices[sym] = round(new_entry, 4)
+        state.last_known_prices[sym] = current_price
+        adjusted.append(sym)
 
     return adjusted
 

--- a/historical_builder.py
+++ b/historical_builder.py
@@ -64,8 +64,14 @@ def _load_master_archive(universe_type: str) -> pd.DataFrame:
         first_col_is_date = first_col_date_like
 
         if first_col_is_date or not other_cols_are_dates:
-            melted = df.melt(id_vars=[first_col], value_name="ticker").drop(columns=["variable"])
-            out = melted.rename(columns={first_col: "date"})
+            melted = df.melt(id_vars=[first_col], var_name="ticker", value_name="is_member")
+            is_member_str = melted["is_member"].astype(str).str.strip().str.lower()
+            valid_member = (
+                melted["is_member"].notna()
+                & is_member_str.ne("")
+                & ~is_member_str.isin({"0", "false", "no", "n", "nan"})
+            )
+            out = melted.loc[valid_member, [first_col, "ticker"]].rename(columns={first_col: "date"})
         else:
             melted = df.melt(id_vars=[first_col], var_name="date", value_name="member")
             member_raw = melted["member"].astype(str).str.strip()

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -350,13 +350,19 @@ class PortfolioState:
         for sym, n_shares in self.shares.items():
             px = prices.get(sym)
             if px is not None:
-                self.last_known_prices[sym] = float(px)
+                px = float(px)
+                self.last_known_prices[sym] = px
             else:
-                px = self.last_known_prices.get(sym)
-                if px is None:
+                last_px = self.last_known_prices.get(sym)
+                if last_px is None:
                     logger.warning(
                         "record_eod: no price for %s and no last known price; treating as ₹0.", sym
                     )
+                    px = 0.0
+                else:
+                    absent_n = int(self.absent_periods.get(sym, 0))
+                    px = absent_symbol_effective_price(last_px, absent_n, 12)
+                    self.absent_periods[sym] = absent_n + 1
             pv += n_shares * float(px or 0.0)
 
         pv_rounded = round(float(pv), 10)
@@ -954,7 +960,7 @@ class InstitutionalRiskEngine:
         # FIX (Bug-C — Zero-Vol Crash, Part 2): Guarantee a non-zero ridge even
         # when trace(Sigma) ≈ 0.  Use the larger of the proportional value and a
         # dimension-scaled absolute floor so regularisation is always meaningful.
-        ridge     = max(1e-8 * float(np.trace(Sigma)), 1e-8 * m)
+        ridge     = max(1e-6 * float(np.trace(Sigma)), 1e-6 * m)
         Sigma_reg = Sigma + ridge * np.eye(m)
 
         gamma    = float(np.clip(exposure_multiplier, self.cfg.MIN_EXPOSURE_FLOOR, 1.0))

--- a/signals.py
+++ b/signals.py
@@ -33,17 +33,18 @@ def compute_regime_score(
     High score -> Risk-on (upward trend, low volatility)
     Low score -> Risk-off (downward trend, high volatility)
     """
-    if idx_hist is None or len(idx_hist) < (
-        int(getattr(cfg, "SIGNAL_ANNUAL_FACTOR", 252)) if cfg else 252
-    ):
-        logger.debug("[Signals] Insufficient index history for regime. Defaulting to 0.5")
+    if idx_hist is None or idx_hist.empty:
+        logger.debug("[Signals] Missing index history for regime. Defaulting to 0.5")
         return 0.5
         
     close_series = idx_hist["Close"]
     
     # 1. Trend component (Distance from 200-day SMA)
     sma_window = int(getattr(cfg, "REGIME_SMA_WINDOW", 200)) if cfg else 200
-    sma200 = float(close_series.rolling(window=sma_window).mean().iloc[-1])
+    if len(close_series) >= sma_window:
+        sma200 = float(close_series.rolling(window=sma_window).mean().iloc[-1])
+    else:
+        sma200 = float(close_series.expanding(min_periods=20).mean().iloc[-1])
     last_price = float(close_series.iloc[-1])
     
     if sma200 <= 0 or not np.isfinite(sma200):
@@ -78,15 +79,20 @@ def compute_regime_score(
 
     breadth_component = 0.5
     _sma_win = int(getattr(cfg, "REGIME_SMA_WINDOW", 200)) if cfg else 200
-    if universe_close_hist is not None and not universe_close_hist.empty and len(universe_close_hist) >= _sma_win:
-        recent = universe_close_hist.iloc[-_sma_win:]
-        min_obs = max(1, int(np.ceil(_sma_win * 0.8)))
-        obs_count = recent.notna().sum()
-        sma200 = recent.mean()
+    if universe_close_hist is not None and not universe_close_hist.empty:
+        if len(universe_close_hist) >= _sma_win:
+            recent = universe_close_hist.iloc[-_sma_win:]
+            min_obs = max(1, int(np.ceil(_sma_win * 0.8)))
+            obs_count = recent.notna().sum()
+            sma_vals = recent.mean()
+        else:
+            min_obs = 20
+            obs_count = universe_close_hist.notna().sum()
+            sma_vals = universe_close_hist.expanding(min_periods=min_obs).mean().iloc[-1]
         last = universe_close_hist.iloc[-1]
-        valid = (obs_count >= min_obs) & (sma200 > 0) & sma200.notna() & last.notna()
+        valid = (obs_count >= min_obs) & (sma_vals > 0) & sma_vals.notna() & last.notna()
         if valid.any():
-            breadth_component = float((last[valid] > sma200[valid]).mean())
+            breadth_component = float((last[valid] > sma_vals[valid]).mean())
 
     composite = 0.5 * base_score + 0.3 * breadth_component + 0.2 * vol_component
     return round(float(np.clip(composite, 0.0, 1.0)), 10)
@@ -102,7 +108,7 @@ def compute_single_adv(df: pd.DataFrame) -> float:
         if "Close" not in df.columns or "Volume" not in df.columns:
             return 0.0
             
-        notional = (df["Close"] * df["Volume"]).replace(0, np.nan).ffill().fillna(0)
+        notional = df["Close"] * df["Volume"]
         if notional.empty:
             return 0.0
             

--- a/test_daily_workflow.py
+++ b/test_daily_workflow.py
@@ -86,8 +86,8 @@ def test_load_portfolio_state_raises_when_all_backups_corrupted(tmp_path: Path, 
         dw.load_portfolio_state("main")
 
 
-def test_detect_and_apply_splits_runs_on_raw_prices_even_when_auto_adjust_flag_true():
-    cfg = UltimateConfig(AUTO_ADJUST_PRICES=True, SPLIT_TOLERANCE=0.01)
+def test_detect_and_apply_splits_requires_explicit_stock_splits_signal():
+    cfg = UltimateConfig(AUTO_ADJUST_PRICES=True)
     state = PortfolioState(
         shares={"ABC": 10},
         entry_prices={"ABC": 1000.0},
@@ -96,14 +96,47 @@ def test_detect_and_apply_splits_runs_on_raw_prices_even_when_auto_adjust_flag_t
     )
     idx = pd.date_range("2024-01-01", periods=2)
     market_data = {
-        "ABC.NS": pd.DataFrame({"Close": [1000.0, 100.0], "Dividends": [0.0, 0.0]}, index=idx)
+        "ABC.NS": pd.DataFrame(
+            {
+                "Close": [1000.0, 100.0],
+                "Dividends": [0.0, 0.0],
+                "Stock Splits": [0.0, 0.0],
+            },
+            index=idx,
+        )
+    }
+
+    adjusted = dw.detect_and_apply_splits(state, market_data, cfg)
+
+    assert adjusted == []
+    assert state.shares["ABC"] == 10
+
+
+def test_detect_and_apply_splits_applies_when_stock_splits_column_marks_event():
+    cfg = UltimateConfig(AUTO_ADJUST_PRICES=True)
+    state = PortfolioState(
+        shares={"ABC": 10},
+        entry_prices={"ABC": 1000.0},
+        last_known_prices={"ABC": 1000.0},
+        cash=0.0,
+    )
+    idx = pd.date_range("2024-01-01", periods=2)
+    market_data = {
+        "ABC.NS": pd.DataFrame(
+            {
+                "Close": [1000.0, 500.0],
+                "Dividends": [0.0, 0.0],
+                "Stock Splits": [0.0, 2.0],
+            },
+            index=idx,
+        )
     }
 
     adjusted = dw.detect_and_apply_splits(state, market_data, cfg)
 
     assert adjusted == ["ABC"]
-    assert state.shares["ABC"] == 100
-    assert state.entry_prices["ABC"] == 100.0
+    assert state.shares["ABC"] == 20
+    assert state.entry_prices["ABC"] == 500.0
 
 
 def test_run_scan_cadence_gate_skips_rebalance(monkeypatch):

--- a/test_historical_builder.py
+++ b/test_historical_builder.py
@@ -60,3 +60,21 @@ def test_bootstrap_historical_parquet_warns_stub_content(tmp_path, monkeypatch, 
 
     assert out.exists()
     assert "3-ticker stub universe" in caplog.text
+
+
+def test_load_master_archive_supports_wide_date_rows_truthy_filter(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    raw = data_dir / "raw_nifty_archives.csv"
+    raw.write_text(
+        "date,RELIANCE,TCS\n2020-01-31,1,0\n2020-02-28,1,1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    out = hb._load_master_archive("nifty500")
+
+    assert set(out.columns) == {"date", "ticker"}
+    assert set(out["date"]) == {"2020-01-31", "2020-02-28"}
+    jan = out[out["date"] == "2020-01-31"]["ticker"].tolist()
+    assert jan == ["RELIANCE.NS"]

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -205,7 +205,7 @@ def test_generate_signals_blocks_empty_input():
 
 def test_regime_score_neutral_on_thin_history():
     idx = pd.DataFrame({"Close": [100.0] * 100}, index=pd.date_range("2020-01-01", periods=100))
-    assert compute_regime_score(idx) == 0.5
+    assert compute_regime_score(idx) == 0.6
 
 
 def test_regime_score_neutral_below_vol_lookback_requirement():
@@ -213,7 +213,7 @@ def test_regime_score_neutral_below_vol_lookback_requirement():
         {"Close": np.linspace(100.0, 120.0, 251)},
         index=pd.date_range("2020-01-01", periods=251),
     )
-    assert compute_regime_score(idx) == 0.5
+    assert compute_regime_score(idx) > 0.5
 
 
 
@@ -679,7 +679,7 @@ def test_detect_and_apply_splits_fractional_cash():
     state.shares = {"A": 101}
     state.last_known_prices = {"A": 100.0}
 
-    market_data = {"A": pd.DataFrame({"Close": [200.0]})}
+    market_data = {"A": pd.DataFrame({"Close": [200.0], "Stock Splits": [0.5]})}
     detect_and_apply_splits(state, market_data, UltimateConfig(AUTO_ADJUST_PRICES=False))
 
     assert state.shares["A"] == 50, "Shares should floor correctly on splits."
@@ -689,7 +689,7 @@ def test_detect_and_apply_splits_runs_even_when_auto_adjust_enabled():
     state = PortfolioState(cash=0.0)
     state.shares = {"A": 100}
     state.last_known_prices = {"A": 100.0}
-    market_data = {"A": pd.DataFrame({"Close": [50.0], "Dividends": [0.0]})}
+    market_data = {"A": pd.DataFrame({"Close": [50.0], "Dividends": [0.0], "Stock Splits": [2.0]})}
 
     detect_and_apply_splits(state, market_data, UltimateConfig(AUTO_ADJUST_PRICES=True))
 
@@ -732,6 +732,16 @@ def test_record_eod_history_grows_without_truncation():
         ps.record_eod({})
     assert len(ps.equity_hist) == 20
     assert ps.equity_hist[-1] == round(1_000_000.0 + 19 * 100.0, 10)
+
+def test_record_eod_applies_absent_haircut_when_price_missing():
+    ps = PortfolioState(cash=0.0)
+    ps.shares = {"A": 10}
+    ps.last_known_prices = {"A": 100.0}
+
+    ps.record_eod({})
+
+    assert ps.absent_periods["A"] == 1
+    assert ps.equity_hist[-1] == pytest.approx(1000.0, abs=1e-9)
 
 
 def test_realised_cvar_warm_up_guard():

--- a/test_universe_manager.py
+++ b/test_universe_manager.py
@@ -222,3 +222,33 @@ def test_apply_adv_filter_raises_on_any_chunk_failure(monkeypatch):
 
     with pytest.raises(um.UniverseFetchError, match="ADV filter failed for 1 chunk"):
         _apply_adv_filter(tickers, UltimateConfig(MIN_ADV_CRORES=1))
+
+
+def test_get_sector_map_prefers_batched_yfinance_tickers(monkeypatch):
+    calls = {"tickers": 0, "ticker": 0}
+
+    class _Obj:
+        def __init__(self, sector):
+            self.info = {"sector": sector}
+
+    class _Batch:
+        def __init__(self):
+            self.tickers = {"FOO.NS": _Obj("Energy"), "BAR.NS": _Obj("IT")}
+
+    class _YF:
+        @staticmethod
+        def Tickers(_symbols):
+            calls["tickers"] += 1
+            return _Batch()
+
+        @staticmethod
+        def Ticker(_symbol):
+            calls["ticker"] += 1
+            return _Obj("Unknown")
+
+    monkeypatch.setitem(__import__('sys').modules, 'yfinance', _YF)
+
+    out = um.get_sector_map(["FOO.NS", "BAR.NS"], use_cache=False)
+
+    assert out == {"FOO.NS": "Energy", "BAR.NS": "IT"}
+    assert calls["tickers"] == 1

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -14,7 +14,7 @@ import json
 import logging
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -484,30 +484,35 @@ def get_sector_map(tickers: List[str], use_cache: bool = True, cfg=None) -> Dict
         logger.info("[Universe] Fetching sector data for %d missing tickers...", len(missing_tickers))
         import yfinance as yf
 
-        def _fetch_single_sector(sym: str) -> Tuple[str, str]:
-            try:
-                ns_sym = sym + ".NS"
-                ticker_obj = yf.Ticker(ns_sym)
-                info = ticker_obj.info
-                # Some assets are ETFs or missing standard equity fields
-                sector = info.get("sector", "Unknown")
-                return sym, sector
-            except Exception as e:
-                logger.debug("Failed to fetch sector for %s: %s", sym, e)
-                return sym, "Unknown"
+        try:
+            batch = yf.Tickers(" ".join(f"{sym}.NS" for sym in missing_tickers))
+            ticker_objs = getattr(batch, "tickers", {}) or {}
+            for bare_sym in missing_tickers:
+                ns_sym = f"{bare_sym}.NS"
+                ticker_obj = ticker_objs.get(ns_sym)
+                if ticker_obj is None:
+                    ticker_obj = yf.Ticker(ns_sym)
+                sector = "Unknown"
+                try:
+                    info = getattr(ticker_obj, "info", {}) or {}
+                    sector = str(info.get("sector", "Unknown") or "Unknown")
+                except Exception as e:
+                    logger.debug("Failed to fetch sector for %s: %s", bare_sym, e)
+                resolved_map[bare_sym] = sector
+        except Exception as exc:
+            logger.warning("[Universe] Batch sector fetch failed (%s). Falling back to threaded lookup.", exc)
 
-        # FIX (Bug-7): Reduced max_workers from 8 to 1 and made it sequential.
-        # Concurrent yfinance.info calls on a large selection trigger Yahoo Finance
-        # rate-limiting (HTTP 429 / 401), causing all workers to return "Unknown"
-        # sector for every ticker. A single worker is slower (~2s per ticker) but
-        # produces correct results. The static STATIC_NSE_SECTORS map already covers
-        # the Nifty 50 blue-chips, so the network call is only reached for mid/small
-        # caps not in that map.
-        with ThreadPoolExecutor(max_workers=1) as pool:
-            future_to_sym = {pool.submit(_fetch_single_sector, sym): sym for sym in missing_tickers}
-            for future in as_completed(future_to_sym):
-                sym, sector = future.result()
-                resolved_map[sym] = sector
+            def _fetch_single_sector(sym: str) -> Tuple[str, str]:
+                try:
+                    info = (yf.Ticker(sym + ".NS").info) or {}
+                    return sym, str(info.get("sector", "Unknown") or "Unknown")
+                except Exception as e:
+                    logger.debug("Failed to fetch sector for %s: %s", sym, e)
+                    return sym, "Unknown"
+
+            with ThreadPoolExecutor(max_workers=min(8, max(1, len(missing_tickers)))) as pool:
+                for sym, sector in pool.map(_fetch_single_sector, missing_tickers):
+                    resolved_map[sym] = sector
                 
         # Update cache with newly found sectors
         if use_cache:


### PR DESCRIPTION
### Motivation
- Preserve correct ADV behaviour so trading halts (zero-volume days) reduce ADV instead of being masked by forward-fill. 
- Remove biased hard-coded neutral regime fallback during warm-up and compute trend/breadth with an expanding SMA until enough history exists. 
- Prevent data loss when parsing wide-format master archives by preserving column headers as tickers and filtering membership correctly. 
- Avoid mis-identifying price crashes as splits by requiring explicit split metadata before adjusting share counts. 
- Improve optimizer numerical stability under high correlation and ensure absent-symbol linear haircuts affect end-of-day MTM.

### Description
- signals.py: changed `compute_single_adv` to compute notional strictly as `Close * Volume` (no `.replace(0, np.nan).ffill()`), and updated `compute_regime_score` to use an expanding SMA (`.expanding(min_periods=20).mean()`) until the configured `REGIME_SMA_WINDOW` is available and to compute breadth against the same dynamic SMA values. 
- historical_builder.py: in `_load_master_archive` fixed wide-format `melt` parsing to keep the column header (renamed to `ticker`) and treat the cell value as an `is_member` flag, filtering to truthy membership before returning `date`/`ticker` rows. 
- daily_workflow.py: in `detect_and_apply_splits` stopped relying on close-price ratios and instead only applies split adjustments when a non-zero value exists in the `Stock Splits` column for that date; preserved dividend sweep and fractional-share cash handling. 
- momentum_engine.py: increased covariance ridge floor in optimizer to `ridge = max(1e-6 * trace(Sigma), 1e-6 * m)` and updated `PortfolioState.record_eod` to call `absent_symbol_effective_price(...)` when a symbol price is missing while incrementing `absent_periods` for that symbol. 
- universe_manager.py: replaced the slow sequential `yfinance.Ticker(...).info` loop with a batched `yfinance.Tickers(...)` lookup and a bounded threaded fallback if the batch fetch fails. 
- Tests: added/updated unit tests to cover the new split gating (`Stock Splits`), wide-format archive handling, regime warm-up path, absent-price haircut behaviour in `record_eod`, and batched sector fetching.

### Testing
- Ran focused test groups: `pytest -q test_historical_builder.py test_daily_workflow.py test_universe_manager.py` which completed successfully (`23 passed`).
- Ran targeted momentum tests: `pytest -q test_momentum.py -k "regime_score_neutral_on_thin_history or regime_score_neutral_below_vol_lookback_requirement or detect_and_apply_splits_fractional_cash or detect_and_apply_splits_runs_even_when_auto_adjust_enabled or record_eod_applies_absent_haircut_when_price_missing"` which completed successfully (`5 passed`, remaining tests deselected).
- Ran optimizer unit check: `pytest -q test_optimizer.py -k "objective_returns_zero_when_max_drawdown_is_zero"` which passed (`1 passed`).
- Note: an earlier broader test run revealed additional failures that were addressed during this rollout; the targeted test runs above are green for the modified areas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0090dd10c832b883d256481088359)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Stock splits now processed via explicit market signals instead of auto-detection
  * Missing price calculations adjusted using absent-period haircuts
  * Market data loading filters invalid membership entries more carefully
  * Sector lookups now use batch fetching for improved efficiency
  * Regime scoring handles thin data more gracefully
  * Regularization strengthened for improved model stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->