### PR TITLE
Harden cache fallback and clarify historical-universe logging

### DIFF
--- a/data_cache.py
+++ b/data_cache.py
@@ -417,6 +417,31 @@ def load_or_fetch(
                 if raw_data is not None and not raw_data.empty:
                     break
             if raw_data is None or raw_data.empty:
+                recovered = 0
+                for ticker in chunk:
+                    parquet_path = CACHE_DIR / f"{ticker}.parquet"
+                    if not parquet_path.exists():
+                        continue
+                    try:
+                        fallback_df = _normalize_history_index(pd.read_parquet(parquet_path))
+                        if fallback_df is None or fallback_df.empty:
+                            continue
+                        market_data[ticker] = fallback_df
+                        recovered += 1
+                        logger.warning(
+                            "[Cache] Using stale cached parquet for %s after provider failures.",
+                            ticker,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "[Cache] Failed loading stale parquet fallback for %s: %s",
+                            ticker,
+                            exc,
+                        )
+
+                if recovered == len(chunk):
+                    continue
+
                 raise DataFetchError(
                     f"Failed to fetch data for chunk starting with {chunk[0]} after all providers."
                 )

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -217,14 +217,12 @@ def get_historical_universe(universe_type: str, date: pd.Timestamp) -> List[str]
     if csv_members:
         return csv_members
 
-    # Warn once only when both parquet and CSV are unavailable for the date.
-    if not _NO_RECORD_WARNED.get(universe_type):
-        logger.warning(
-            "[Universe] %s: No point-in-time historical record found in parquet/CSV. "
-            "Returning empty universe (survivorship bias risk if caller falls back).",
-            universe_type,
-        )
-        _NO_RECORD_WARNED[universe_type] = True
+    logger.error(
+        "[Universe] %s: No point-in-time historical record found in parquet/CSV. "
+        "Returning empty universe (survivorship bias risk if caller falls back).",
+        universe_type,
+    )
+    _NO_RECORD_WARNED[universe_type] = True
     return []
 
 # ─── Cache Management ─────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Prevent hard failures when all remote providers fail for a download chunk by allowing safe reuse of locally cached parquet files where possible.
- Make the historical-universe logging explicit and visible so operators are clearly warned about survivorship-bias risk when neither parquet nor CSV point-in-time snapshots exist.
- Preserve existing strict failure semantics when no usable cache or provider data is available so callers still get a `DataFetchError` in unrecoverable cases.

### Description
- In `data_cache.py` added a stale-parquet recovery path inside `load_or_fetch` that attempts to load per-ticker cached parquet files for a chunk after all providers fail and will use them when every ticker in the chunk can be recovered, while still raising `DataFetchError` when recovery is incomplete. 
- Kept the normal downstream processing unchanged so fresh `raw_data` is still extracted with `_extract_ticker_frame`, validated with `_is_valid_dataframe`, written to parquet, and checkpointed via `_save_manifest`.
- In `universe_manager.py` adjusted the missing-historical-data messaging so the parquet-missing path is reported, and the final missing-record path emits an explicit survivorship-bias-risk message at error level when both parquet and CSV fallbacks are absent.

### Testing
- Ran the full test suite with `pytest -q` and confirmed all tests pass: `146 passed`.
- Also ran targeted tests `test_universe_manager.py::test_get_historical_universe_warns_when_no_parquet_or_csv`, `test_universe_manager.py::test_get_historical_universe_uses_csv_without_survivorship_warning`, and `test_momentum.py::test_data_cache_staleness_logic`, which all passed prior to the full run.
- No new automated test failures were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01f7a0da8832b93aa07f6ac5cf818)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented fallback recovery from locally cached datasets when primary data fetch operations fail, enabling partial recovery and improved resilience against temporary unavailability.
  * Enhanced error reporting for missing historical records during fallback operations to improve diagnostic visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->