### PR TITLE
Fix ghost-position absence accounting and tighten data/universe guards

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -57,6 +57,7 @@ class BacktestEngine:
         self.engine              = engine
         self.state               = PortfolioState(cash=initial_cash)
         self.state.equity_hist_cap = engine.cfg.EQUITY_HIST_CAP
+        self.state.max_absent_periods = engine.cfg.MAX_ABSENT_PERIODS
         self.trades:  List[Trade]  = []
         self._eq_dates: list       = []
         self._eq_vals:  list       = []

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -405,6 +405,7 @@ def _run_scan(
     cfg    = cfg_override if cfg_override else load_optimized_config()
     engine = InstitutionalRiskEngine(cfg)
     state.equity_hist_cap = cfg.EQUITY_HIST_CAP
+    state.max_absent_periods = cfg.MAX_ABSENT_PERIODS
 
     today = pd.Timestamp(datetime.today().date())
     next_due = _next_rebalance_due(state.last_rebalance_date, cfg.REBALANCE_FREQ)
@@ -417,9 +418,9 @@ def _run_scan(
             cfg.REBALANCE_FREQ,
         )
 
-    # Pass tomorrow as end_date so load_or_fetch's required_end covers today.
-    # yfinance end= is exclusive, so +1 day ensures today's close is fetched.
-    end_date   = (datetime.today() + timedelta(days=1)).strftime("%Y-%m-%d")
+    # Pass the actual desired terminal date; load_or_fetch applies the
+    # yfinance exclusive-end +1 day correction internally.
+    end_date   = datetime.today().strftime("%Y-%m-%d")
     start_date = (datetime.today() - timedelta(days=400)).strftime("%Y-%m-%d")
 
     # FIX (Bug-D — Delisting Crash / PV Gap): Always include currently-held symbols

--- a/data_cache.py
+++ b/data_cache.py
@@ -267,7 +267,7 @@ def invalidate_cache() -> None:
             logger.error("[Cache] Failed to invalidate cache: %s", e)
 
 
-def _is_valid_dataframe(df: pd.DataFrame) -> bool:
+def _is_valid_dataframe(df: pd.DataFrame, ticker: Optional[str] = None) -> bool:
     """
     Strict structural validation gate applied before any data is written to disk.
 
@@ -293,7 +293,8 @@ def _is_valid_dataframe(df: pd.DataFrame) -> bool:
         return False
     if "Adj Close" not in df.columns or df["Adj Close"].isnull().all():
         return False
-    if "Volume" not in df.columns or df["Volume"].isnull().all():
+    is_index_ticker = bool(ticker) and str(ticker).startswith("^")
+    if (not is_index_ticker) and ("Volume" not in df.columns or df["Volume"].isnull().all()):
         return False
     return True
 
@@ -432,7 +433,7 @@ def load_or_fetch(
                     # Structural validation before anything touches disk.
                     # Catches non-unique/non-monotonic indexes and all-NaN Close
                     # columns that dropna(how='all') cannot detect.
-                    if not _is_valid_dataframe(df):
+                    if not _is_valid_dataframe(df, ticker=ticker):
                         logger.warning(
                             "[Cache] Structural validation failed for %s "
                             "(non-monotonic index, duplicate dates, or null Close). Skipping.",

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -271,6 +271,7 @@ class PortfolioState:
     override_cooldown:    int              = 0
     consecutive_failures: int              = 0
     equity_hist_cap:      int              = 250
+    max_absent_periods:   int              = 12
     absent_periods:       Dict[str, int]   = field(default_factory=dict)
     last_known_prices:    Dict[str, float] = field(default_factory=dict)
     last_known_volatility:Dict[str, float] = field(default_factory=dict)
@@ -361,8 +362,7 @@ class PortfolioState:
                     px = 0.0
                 else:
                     absent_n = int(self.absent_periods.get(sym, 0))
-                    px = absent_symbol_effective_price(last_px, absent_n, 12)
-                    self.absent_periods[sym] = absent_n + 1
+                    px = absent_symbol_effective_price(last_px, absent_n, self.max_absent_periods)
             pv += n_shares * float(px or 0.0)
 
         pv_rounded = round(float(pv), 10)
@@ -386,6 +386,7 @@ class PortfolioState:
             "override_cooldown":    self.override_cooldown,
             "consecutive_failures": self.consecutive_failures,
             "equity_hist_cap":      self.equity_hist_cap,
+            "max_absent_periods":   self.max_absent_periods,
             "absent_periods":       dict(sorted(self.absent_periods.items())),
             "last_known_prices":    _r(self.last_known_prices),
             "last_known_volatility":_r(self.last_known_volatility),
@@ -433,6 +434,7 @@ class PortfolioState:
         ps.override_cooldown    = _get("override_cooldown",    int,                                             0)
         ps.consecutive_failures = _get("consecutive_failures", int,                                             0)
         ps.equity_hist_cap      = _get("equity_hist_cap",      int,                                             250)
+        ps.max_absent_periods   = _get("max_absent_periods",   int,                                             12)
         ps.absent_periods       = _get("absent_periods",       lambda v: {k: int(x) for k, x in v.items()},   {})
         ps.last_known_prices    = _get("last_known_prices",    lambda v: {k: float(x) for k, x in v.items()}, {})
         ps.last_known_volatility= _get("last_known_volatility",lambda v: {k: float(x) for k, x in v.items()}, {})
@@ -609,6 +611,11 @@ def execute_rebalance(
         for _, sym, price, _ in ranked:
             if residual_cash >= price:
                 extra = int(residual_cash // price)
+                max_extra_notional = cfg.MAX_SINGLE_NAME_WEIGHT * pv - desired_shares[sym] * price
+                max_extra_shares = max(0, int(max_extra_notional // price))
+                extra = min(extra, max_extra_shares)
+                if extra <= 0:
+                    continue
                 desired_shares[sym] += extra
                 residual_cash -= extra * price
 

--- a/test_data_cache.py
+++ b/test_data_cache.py
@@ -104,3 +104,31 @@ def test_extract_ticker_frame_fills_adj_close_for_multiindex_payload():
     out = data_cache._extract_ticker_frame(raw, "ABC.NS")
     assert out is not None
     assert out["Adj Close"].equals(out["Close"])
+
+
+def test_is_valid_dataframe_allows_index_ticker_with_nan_volume():
+    idx = pd.date_range("2024-01-01", periods=6, freq="D")
+    df = pd.DataFrame(
+        {
+            "Close": [100, 101, 102, 103, 104, 105],
+            "Adj Close": [100, 101, 102, 103, 104, 105],
+            "Volume": [None, None, None, None, None, None],
+        },
+        index=idx,
+    )
+
+    assert data_cache._is_valid_dataframe(df, ticker="^NSEI")
+
+
+def test_is_valid_dataframe_rejects_non_index_ticker_with_nan_volume():
+    idx = pd.date_range("2024-01-01", periods=6, freq="D")
+    df = pd.DataFrame(
+        {
+            "Close": [100, 101, 102, 103, 104, 105],
+            "Adj Close": [100, 101, 102, 103, 104, 105],
+            "Volume": [None, None, None, None, None, None],
+        },
+        index=idx,
+    )
+
+    assert not data_cache._is_valid_dataframe(df, ticker="ABC.NS")

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -740,7 +740,7 @@ def test_record_eod_applies_absent_haircut_when_price_missing():
 
     ps.record_eod({})
 
-    assert ps.absent_periods["A"] == 1
+    assert ps.absent_periods == {}
     assert ps.equity_hist[-1] == pytest.approx(1000.0, abs=1e-9)
 
 
@@ -1403,3 +1403,32 @@ def test_run_backtest_simulate_halts_does_not_mutate_input_market_data():
 
     assert market_data["AAA.NS"].index.equals(raw.index)
     assert market_data["AAA.NS"]["Close"].equals(raw["Close"])
+
+
+def test_record_eod_uses_state_max_absent_periods_for_haircut():
+    ps = PortfolioState(cash=0.0, max_absent_periods=20)
+    ps.shares = {"A": 10}
+    ps.last_known_prices = {"A": 100.0}
+    ps.absent_periods = {"A": 12}
+
+    ps.record_eod({})
+
+    expected = 10 * absent_symbol_effective_price(100.0, 12, 20)
+    assert ps.equity_hist[-1] == pytest.approx(expected, abs=1e-9)
+
+
+def test_execute_rebalance_residual_cash_respects_single_name_cap():
+    cfg = UltimateConfig(MAX_SINGLE_NAME_WEIGHT=0.25, ROUND_TRIP_SLIPPAGE_BPS=0.0)
+    state = PortfolioState(cash=1_000.0)
+
+    execute_rebalance(
+        state=state,
+        target_weights=np.array([0.25, 0.25], dtype=float),
+        prices=np.array([10.0, 10.0], dtype=float),
+        active_symbols=["A", "B"],
+        cfg=cfg,
+        conviction_scores=np.array([1.0, 0.1], dtype=float),
+    )
+
+    a_notional = state.shares.get("A", 0) * 10.0
+    assert a_notional <= cfg.MAX_SINGLE_NAME_WEIGHT * 1_000.0 + 1e-9

--- a/test_universe_manager.py
+++ b/test_universe_manager.py
@@ -252,3 +252,19 @@ def test_get_sector_map_prefers_batched_yfinance_tickers(monkeypatch):
 
     assert out == {"FOO.NS": "Energy", "BAR.NS": "IT"}
     assert calls["tickers"] == 1
+
+
+def test_apply_adv_filter_deduplicates_ns_equivalents(monkeypatch):
+    import data_cache
+    from momentum_engine import UltimateConfig
+
+    inputs = ["RELIANCE", "RELIANCE.NS", "TCS"]
+
+    def _fake_load_or_fetch(tickers, start, end, cfg=None):
+        return _make_adv_market_data(tickers)
+
+    monkeypatch.setattr(data_cache, "load_or_fetch", _fake_load_or_fetch)
+
+    out = _apply_adv_filter(inputs, UltimateConfig(MIN_ADV_CRORES=1))
+
+    assert out.count("RELIANCE.NS") == 1

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -350,7 +350,7 @@ def _apply_adv_filter(tickers: List[str], cfg=None) -> List[str]:
             f"{len(chunk_failures)} chunk(s); sample symbols: {preview_txt}"
         )
 
-    return filtered_tickers
+    return list(dict.fromkeys(filtered_tickers))
 
 
 


### PR DESCRIPTION
### Motivation
- Prevent silent backtest data corruption from double-counting `absent_periods` by making end-of-day marking purely mark-to-market and letting rebalance logic own absence progression. 
- Make absent-symbol haircut respect runtime configuration instead of a hardcoded `12` periods so operator-set `MAX_ABSENT_PERIODS` is honoured. 
- Eliminate duplicated exclusive-end date adjustments between caller and cache and prevent residual-cash top-ups from breaching single-name concentration caps. 
- Harden market-data ingestion and universe filtering to avoid losing index inputs (NaN Volume) and emitting duplicate `.NS` tickers.

### Description
- Added `max_absent_periods` to `PortfolioState` and serialize/deserialize it so state valuation uses a configurable threshold via `self.max_absent_periods` instead of a literal `12`.
- Removed `absent_periods` increment from `PortfolioState.record_eod()` so absence progression is handled exclusively by `execute_rebalance()` and related rebalance logic.
- Propagated `cfg.MAX_ABSENT_PERIODS` into runtime state in `BacktestEngine.__init__` and `daily_workflow._run_scan` by setting `state.max_absent_periods` during initialization.
- Stopped caller-side `+1 day` end-date adjustment in `daily_workflow._run_scan` and relied on the cache layer's internal `yfinance` exclusive-end `+1` handling in `load_or_fetch`.
- Added a concentration guard in `execute_rebalance()` that clamps residual-cash extra-share allocation so topping-up cannot exceed `cfg.MAX_SINGLE_NAME_WEIGHT` notional.
- Broadened `data_cache._is_valid_dataframe()` to accept an optional `ticker` and allow index tickers (starting with `^`) to pass even when `Volume` is all-NaN, and passed `ticker` into validation calls in `load_or_fetch()`.
- De-duplicated `_apply_adv_filter()` output in `universe_manager` by returning `list(dict.fromkeys(filtered_tickers))` so mixed bare/suffixed inputs yield unique `.NS` symbols.
- Added and updated unit tests that assert the new absence semantics, configurable haircut usage, residual-cash concentration guard, index-volume validation exception, and ADV-filter deduplication.

### Testing
- Ran focused unit tests covering the changes with: `pytest -q test_momentum.py::test_record_eod_applies_absent_haircut_when_price_missing test_momentum.py::test_record_eod_uses_state_max_absent_periods_for_haircut test_momentum.py::test_execute_rebalance_residual_cash_respects_single_name_cap test_data_cache.py::test_is_valid_dataframe_allows_index_ticker_with_nan_volume test_data_cache.py::test_is_valid_dataframe_rejects_non_index_ticker_with_nan_volume test_universe_manager.py::test_apply_adv_filter_deduplicates_ns_equivalents test_daily_workflow.py::test_run_scan_returns_early_when_universe_has_no_data` and all 7 tests passed.
- Ran broader suites with `pytest -q test_data_cache.py test_universe_manager.py test_daily_workflow.py` which completed successfully (26 passed, 1 warning) and `pytest -q test_backtest_engine.py` which passed (1 passed).
- Attempted to run an integration test referenced in the review (`test_book_cvar_screen_with_ghost_resets_failures`) but that test name was not present in this repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0112b0bb0832bb35e9986eaa22882)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable absent-period threshold for portfolio rebalancing.
  * Implemented per-symbol purchase limit enforcement during rebalancing.

* **Bug Fixes**
  * Corrected date handling in data loading pipeline.
  * Fixed validation logic for index tickers with missing volume data.
  * Eliminated duplicate NS-suffixed ticker entries in universe filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->