### PR TITLE
Add resilient fallback URLs for historical archive downloads

### DIFF
--- a/historical_builder.py
+++ b/historical_builder.py
@@ -24,9 +24,16 @@ DATA_DIR = Path("data")
 REMOTE_ARCHIVE_URLS: dict[str, list[str]] = {
     "nifty500": [
         "https://raw.githubusercontent.com/india-investing/historical-index-constituents/main/raw_nifty_archives.csv",
+        "https://raw.githubusercontent.com/india-investing/historical-index-constituents/main/raw_nifty500_archives.csv",
+        "https://raw.githubusercontent.com/india-investing/historical-index-constituents/master/raw_nifty_archives.csv",
+        "https://raw.githubusercontent.com/india-investing/historical-index-constituents/master/raw_nifty500_archives.csv",
+        "https://raw.githubusercontent.com/india-investing/historical-index-constituents/main/data/raw_nifty_archives.csv",
+        "https://raw.githubusercontent.com/india-investing/historical-index-constituents/main/data/raw_nifty500_archives.csv",
     ],
     "nse_total": [
         "https://raw.githubusercontent.com/india-investing/historical-index-constituents/main/raw_nse_total_archives.csv",
+        "https://raw.githubusercontent.com/india-investing/historical-index-constituents/master/raw_nse_total_archives.csv",
+        "https://raw.githubusercontent.com/india-investing/historical-index-constituents/main/data/raw_nse_total_archives.csv",
     ],
 }
 


### PR DESCRIPTION
### Motivation
- The historical archive download for `nifty500` was failing (404) when upstream repository paths or filenames changed, so remote bootstrap must try alternative locations before giving up.

### Description
- Expanded `REMOTE_ARCHIVE_URLS` in `historical_builder.py` for `nifty500` with additional candidate paths including `raw_nifty500_archives.csv`, `master` branch variants, and `data/` subpath variants to tolerate repository layout drift.
- Added similar branch/path fallbacks for `nse_total` so `_download_master_archive()` will iterate more resiliently over candidate URLs.
- No changes to local-file loading behavior; the function still prefers local `data/raw_*.csv` files when present.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed (`147 passed`).
- Unit tests that exercise download/bootstrapping logic (using monkeypatched `requests.get`) also passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b03f518460832b8e54cf663f5e030b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added multiple alternative endpoints for historical data archive access to improve download resilience and availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->