### PR TITLE
Fix halted-stock ADV inflation in vectorized compute_adv

### DIFF
--- a/signals.py
+++ b/signals.py
@@ -143,14 +143,13 @@ def compute_adv(market_data: dict, active_symbols: List[str], cfg: Optional['Ult
         ns_sym = to_ns(symbol)
         df = market_data.get(ns_sym)
         if df is not None and "Close" in df.columns and "Volume" in df.columns:
-            notional_cols[symbol] = (df["Close"] * df["Volume"]).replace(0, np.nan)
+            notional_cols[symbol] = df["Close"] * df["Volume"]
 
     if not notional_cols:
         return np.zeros(len(active_symbols), dtype=float)
 
     # Single rolling mean across the entire matrix — O(T·N) instead of N × O(T).
     notional_df = pd.DataFrame(notional_cols)
-    notional_df.ffill(inplace=True)
     notional_df.fillna(0.0, inplace=True)
     adv_lookback = int(getattr(cfg, "ADV_LOOKBACK", 20)) if cfg else 20
     adv_last_row = notional_df.rolling(adv_lookback, min_periods=1).mean().iloc[-1]


### PR DESCRIPTION
### Motivation
- Prevent halted or suspended symbols with zero volume from inheriting stale notional values which artificially inflate Average Daily Volume (ADV) and allow them to bypass liquidity gates.

### Description
- Compute per-symbol notional strictly as `df["Close"] * df["Volume"]` (remove the previous `.replace(0, np.nan)`) and remove the matrix-level `notional_df.ffill(inplace=True)` so true zero-volume sessions remain `0.0` and correctly reduce rolling ADV.

### Testing
- Ran `python -m py_compile signals.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b00d5e2cb4832b8a319fea24609e42)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated notional value calculation methodology in Average Daily Volume (ADV) computations to improve accuracy in volume data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->