### PR TITLE
Fix live scan NaN MTM poisoning and preserve residual buy allocations

### DIFF
--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -518,11 +518,15 @@ def _run_scan(
     prices   = close.iloc[-1].values.astype(float)
     active_idx = {sym: i for i, sym in enumerate(active)}
 
-    mtm_notional = sum(
-        state.shares.get(sym, 0) * prices[active_idx[sym]]
-        for sym in state.shares
-        if sym in active_idx
-    )
+    # Guard live PV mark-to-market against feed corruption (e.g., all-NaN close
+    # for a held symbol). NaN here poisons pv and causes optimizer hard-fail.
+    mtm_notional = 0.0
+    for sym in state.shares:
+        if sym in active_idx:
+            px = prices[active_idx[sym]]
+            if np.isnan(px) or px <= 0:
+                px = float(state.last_known_prices.get(sym, 0.0))
+            mtm_notional += state.shares.get(sym, 0) * px
     # FIX (Bug-D — Delisting PV Gap): Include held stocks that are absent from the
     # current scan universe (possibly delisted / suspended) at their last-known
     # price.  Omitting them under-counts total equity, causing the optimizer to

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -761,16 +761,19 @@ def execute_rebalance(
             delta = s - old_s
 
             if delta != 0 and old_s > 0 and s > 0 and not force_rebalance_trades:
-                drift_threshold = getattr(cfg, "DRIFT_TOLERANCE", 0.02)
-                weight_change = abs(delta * price) / max(pv_exec, 1.0)
-                if weight_change < drift_threshold:
-                    s = old_s
-                    delta = 0
-                    new_weights[sym] = old_s * price / max(pv_exec, 1.0)
-                    new_shares[sym]  = old_s
-                    new_entry_prices[sym] = state.entry_prices.get(sym, price)
-                    actual_notional += old_s * price
-                    continue
+                # Apply drift tolerance only to marginal trims. If shares increase,
+                # retain the trade so residual-cash allocation is not stranded.
+                if s < old_s:
+                    drift_threshold = getattr(cfg, "DRIFT_TOLERANCE", 0.02)
+                    weight_change = abs(delta * price) / max(pv_exec, 1.0)
+                    if weight_change < drift_threshold:
+                        s = old_s
+                        delta = 0
+                        new_weights[sym] = old_s * price / max(pv_exec, 1.0)
+                        new_shares[sym]  = old_s
+                        new_entry_prices[sym] = state.entry_prices.get(sym, price)
+                        actual_notional += old_s * price
+                        continue
 
             slip_rate = compute_one_way_slip_rate(
                 cfg=cfg,

--- a/test_daily_workflow.py
+++ b/test_daily_workflow.py
@@ -73,6 +73,53 @@ def test_run_scan_returns_early_when_universe_has_no_data(monkeypatch):
     assert captured["cfg"] is cfg
 
 
+
+
+def test_run_scan_uses_last_known_price_when_live_quote_is_all_nan(monkeypatch):
+    idx = pd.date_range("2024-01-01", periods=6)
+    md = {
+        "BAD.NS": pd.DataFrame({"Close": [float("nan")] * 6, "Dividends": [0.0] * 6}, index=idx),
+        "GOOD.NS": pd.DataFrame({"Close": [100, 101, 102, 103, 104, 105], "Dividends": [0.0] * 6}, index=idx),
+        "^NSEI": pd.DataFrame({"Close": [100] * 6}, index=idx),
+        "^CRSLDX": pd.DataFrame({"Close": [100] * 6}, index=idx),
+    }
+
+    monkeypatch.setattr(dw, "load_or_fetch", lambda *_args, **_kwargs: md)
+    monkeypatch.setattr(dw, "_print_stage_status", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(dw, "detect_and_apply_splits", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(dw, "compute_regime_score", lambda *_args, **_kwargs: 0.5)
+    monkeypatch.setattr(dw, "compute_book_cvar", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(dw, "compute_adv", lambda *_args, **_kwargs: __import__("numpy").array([1e9, 1e9]))
+    monkeypatch.setattr(dw, "get_sector_map", lambda syms, cfg=None: {s: "Unknown" for s in syms})
+    monkeypatch.setattr(dw, "execute_rebalance", lambda *args, **kwargs: 0.0)
+
+    def _fake_generate_signals(*_args, **_kwargs):
+        import numpy as np
+        return np.array([0.0, 0.01]), np.array([0.0, 1.0]), [1], {
+            "total": 2, "history_gated": 2, "adv_gated": 2, "knife_gated": 1, "selected": 1
+        }
+
+    monkeypatch.setattr(dw, "generate_signals", _fake_generate_signals)
+
+    class _Engine:
+        def __init__(self, _cfg):
+            pass
+
+        def optimize(self, **kwargs):
+            import numpy as np
+            assert np.isfinite(kwargs["portfolio_value"])
+            assert kwargs["portfolio_value"] > 0
+            return __import__("numpy").array([1.0])
+
+    monkeypatch.setattr(dw, "InstitutionalRiskEngine", _Engine)
+
+    state = PortfolioState(cash=10_000.0)
+    state.shares = {"BAD": 10}
+    state.entry_prices = {"BAD": 100.0}
+    state.last_known_prices = {"BAD": 99.0}
+
+    dw._run_scan(["BAD", "GOOD"], state, "TEST", cfg_override=UltimateConfig())
+
 def test_load_portfolio_state_raises_when_all_backups_corrupted(tmp_path: Path, monkeypatch):
     data_dir = tmp_path / "data"
     data_dir.mkdir()

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -626,7 +626,30 @@ def test_execute_rebalance_uses_notional_adv_for_impact_parity():
     assert slip_low == pytest.approx(slip_high, rel=1e-6)
 
 
-def test_execute_rebalance_force_rebalance_trades_bypasses_drift_tolerance():
+
+
+def test_execute_rebalance_drift_tolerance_does_not_block_residual_buys():
+    cfg = UltimateConfig(DRIFT_TOLERANCE=0.02, MAX_SINGLE_NAME_WEIGHT=1.0)
+
+    state = PortfolioState(cash=0.0)
+    state.shares = {"A": 100, "B": 100}
+    state.weights = {"A": 0.50, "B": 0.50}
+    state.entry_prices = {"A": 100.0, "B": 100.0}
+    state.last_known_prices = {"A": 100.0, "B": 100.0}
+
+    execute_rebalance(
+        state,
+        target_weights=np.array([0.52, 0.48]),
+        prices=np.array([100.0, 100.0]),
+        active_symbols=["A", "B"],
+        cfg=cfg,
+        force_rebalance_trades=False,
+    )
+
+    assert state.shares["A"] == 104
+    assert state.shares["B"] == 96
+
+def test_execute_rebalance_force_rebalance_trades_still_allows_small_buys():
     cfg = UltimateConfig(DRIFT_TOLERANCE=0.05, MAX_SINGLE_NAME_WEIGHT=1.0)
 
     no_force = PortfolioState(cash=0.0)
@@ -659,7 +682,7 @@ def test_execute_rebalance_force_rebalance_trades_bypasses_drift_tolerance():
         force_rebalance_trades=True,
     )
 
-    assert no_force.shares["A"] == 100
+    assert no_force.shares["A"] == 102
     assert force.shares["A"] == 102
 
 


### PR DESCRIPTION
### Motivation
- Prevent live-scan failures where an all-NaN quote for a held symbol poisons the portfolio value and causes the optimizer to raise `OptimizationError` and halt live trading. 
- Prevent residual-cash allocation from being reverted by the drift-tolerance check which can strand cash after the multi-pass residual sweep.

### Description
- Hardened MTM assembly in `daily_workflow._run_scan` so held symbols with a NaN or non-positive latest close fall back to `state.last_known_prices` when computing `mtm_notional`, avoiding non-finite `pv` values. (`daily_workflow.py`)
- Changed drift-tolerance logic in `execute_rebalance` to apply only to marginal trims (`s < old_s`), thereby allowing buy-side increases produced by the residual-cash sweep to stand. (`momentum_engine.py`)
- Added regression coverage for both fixes by adding `test_run_scan_uses_last_known_price_when_live_quote_is_all_nan` and `test_execute_rebalance_drift_tolerance_does_not_block_residual_buys`, and updated a neighboring drift-related test to reflect the corrected buy-side behavior. (`test_daily_workflow.py`, `test_momentum.py`)

### Testing
- Ran targeted pytest cases for the new/updated regressions: `test_run_scan_uses_last_known_price_when_live_quote_is_all_nan`, `test_execute_rebalance_drift_tolerance_does_not_block_residual_buys`, and the adjacent drift tolerance test `test_execute_rebalance_force_rebalance_trades_still_allows_small_buys`, and all selected tests passed. 
- Files changed: `daily_workflow.py`, `momentum_engine.py`, `test_daily_workflow.py`, and `test_momentum.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3a78418dc832ba25dffb03d596819)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced handling of missing or invalid price data by falling back to historical prices when live quotes are unavailable or invalid.
  * Refined drift tolerance logic to apply exclusively to position reductions, allowing position increases to proceed without drift threshold constraints.

* **Tests**
  * Added comprehensive test coverage for missing price data scenarios and forced rebalance trade execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->