### PR TITLE
Fix backtest crashes for empty market data and non-positive initial capital

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -92,6 +92,10 @@ class BacktestEngine:
         splits:          Optional[pd.DataFrame] = None,
         universe_by_rebalance_date: Optional[Dict[pd.Timestamp, set[str]]] = None,
     ) -> pd.DataFrame:
+        if close.empty:
+            logger.warning("[Backtest] Received empty close dataframe; skipping run.")
+            return pd.DataFrame({"equity": pd.Series(dtype=float)})
+
         start_dt = pd.Timestamp(start_date)
         end_dt   = pd.Timestamp(end_date) if end_date else close.index[-1]
         symbols  = list(close.columns)
@@ -837,6 +841,22 @@ def _compute_metrics(
     periods_per_year: int = 252,
     trades: Optional[List[Trade]] = None,
 ) -> Dict:
+    if initial <= 0:
+        logger.warning(
+            "[Backtest] Non-positive initial capital (%.4f) supplied; returning neutral metrics.",
+            initial,
+        )
+        return {
+            "cagr": 0.0,
+            "max_dd": 0.0,
+            "final": float(eq.iloc[-1]) if not eq.empty else float(initial),
+            "sharpe": 0.0,
+            "sortino": 0.0,
+            "calmar": 0.0,
+            "hit_rate": 0.0,
+            "turnover": 0.0,
+        }
+
     if eq.empty:
         return {
             "cagr": 0.0,

--- a/test_backtest_engine.py
+++ b/test_backtest_engine.py
@@ -124,3 +124,31 @@ def test_run_backtest_uses_adjusted_close_for_valuation_when_auto_adjust_enabled
         )
 
     assert list(captured["close"]["AAA"]) == [100.0, 100.0]
+
+
+def test_backtest_run_handles_empty_close_dataframe():
+    cfg = UltimateConfig()
+    engine = InstitutionalRiskEngine(cfg)
+    bt = be.BacktestEngine(engine)
+
+    empty = pd.DataFrame()
+    out = bt.run(
+        close=empty,
+        volume=empty,
+        returns=empty,
+        rebalance_dates=pd.DatetimeIndex([]),
+        start_date="2020-01-01",
+    )
+
+    assert out.empty
+    assert list(out.columns) == ["equity"]
+
+
+def test_compute_metrics_handles_non_positive_initial_capital():
+    eq = pd.Series([100.0, 110.0], index=pd.date_range("2020-01-01", periods=2, freq="B"))
+
+    metrics = be._compute_metrics(eq, initial=0.0)
+
+    assert metrics["cagr"] == 0.0
+    assert metrics["calmar"] == 0.0
+    assert metrics["final"] == 110.0


### PR DESCRIPTION
### Motivation
- Prevent crashes when the backtest receives no market data or an invalid starting capital, which previously caused indexing errors and invalid metric math.
- Ensure downstream consumers always receive a well-formed results object and numeric metrics even in edge cases.

### Description
- Added an early guard in `BacktestEngine.run()` to detect an empty `close` DataFrame and return an empty equity frame while logging a warning. (`backtest_engine.py`)
- Hardened `_compute_metrics()` to handle non-positive `initial` capital by returning neutral metrics and preserving the final equity when available, avoiding invalid CAGR/divide-by-zero calculations. (`backtest_engine.py`)
- Added regression tests `test_backtest_run_handles_empty_close_dataframe` and `test_compute_metrics_handles_non_positive_initial_capital` to cover both edge cases. (`test_backtest_engine.py`)

### Testing
- Ran the full test suite via `pytest -q`, which completed successfully with all tests passing (`150 passed, 160 warnings`).
- The newly added unit tests passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b25bbc9eb4832b816aff4ed96d095a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backtest engine now gracefully handles empty data by returning empty results with appropriate warnings instead of crashing.
  * Backtest engine now validates initial capital and returns neutral metrics with warnings when invalid values are provided.

* **Tests**
  * Added test coverage for edge cases: empty datasets and invalid initial capital scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->