### PR TITLE
Download remote raw archives as fallback and refactor main pipeline

### DIFF
--- a/historical_builder.py
+++ b/historical_builder.py
@@ -6,16 +6,66 @@ Generate point-in-time (PIT) universe snapshots for survivorship-safe backtests.
 
 from __future__ import annotations
 
+import io
 import logging
+import os
 from pathlib import Path
 
 import pandas as pd
+import requests
 
 logger = logging.getLogger(__name__)
 
 # All paths in this module are rooted here.  Change DATA_DIR to relocate
 # the entire historical-data directory without touching individual functions.
+
 DATA_DIR = Path("data")
+
+REMOTE_ARCHIVE_URLS: dict[str, list[str]] = {
+    "nifty500": [
+        "https://raw.githubusercontent.com/india-investing/historical-index-constituents/main/raw_nifty_archives.csv",
+    ],
+    "nse_total": [
+        "https://raw.githubusercontent.com/india-investing/historical-index-constituents/main/raw_nse_total_archives.csv",
+    ],
+}
+
+
+def _candidate_remote_archive_urls(universe_type: str) -> list[str]:
+    env_key = f"HIST_BUILDER_{universe_type.upper()}_ARCHIVE_URL"
+    env_override = os.getenv(env_key, "").strip()
+    urls: list[str] = []
+    if env_override:
+        urls.append(env_override)
+    urls.extend(REMOTE_ARCHIVE_URLS.get(universe_type, []))
+    return [u for u in urls if u]
+
+
+def _download_master_archive(universe_type: str, output_path: Path) -> Path | None:
+    """Attempt to download a raw archive CSV for universe_type."""
+    urls = _candidate_remote_archive_urls(universe_type)
+    if not urls:
+        return None
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    headers = {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+        "Accept": "text/csv,application/csv,text/plain,*/*",
+    }
+    for url in urls:
+        try:
+            resp = requests.get(url, headers=headers, timeout=20)
+            resp.raise_for_status()
+            preview = pd.read_csv(io.StringIO(resp.text), nrows=5)
+            if preview.empty and len(preview.columns) < 2:
+                raise ValueError("downloaded archive does not look like a valid CSV")
+            output_path.write_text(resp.text, encoding="utf-8")
+            logger.info("[HistoricalBuilder] Downloaded %s archive from %s", universe_type, url)
+            return output_path
+        except Exception as exc:
+            logger.warning("[HistoricalBuilder] Download failed for %s from %s: %s", universe_type, url, exc)
+
+    return None
 
 
 def _ns_ticker(sym: str) -> str:
@@ -41,7 +91,12 @@ def _load_master_archive(universe_type: str) -> pd.DataFrame:
     ]
     src = next((p for p in candidates if p.exists()), None)
     if src is None:
-        return pd.DataFrame(columns=["date", "ticker"])
+        download_target = DATA_DIR / f"raw_{universe_type}_archives.csv"
+        downloaded = _download_master_archive(universe_type, download_target)
+        if downloaded is not None and downloaded.exists():
+            src = downloaded
+        else:
+            return pd.DataFrame(columns=["date", "ticker"])
 
     df = pd.read_csv(src)
     cols = {c.lower().strip(): c for c in df.columns}
@@ -236,24 +291,29 @@ def main() -> None:
     Never call bootstrap_historical_parquet() here — it produces a single-row
     stub dated today which makes every historical lookup miss.
     """
+    jobs = [
+        ("nifty500", DATA_DIR / "historical_nifty500.csv", DATA_DIR / "historical_nifty500.parquet"),
+        ("nse_total", DATA_DIR / "historical_nse_total.csv", DATA_DIR / "historical_nse_total.parquet"),
+    ]
+
     print("[HistoricalBuilder] Step 1/2 — Building PIT CSV snapshots...")
-    csv_nifty   = build_historical_csv("nifty500",  str(DATA_DIR / "historical_nifty500.csv"))
-    csv_total   = build_historical_csv("nse_total", str(DATA_DIR / "historical_nse_total.csv"))
-    print(f"  [+] {csv_nifty}")
-    print(f"  [+] {csv_total}")
+    built_csvs: list[Path] = []
+    for universe_type, csv_path, _ in jobs:
+        built = build_historical_csv(universe_type, str(csv_path))
+        built_csvs.append(built)
+        print(f"  [+] {built}")
 
     print("[HistoricalBuilder] Step 2/2 — Converting CSVs to parquet...")
-    pq_nifty  = build_parquet_from_csv(
-        str(DATA_DIR / "historical_nifty500.csv"),  str(DATA_DIR / "historical_nifty500.parquet")
-    )
-    pq_total  = build_parquet_from_csv(
-        str(DATA_DIR / "historical_nse_total.csv"), str(DATA_DIR / "historical_nse_total.parquet")
-    )
-    print(f"  [+] {pq_nifty}")
-    print(f"  [+] {pq_total}")
+    built_parquets: list[Path] = []
+    for _, csv_path, parquet_path in jobs:
+        built = build_parquet_from_csv(str(csv_path), str(parquet_path))
+        built_parquets.append(built)
+        print(f"  [+] {built}")
 
-    print("\n[HistoricalBuilder] All PIT files ready. Backtests will now use "
-          "correct point-in-time constituents without survivorship bias.")
+    print(
+        "\n[HistoricalBuilder] Completed. "
+        f"CSV files: {len(built_csvs)} | parquet files: {len(built_parquets)}."
+    )
 
 
 if __name__ == "__main__":

--- a/test_historical_builder.py
+++ b/test_historical_builder.py
@@ -78,3 +78,37 @@ def test_load_master_archive_supports_wide_date_rows_truthy_filter(tmp_path, mon
     assert set(out["date"]) == {"2020-01-31", "2020-02-28"}
     jan = out[out["date"] == "2020-01-31"]["ticker"].tolist()
     assert jan == ["RELIANCE.NS"]
+
+
+def test_main_downloads_archives_when_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    sample_by_universe = {
+        "nifty500": "date,ticker\n2020-01-31,RELIANCE\n2020-01-31,TCS\n",
+        "nse_total": "date,ticker\n2020-01-31,INFY\n2020-01-31,SBIN\n",
+    }
+
+    class _Resp:
+        def __init__(self, text):
+            self.text = text
+
+        def raise_for_status(self):
+            return None
+
+    def _fake_get(url, headers=None, timeout=20):
+        if "nifty" in url:
+            return _Resp(sample_by_universe["nifty500"])
+        return _Resp(sample_by_universe["nse_total"])
+
+    monkeypatch.setattr(hb, "REMOTE_ARCHIVE_URLS", {
+        "nifty500": ["https://example.com/nifty500.csv"],
+        "nse_total": ["https://example.com/nse_total.csv"],
+    })
+    monkeypatch.setattr(hb.requests, "get", _fake_get)
+
+    hb.main()
+
+    assert (tmp_path / "data" / "raw_nifty500_archives.csv").exists()
+    assert (tmp_path / "data" / "raw_nse_total_archives.csv").exists()
+    assert (tmp_path / "data" / "historical_nifty500.parquet").exists()
+    assert (tmp_path / "data" / "historical_nse_total.parquet").exists()


### PR DESCRIPTION
### Motivation

- Allow the historical builder to run when local raw archive CSVs are not present by downloading canonical archives from remote URLs.
- Provide an environment override for archive URLs via `HIST_BUILDER_{UNIVERSE}_ARCHIVE_URL` for flexibility.
- Simplify and DRY up `main()` by iterating a `jobs` list and printing a concise summary of produced files.

### Description

- Added `REMOTE_ARCHIVE_URLS`, `_candidate_remote_archive_urls`, and `_download_master_archive` to fetch raw CSVs using `requests` and save them under `data/` when local files are missing.
- Updated `_load_master_archive` to attempt a download fallback to `data/raw_{universe}_archives.csv` before returning an empty DataFrame.
- Refactored `main()` to iterate over a `jobs` list to call `build_historical_csv()` and `build_parquet_from_csv()` for each universe and print a summary; added `io`, `os`, and `requests` imports.

### Testing

- Ran unit tests including `test_main_downloads_archives_when_missing`, `test_load_master_archive_supports_wide_date_rows_truthy_filter`, and `test_bootstrap_historical_parquet_warns_stub_content`, and they passed.
- The new test verifies that `hb.main()` downloads `data/raw_*_archives.csv` when missing and produces the corresponding `historical_*.parquet` files in the temporary test directory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b03c61edd4832bba1aa0fca7352f90)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Historical archives are now automatically downloaded from remote sources when local copies are unavailable
  * Batch processing now supports multiple index universes (Nifty500 and NSE Total) simultaneously

<!-- end of auto-generated comment: release notes by coderabbit.ai -->