### PR TITLE
Seed optimizer study with a warm-start Optuna trial

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -671,6 +671,16 @@ def run_optimization(
         logger.info("")
 
     try:
+        # Suggest a high-conviction seed so TPE starts from a known robust region.
+        if hasattr(study, "enqueue_trial"):
+            study.enqueue_trial({
+                "HALFLIFE_FAST": 26,
+                "HALFLIFE_SLOW": 57,
+                "CONTINUITY_BONUS": 0.26,
+                "RISK_AVERSION": 10.5,
+                "CVAR_DAILY_LIMIT": 0.056,
+                "CVAR_LOOKBACK": 140,
+            })
         study.optimize(
             objective,
             n_trials=N_TRIALS,


### PR DESCRIPTION
### Motivation
- Give the Optuna TPE a reliable starting point so optimization converges from a known robust region while preserving compatibility with lightweight/mock `Study` objects used in tests.

### Description
- Add a warm-start trial via `study.enqueue_trial({...})` immediately before calling `study.optimize` to seed the search with a high-conviction parameter set in `optimizer.py`.
- Guard the enqueue call with `hasattr(study, "enqueue_trial")` so code works with mock `Study` objects that do not implement `enqueue_trial`.

### Testing
- Compiled the module with `python -m py_compile optimizer.py` which succeeded. 
- Ran unit tests with `pytest -q test_optimizer.py` and all tests passed (`28 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4445432e4832b98de18fb0af48846)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimizer initialization now includes an intelligent pre-seeding strategy, improving convergence speed and solution quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->