### PR TITLE
Fix split valuation, rebalance efficiency, and data-quality edge cases

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -166,6 +166,8 @@ class BacktestEngine:
     ) -> None:
         cfg = self.engine.cfg
 
+        sym_to_global_idx = {sym: i for i, sym in enumerate(symbols)}
+
         active_symbols = symbols
         active_prices = prices_t
         if member_universe is not None:
@@ -173,7 +175,7 @@ class BacktestEngine:
             active_symbols = [sym for sym in symbols if sym in member_set]
             if not active_symbols:
                 return
-            active_positions = [symbols.index(sym) for sym in active_symbols]
+            active_positions = [sym_to_global_idx[sym] for sym in active_symbols]
             active_prices = prices_t[active_positions]
 
         prev_idx = close.index.get_loc(date) - 1
@@ -214,11 +216,10 @@ class BacktestEngine:
         gross_exposure = sum(
             self.state.shares.get(sym, 0) * (
                 float(valuation_close[sym])
-                if pd.notna(valuation_close[sym])
+                if (sym in valuation_close.index and pd.notna(valuation_close[sym]))
                 else _ffill_price(self.state, sym, cfg)
             )
             for sym in self.state.shares
-            if sym in symbols
         ) / max(pv, 1e-6)
 
         self.state.update_exposure(regime_score, realised_cvar, cfg, gross_exposure=gross_exposure)
@@ -585,7 +586,8 @@ def run_backtest(
         row = market_data[key]
         if cfg.SIMULATE_HALTS:
             row = _repair_suspension_gaps(row, key)
-        close_d[sym]  = row["Close"].ffill()
+        valuation_series = row.get("Adj Close", row["Close"]) if cfg.AUTO_ADJUST_PRICES else row["Close"]
+        close_d[sym]  = valuation_series.ffill()
         close_adj_d[sym] = row.get("Adj Close", row["Close"]).ffill()
         open_d[sym] = row.get("Open", row["Close"]).ffill()
         high_d[sym] = row.get("High", row["Close"]).ffill()

--- a/data_cache.py
+++ b/data_cache.py
@@ -358,7 +358,7 @@ def load_or_fetch(
     if _market_closed_today:
         latest_bday = _now_ist.strftime("%Y-%m-%d")
     else:
-        latest_bday = (pd.Timestamp.today() - pd.offsets.BDay(1)).strftime("%Y-%m-%d")
+        latest_bday = (_now_ist - pd.offsets.BDay(1)).strftime("%Y-%m-%d")
     
     tickers_to_download = []
     market_data: Dict[str, pd.DataFrame] = {}

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -696,7 +696,7 @@ def execute_rebalance(
     for sym in symbols_to_force_close:
         close_price = absent_symbol_effective_price(
             state.last_known_prices.get(sym, 0.0),
-            max(0, state.absent_periods.get(sym, 0) - 1),
+            state.absent_periods.get(sym, 0),
             cfg.MAX_ABSENT_PERIODS,
         )
         n_shares    = state.shares.get(sym, 0)
@@ -771,14 +771,24 @@ def compute_book_cvar(
             .dropna()
         )
         for sym, vol in rolling_vol.items():
-            state.last_known_volatility[str(sym)] = float(max(vol, 1e-4))
+            vol_value = float(max(vol, 1e-4))
+            key = str(sym)
+            state.last_known_volatility[key] = vol_value
+            state.last_known_volatility[to_bare(key)] = vol_value
+            state.last_known_volatility[to_ns(key)] = vol_value
 
     ghost_mask = np.array([s not in active_idx for s in held_syms])
     if ghost_mask.any():
         rng = np.random.RandomState(42)
         ghost_cols = sorted(s for s, is_ghost in zip(held_syms, ghost_mask) if is_ghost)
         for sym in ghost_cols:
-            ghost_vol = state.last_known_volatility.get(sym, cfg.GHOST_VOL_FALLBACK)
+            ghost_vol = state.last_known_volatility.get(
+                sym,
+                state.last_known_volatility.get(
+                    to_bare(sym),
+                    state.last_known_volatility.get(to_ns(sym), cfg.GHOST_VOL_FALLBACK),
+                ),
+            )
             ghost_vol = float(max(1e-4, ghost_vol))
             rets.loc[:, sym] = rng.normal(cfg.GHOST_RET_DRIFT, ghost_vol, size=len(rets))
 

--- a/optimizer.py
+++ b/optimizer.py
@@ -272,7 +272,8 @@ class MomentumObjective:
             # Still run the OOS backtest so exceptions propagate (parameters
             # that produce NaN signals in 2019 should be pruned), but do not
             # append its score to the aggregate.
-            exclude_from_score = (oos_year == 2019)
+            first_oos_year = pd.Timestamp(TRAIN_START).year + 1
+            exclude_from_score = (oos_year == first_oos_year)
 
             oos = run_backtest(
                 market_data=self.market_data,

--- a/signals.py
+++ b/signals.py
@@ -225,7 +225,11 @@ def generate_signals(
     # Gate C: Falling Knife Protection
     if len(log_rets) >= cfg.KNIFE_WINDOW:
         recent_simple = np.expm1(log_rets.iloc[-cfg.KNIFE_WINDOW:])
-        recent_cumulative_returns = ((1.0 + recent_simple).prod(min_count=1) - 1.0).values
+        recent_cumulative_returns = (
+            (1.0 + recent_simple)
+            .prod(skipna=False, min_count=cfg.KNIFE_WINDOW)
+            - 1.0
+        ).values
         for i, cumulative_ret in enumerate(recent_cumulative_returns):
             if np.isfinite(cumulative_ret) and cumulative_ret < cfg.KNIFE_THRESHOLD:
                 adj_scores[i] = -np.inf

--- a/test_backtest_engine.py
+++ b/test_backtest_engine.py
@@ -79,3 +79,43 @@ def test_run_skips_corporate_actions_when_auto_adjust_prices_enabled(monkeypatch
 
     assert bt.state.shares["AAA"] == 10
     assert bt.state.cash == 0.0
+
+
+def test_run_backtest_uses_adjusted_close_for_valuation_when_auto_adjust_enabled(monkeypatch):
+    cfg = UltimateConfig(AUTO_ADJUST_PRICES=True, REBALANCE_FREQ="W-FRI")
+
+    dates = pd.DatetimeIndex([pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")])
+    market_data = {
+        "AAA.NS": pd.DataFrame(
+            {
+                "Close": [100.0, 50.0],
+                "Adj Close": [100.0, 100.0],
+                "Open": [100.0, 50.0],
+                "High": [100.0, 50.0],
+                "Low": [100.0, 50.0],
+                "Volume": [1_000_000, 1_000_000],
+                "Dividends": [0.0, 0.0],
+                "Stock Splits": [0.0, 2.0],
+            },
+            index=dates,
+        ),
+        "^NSEI": pd.DataFrame({"Close": [1.0, 1.0]}, index=dates),
+    }
+
+    captured = {}
+
+    def _fake_run(self, close, *_args, **_kwargs):
+        captured["close"] = close.copy()
+        return pd.DataFrame({"equity": pd.Series(dtype=float)})
+
+    monkeypatch.setattr(be.BacktestEngine, "run", _fake_run)
+
+    be.run_backtest(
+        market_data=market_data,
+        start_date="2020-01-01",
+        end_date="2020-01-02",
+        cfg=cfg,
+        universe=["AAA"],
+    )
+
+    assert list(captured["close"]["AAA"]) == [100.0, 100.0]

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -1090,7 +1090,7 @@ def test_ghost_position_single_day_absence_is_preserved():
 
 
 
-def test_force_close_uses_prior_marked_value_without_pv_spike():
+def test_force_close_uses_current_absence_marked_value_without_pv_spike():
     cfg = UltimateConfig(MAX_ABSENT_PERIODS=4, ROUND_TRIP_SLIPPAGE_BPS=0.0)
     state = PortfolioState(cash=0.0)
     state.shares = {"GHOST": 10}
@@ -1109,7 +1109,7 @@ def test_force_close_uses_prior_marked_value_without_pv_spike():
         )
         assert state.cash + current_mtm == pytest.approx(expected_mtm)
 
-    marked_before_close = 10 * absent_symbol_effective_price(100.0, cfg.MAX_ABSENT_PERIODS - 1, cfg.MAX_ABSENT_PERIODS)
+    marked_before_close = 10 * absent_symbol_effective_price(100.0, cfg.MAX_ABSENT_PERIODS, cfg.MAX_ABSENT_PERIODS)
     execute_rebalance(state, target_empty, np.array([]), [], cfg)
 
     assert "GHOST" not in state.shares
@@ -1136,9 +1136,9 @@ def test_ghost_position_delists_after_max_absent_periods():
     assert "DELISTED" not in state.shares, "Position must be closed after MAX_ABSENT_PERIODS."
     sell_trades = [t for t in trade_log if t.symbol == "DELISTED" and t.direction == "SELL"]
     assert sell_trades, "A SELL trade must be logged for the delisted position."
-    expected_close = absent_symbol_effective_price(900.0, cfg.MAX_ABSENT_PERIODS - 1, cfg.MAX_ABSENT_PERIODS)
+    expected_close = absent_symbol_effective_price(900.0, cfg.MAX_ABSENT_PERIODS, cfg.MAX_ABSENT_PERIODS)
     assert sell_trades[-1].exec_price == pytest.approx(expected_close, rel=1e-4), \
-        "Delisted position must be closed at the same prior marked value used for PV."
+        "Delisted position must be closed at the same marked value used for current absence count."
 
 
 def test_decay_rounds_increment_and_counter_reset():

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -286,7 +286,7 @@ def _apply_adv_filter(tickers: List[str], cfg=None) -> List[str]:
         cfg = UltimateConfig()
 
     end_date   = datetime.today().strftime("%Y-%m-%d")
-    start_date = (datetime.today() - timedelta(days=40)).strftime("%Y-%m-%d")
+    start_date = (datetime.today() - timedelta(days=max(150, int(cfg.ADV_LOOKBACK) * 2))).strftime("%Y-%m-%d")
 
     chunk_size  = 75
     chunks      = [tickers[i:i + chunk_size] for i in range(0, len(tickers), chunk_size)]


### PR DESCRIPTION
### Motivation

- Prevent a critical silent PV/CAGR corruption where unadjusted `Close` led to permanent value halving across splits under the default `AUTO_ADJUST_PRICES=True` configuration.  
- Fix correctness and data-quality gaps caused by too-short ADV history fetch windows and a hardcoded optimizer exclusion year.  
- Eliminate an O(N²) rebalance hotspot that used repeated `list.index()` scans and ensure `gross_exposure` includes held symbols even when absent from the current snapshot.  
- Harden several robustness edge-cases including IST business-day drift in cache staleness, NaN-handling in the falling-knife product, volatility key-format divergence, and a force-close N vs N-1 haircut inconsistency.

### Description

- Align valuation with adjusted prices and improve rebalance indexing: `run_backtest`/`backtest_engine.py` now builds the pre-trade valuation series from `Adj Close` when `AUTO_ADJUST_PRICES=True`, precomputes a `sym_to_global_idx` map to avoid repeated `list.index()` calls, and fixes `gross_exposure` to value all held symbols with proper fallback pricing.  
- Extend ADV history and normalize universe fetching: `universe_manager.py` now computes `start_date` as `datetime.today() - timedelta(days=max(150, int(cfg.ADV_LOOKBACK) * 2))` to provide sufficient calendar coverage for rolling ADV.  
- Make optimizer exclusion dynamic: `optimizer.py` replaces the hardcoded `oos_year == 2019` with `first_oos_year = pd.Timestamp(TRAIN_START).year + 1` and derives `exclude_from_score` from it.  
- Miscellaneous robustness fixes: `data_cache.py` computes `latest_bday` from IST (`_now_ist`) consistently; `signals.py` uses `.prod(skipna=False, min_count=cfg.KNIFE_WINDOW)` so NaNs do not act as 0% days; `momentum_engine.py` stores/looks-up `last_known_volatility` under bare and `.NS` forms and uses the current absence-count when computing force-close proceeds; tests updated and a new regression added to cover adjusted-close valuation.

### Testing

- Ran `pytest -q test_backtest_engine.py test_optimizer.py test_data_cache.py test_momentum.py test_daily_workflow.py`.  
- All targeted tests passed (`133 passed`) including the new regression `test_run_backtest_uses_adjusted_close_for_valuation_when_auto_adjust_enabled` and the updated force-close semantics tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f6ac2624832b972e0288388fa50f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data handling to prevent missing symbol errors in exposure calculations.
  * Enhanced volatility lookups across symbol naming variants.
  * Fixed falling knife protection signal filtering to properly handle NaN values.

* **New Features**
  * Dynamic ADV liquidity filter lookback window (adjusted from fixed 40 days based on configuration).
  * Adjusted close price support in halt simulations when price adjustment is enabled.

* **Improvements**
  * Refined out-of-sample backtesting year exclusion logic based on training configuration.
  * Enhanced liquidation pricing calculations.

* **Tests**
  * Added validation for adjusted close valuation in backtests and liquidation pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->