### PR TITLE
Add GitHub tree fallback for historical archive downloads

### DIFF
--- a/historical_builder.py
+++ b/historical_builder.py
@@ -37,6 +37,27 @@ REMOTE_ARCHIVE_URLS: dict[str, list[str]] = {
     ],
 }
 
+GITHUB_TREE_API_URLS: dict[str, list[str]] = {
+    "nifty500": [
+        "https://api.github.com/repos/india-investing/historical-index-constituents/git/trees/main?recursive=1",
+        "https://api.github.com/repos/india-investing/historical-index-constituents/git/trees/master?recursive=1",
+    ],
+    "nse_total": [
+        "https://api.github.com/repos/india-investing/historical-index-constituents/git/trees/main?recursive=1",
+        "https://api.github.com/repos/india-investing/historical-index-constituents/git/trees/master?recursive=1",
+    ],
+}
+
+ARCHIVE_FILE_PATTERNS: dict[str, tuple[str, ...]] = {
+    "nifty500": (
+        "raw_nifty500_archives.csv",
+        "raw_nifty_archives.csv",
+    ),
+    "nse_total": (
+        "raw_nse_total_archives.csv",
+    ),
+}
+
 
 def _candidate_remote_archive_urls(universe_type: str) -> list[str]:
     env_key = f"HIST_BUILDER_{universe_type.upper()}_ARCHIVE_URL"
@@ -72,7 +93,69 @@ def _download_master_archive(universe_type: str, output_path: Path) -> Path | No
         except Exception as exc:
             logger.warning("[HistoricalBuilder] Download failed for %s from %s: %s", universe_type, url, exc)
 
+    discovered = _discover_archive_urls_from_github(universe_type, headers=headers)
+    for url in discovered:
+        try:
+            resp = requests.get(url, headers=headers, timeout=20)
+            resp.raise_for_status()
+            preview = pd.read_csv(io.StringIO(resp.text), nrows=5)
+            if preview.empty and len(preview.columns) < 2:
+                raise ValueError("downloaded archive does not look like a valid CSV")
+            output_path.write_text(resp.text, encoding="utf-8")
+            logger.info("[HistoricalBuilder] Downloaded %s archive via discovered URL %s", universe_type, url)
+            return output_path
+        except Exception as exc:
+            logger.warning(
+                "[HistoricalBuilder] Download failed for %s from discovered URL %s: %s",
+                universe_type,
+                url,
+                exc,
+            )
+
     return None
+
+
+def _discover_archive_urls_from_github(universe_type: str, headers: dict[str, str] | None = None) -> list[str]:
+    patterns = ARCHIVE_FILE_PATTERNS.get(universe_type, ())
+    if not patterns:
+        return []
+
+    matches: list[str] = []
+    seen: set[str] = set()
+    for api_url in GITHUB_TREE_API_URLS.get(universe_type, []):
+        try:
+            resp = requests.get(api_url, headers=headers, timeout=20)
+            resp.raise_for_status()
+            payload = resp.json()
+            tree = payload.get("tree", [])
+            for node in tree:
+                path = str(node.get("path", ""))
+                if not any(path.endswith(name) for name in patterns):
+                    continue
+                if node.get("type") != "blob":
+                    continue
+                raw_url = _github_api_to_raw_url(api_url, path)
+                if raw_url and raw_url not in seen:
+                    seen.add(raw_url)
+                    matches.append(raw_url)
+        except Exception as exc:
+            logger.warning("[HistoricalBuilder] GitHub tree discovery failed for %s: %s", api_url, exc)
+
+    return matches
+
+
+def _github_api_to_raw_url(api_url: str, path: str) -> str:
+    marker = "repos/"
+    if marker not in api_url:
+        return ""
+    repo_part = api_url.split(marker, 1)[1]
+    if "/git/trees/" not in repo_part:
+        return ""
+    owner_repo, branch_part = repo_part.split("/git/trees/", 1)
+    branch = branch_part.split("?", 1)[0].strip()
+    if not owner_repo or not branch or not path:
+        return ""
+    return f"https://raw.githubusercontent.com/{owner_repo}/{branch}/{path}"
 
 
 def _ns_ticker(sym: str) -> str:

--- a/test_historical_builder.py
+++ b/test_historical_builder.py
@@ -112,3 +112,64 @@ def test_main_downloads_archives_when_missing(tmp_path, monkeypatch):
     assert (tmp_path / "data" / "raw_nse_total_archives.csv").exists()
     assert (tmp_path / "data" / "historical_nifty500.parquet").exists()
     assert (tmp_path / "data" / "historical_nse_total.parquet").exists()
+
+
+def test_discover_archive_urls_from_github_tree(monkeypatch):
+    class _Resp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "tree": [
+                    {"path": "data/raw_nifty500_archives.csv", "type": "blob"},
+                    {"path": "README.md", "type": "blob"},
+                ]
+            }
+
+    monkeypatch.setattr(hb.requests, "get", lambda *args, **kwargs: _Resp())
+
+    urls = hb._discover_archive_urls_from_github("nifty500", headers={})
+
+    assert set(urls) == {
+        "https://raw.githubusercontent.com/india-investing/historical-index-constituents/main/data/raw_nifty500_archives.csv",
+        "https://raw.githubusercontent.com/india-investing/historical-index-constituents/master/data/raw_nifty500_archives.csv",
+    }
+
+
+def test_download_master_archive_uses_github_tree_fallback(tmp_path, monkeypatch):
+    out = tmp_path / "data" / "raw_nifty500_archives.csv"
+
+    class _TextResp:
+        def __init__(self, text: str):
+            self.text = text
+
+        def raise_for_status(self):
+            return None
+
+    class _TreeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"tree": [{"path": "data/raw_nifty500_archives.csv", "type": "blob"}]}
+
+    def _fake_get(url, headers=None, timeout=20):
+        if "git/trees" in url:
+            return _TreeResp()
+        if "raw.githubusercontent.com" in url and "data/raw_nifty500_archives.csv" in url:
+            return _TextResp("date,ticker\n2020-01-31,RELIANCE\n")
+        raise Exception("404")
+
+    monkeypatch.setattr(hb, "REMOTE_ARCHIVE_URLS", {"nifty500": ["https://example.com/missing.csv"]})
+    monkeypatch.setattr(hb, "GITHUB_TREE_API_URLS", {
+        "nifty500": [
+            "https://api.github.com/repos/india-investing/historical-index-constituents/git/trees/main?recursive=1"
+        ]
+    })
+    monkeypatch.setattr(hb.requests, "get", _fake_get)
+
+    downloaded = hb._download_master_archive("nifty500", out)
+
+    assert downloaded == out
+    assert out.exists()


### PR DESCRIPTION
### Motivation
- The existing download flow can fail when the hardcoded raw URLs are missing (404), preventing `historical_builder` from building PIT snapshots. 
- A resilient discovery mechanism is needed to locate archive CSVs in the upstream repository when direct raw URLs are unavailable.

### Description
- Add `GITHUB_TREE_API_URLS` and `ARCHIVE_FILE_PATTERNS` to declare repository tree endpoints and candidate archive filenames for each universe. 
- Implement `_discover_archive_urls_from_github()` to query the GitHub tree API, match filenames, and produce raw.githubusercontent.com URLs. 
- Implement `_github_api_to_raw_url()` to convert a GitHub tree API URL and file path into a raw file URL. 
- Update `_download_master_archive()` to attempt discovered raw URLs after trying the configured candidate URLs and preserve existing environment override behavior.

### Testing
- Added two unit tests: `test_discover_archive_urls_from_github_tree` and `test_download_master_archive_uses_github_tree_fallback`, and updated the test suite accordingly. 
- Ran `pytest -q test_historical_builder.py` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0404d8634832bbd5081c39a0519b7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub fallback mechanism for archive data discovery and download when primary sources are unavailable.

* **Tests**
  * Added tests to verify GitHub-based archive discovery and download fallback workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->