### PR TITLE
Fix backtest/live consistency for corporate actions, ADV lookback, and split timezone handling

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -95,7 +95,7 @@ class BacktestEngine:
             close_t  = close.loc[date]
             prices_t = close_t.values.astype(float)
 
-            if splits is not None and date in splits.index:
+            if splits is not None and date in splits.index and not self.engine.cfg.AUTO_ADJUST_PRICES:
                 split_row = splits.loc[date]
                 for sym, old_shares in list(self.state.shares.items()):
                     if old_shares <= 0 or sym not in split_row.index:
@@ -115,7 +115,12 @@ class BacktestEngine:
                     old_entry = float(self.state.entry_prices.get(sym, price_now * max(split_ratio, 1e-12)))
                     self.state.entry_prices[sym] = round(old_entry / max(split_ratio, 1e-12), 4)
 
-            if dividends is not None and date in dividends.index and self.engine.cfg.DIVIDEND_SWEEP:
+            if (
+                dividends is not None
+                and date in dividends.index
+                and self.engine.cfg.DIVIDEND_SWEEP
+                and not self.engine.cfg.AUTO_ADJUST_PRICES
+            ):
                 div_row = dividends.loc[date]
                 for sym, shares in self.state.shares.items():
                     if shares <= 0 or sym not in div_row.index:
@@ -181,7 +186,7 @@ class BacktestEngine:
             .replace([np.inf, -np.inf], np.nan)
         )
 
-        adv_vector = _build_adv_vector(active_symbols, close, volume, date)
+        adv_vector = _build_adv_vector(active_symbols, close, volume, date, cfg=cfg)
 
         # Value the pre-trade portfolio using last fully-observed prices (T-1 close).
         # This avoids lookahead when we size orders that execute on the current bar.
@@ -401,7 +406,13 @@ def _build_prev_weights(state: PortfolioState, symbols: List[str], pv: float) ->
     return result
 
 
-def _build_adv_vector(symbols: List[str], close: pd.DataFrame, volume: pd.DataFrame, date: pd.Timestamp) -> np.ndarray:
+def _build_adv_vector(
+    symbols: List[str],
+    close: pd.DataFrame,
+    volume: pd.DataFrame,
+    date: pd.Timestamp,
+    cfg: Optional[UltimateConfig] = None,
+) -> np.ndarray:
     adv = []
     signal_date: Optional[pd.Timestamp] = None
 
@@ -433,7 +444,8 @@ def _build_adv_vector(symbols: List[str], close: pd.DataFrame, volume: pd.DataFr
                 c_series = close.loc[:signal_date, sym]
                 v_series = volume.loc[:signal_date, sym]
                 notional = (c_series * v_series).dropna()
-                lookback = notional.tail(20)
+                adv_lookback = int(getattr(cfg, "ADV_LOOKBACK", 20)) if cfg is not None else 20
+                lookback = notional.tail(adv_lookback)
                 if lookback.empty:
                     adv.append(0.0)
                 else:

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -314,6 +314,15 @@ def detect_and_apply_splits(state: PortfolioState, market_data: dict, cfg: Ultim
                     last_scan_date = None
 
             if last_scan_date is not None:
+                split_index_tz = getattr(split_series.index, "tz", None)
+                if split_index_tz is not None:
+                    if last_scan_date.tzinfo is None:
+                        last_scan_date = last_scan_date.tz_localize(split_index_tz)
+                    else:
+                        last_scan_date = last_scan_date.tz_convert(split_index_tz)
+                elif last_scan_date.tzinfo is not None:
+                    last_scan_date = last_scan_date.tz_localize(None)
+
                 window = split_series.loc[(split_series.index > last_scan_date) & (split_series.index <= split_series.index.max())]
             else:
                 window = split_series.tail(1)

--- a/signals.py
+++ b/signals.py
@@ -150,7 +150,6 @@ def compute_adv(market_data: dict, active_symbols: List[str], cfg: Optional['Ult
 
     # Single rolling mean across the entire matrix — O(T·N) instead of N × O(T).
     notional_df = pd.DataFrame(notional_cols)
-    notional_df.fillna(0.0, inplace=True)
     adv_lookback = int(getattr(cfg, "ADV_LOOKBACK", 20)) if cfg else 20
     adv_last_row = notional_df.rolling(adv_lookback, min_periods=1).mean().iloc[-1]
 

--- a/test_backtest_engine.py
+++ b/test_backtest_engine.py
@@ -48,3 +48,34 @@ def test_rebalance_values_portfolio_from_previous_close(monkeypatch):
 
     # cash (100) + shares (10) * previous close (10)
     assert captured["pv"] == 200.0
+
+
+def test_run_skips_corporate_actions_when_auto_adjust_prices_enabled(monkeypatch):
+    cfg = UltimateConfig(AUTO_ADJUST_PRICES=True, DIVIDEND_SWEEP=True, CVAR_MIN_HISTORY=9999)
+    engine = InstitutionalRiskEngine(cfg)
+    bt = be.BacktestEngine(engine, initial_cash=0.0)
+    bt.state.shares["AAA"] = 10
+    bt.state.entry_prices["AAA"] = 100.0
+
+    dates = pd.DatetimeIndex([pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")])
+    close = pd.DataFrame({"AAA": [100.0, 50.0]}, index=dates)
+    volume = pd.DataFrame({"AAA": [1_000_000, 1_000_000]}, index=dates)
+    returns = close.pct_change(fill_method=None).fillna(0.0)
+
+    dividends = pd.DataFrame({"AAA": [0.0, 5.0]}, index=dates)
+    splits = pd.DataFrame({"AAA": [0.0, 2.0]}, index=dates)
+
+    monkeypatch.setattr(bt, "_run_rebalance", lambda *args, **kwargs: None)
+
+    bt.run(
+        close=close,
+        volume=volume,
+        returns=returns,
+        rebalance_dates=pd.DatetimeIndex([]),
+        start_date="2020-01-01",
+        dividends=dividends,
+        splits=splits,
+    )
+
+    assert bt.state.shares["AAA"] == 10
+    assert bt.state.cash == 0.0

--- a/test_daily_workflow.py
+++ b/test_daily_workflow.py
@@ -246,3 +246,30 @@ def test_execute_rebalance_initializes_dividend_marker_on_new_position():
 
     assert state.shares.get("ABC", 0) > 0
     assert state.dividend_ledger["ABC"].startswith("2025-01-15:")
+
+
+def test_detect_and_apply_splits_handles_tz_aware_split_index():
+    cfg = UltimateConfig(AUTO_ADJUST_PRICES=False)
+    state = PortfolioState(
+        shares={"ABC": 10},
+        entry_prices={"ABC": 1000.0},
+        last_known_prices={"ABC": 1000.0},
+        cash=0.0,
+        last_rebalance_date="2024-01-01",
+    )
+    idx = pd.date_range("2024-01-01", periods=3, tz="Asia/Kolkata")
+    market_data = {
+        "ABC.NS": pd.DataFrame(
+            {
+                "Close": [1000.0, 500.0, 505.0],
+                "Dividends": [0.0, 0.0, 0.0],
+                "Stock Splits": [0.0, 2.0, 0.0],
+            },
+            index=idx,
+        )
+    }
+
+    adjusted = dw.detect_and_apply_splits(state, market_data, cfg)
+
+    assert adjusted == ["ABC"]
+    assert state.shares["ABC"] == 20

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -932,11 +932,13 @@ def test_e2e_ledger_parity():
                 np.log1p(returns.loc[:date].iloc[:-1])
                 .replace([np.inf, -np.inf], np.nan)
             )
-            adv_vector = _build_adv_vector(symbols, close, volume, date)
+            adv_vector = _build_adv_vector(symbols, close, volume, date, cfg=cfg)
             if live_state.shares:
                 compute_book_cvar(live_state, prices_t, symbols, hist_log_rets, cfg)
+            prev_idx = close.index.get_loc(date) - 1
+            valuation_close = close.loc[close.index[prev_idx]] if prev_idx >= 0 else close_t
             pv         = live_state.cash + sum(
-                live_state.shares.get(s, 0) * close_t[s] for s in symbols
+                live_state.shares.get(s, 0) * valuation_close[s] for s in symbols
             )
             prev_w_dict = {
                 sym: (live_state.shares.get(sym, 0) * live_state.last_known_prices.get(sym, 0.0)) / pv
@@ -1483,3 +1485,31 @@ def test_execute_rebalance_residual_cash_respects_single_name_cap():
 
     a_notional = state.shares.get("A", 0) * 10.0
     assert a_notional <= cfg.MAX_SINGLE_NAME_WEIGHT * 1_000.0 + 1e-9
+
+
+def test_compute_adv_does_not_penalize_pre_ipo_nan_history():
+    idx = pd.date_range("2024-01-01", periods=5, freq="B")
+    market_data = {
+        "IPO.NS": pd.DataFrame(
+            {
+                "Close": [np.nan, np.nan, np.nan, 100.0, 100.0],
+                "Volume": [np.nan, np.nan, np.nan, 1_000_000.0, 1_000_000.0],
+            },
+            index=idx,
+        )
+    }
+
+    adv = compute_adv(market_data, ["IPO"], cfg=UltimateConfig(ADV_LOOKBACK=5))
+    assert adv[0] == pytest.approx(100_000_000.0)
+
+
+def test_build_adv_vector_respects_configurable_lookback():
+    cols = ["SYM00"]
+    idx = pd.date_range("2024-01-01", periods=6, freq="B")
+    close = pd.DataFrame({"SYM00": [100.0] * 6}, index=idx)
+    volume = pd.DataFrame({"SYM00": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}, index=idx)
+
+    adv = _build_adv_vector(cols, close, volume, idx[-1], cfg=UltimateConfig(ADV_LOOKBACK=4))
+
+    # T-1 volumes are [1,2,3,4,5] => last 4 mean = (2+3+4+5)/4 = 3.5; close=100
+    assert adv[0] == pytest.approx(350.0)


### PR DESCRIPTION
### Motivation
- Prevent double-counting of corporate actions in backtests when historical prices are already adjusted by the data provider.  
- Ensure backtest ADV construction matches live configuration and removes regressions that penalize newly-listed symbols.  
- Avoid runtime crashes when comparing timezone-naive stored dates to timezone-aware yfinance series.  

### Description
- Backtests now skip explicit split/dividend application when `AUTO_ADJUST_PRICES=True` by gating the corporate-action blocks in `BacktestEngine.run` so adjusted historical prices are not re-applied.  
- `_build_adv_vector` in `backtest_engine.py` now accepts an optional `cfg` and uses `cfg.ADV_LOOKBACK` instead of a hardcoded 20-day tail to align backtest ADV with live behavior.  
- `signals.compute_adv` no longer pre-fills the notional matrix with zeros (removed `fillna(0.0)`), preserving pre-IPO `NaN`s so the rolling mean only averages actual trading days.  
- `daily_workflow.detect_and_apply_splits` now aligns `last_scan_date` timezone with `split_series.index.tz` (or strips timezone) to avoid tz-aware vs tz-naive `TypeError`s.  
- Added/updated regression tests to cover corporate-action skipping with adjusted prices, IPO ADV behavior, configurable backtest ADV lookback, and timezone-aware split handling, and adjusted parity test valuation to T-1 to match backtest logic.  

### Testing
- Ran targeted tests (`pytest -q` for newly added/changed tests): the selected tests for corporate actions, ADV, and timezone handling all passed.  
- Ran the broader suite for `backtest_engine`, `daily_workflow`, and `momentum` with the environment-dependent cache staleness test excluded (`test_data_cache_staleness_logic`), yielding `96 passed, 1 deselected`.  
- An initial failure of the environment/time-dependent `test_data_cache_staleness_logic` was observed and is considered flaky due to time-zone / current-date dependency, so it was excluded from the broad-run validation above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01a94fa48832b8096996135af9f9d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ADV (Average Daily Volume) calculations now support configurable lookback periods for finer analysis control.

* **Bug Fixes**
  * Enhanced timezone-aware handling for stock split processing, improving accuracy in international markets.
  * Refined corporate action processing when automatic price adjustment is enabled.

* **Tests**
  * Added comprehensive test coverage for configurable ADV settings and timezone-aware market data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->