### PR TITLE
Use last-known price when force-closing absent symbols

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -825,11 +825,13 @@ def execute_rebalance(
             )
 
     for sym in symbols_to_force_close:
-        close_price = absent_symbol_effective_price(
-            state.last_known_prices.get(sym, 0.0),
-            state.absent_periods.get(sym, 0),
-            cfg.MAX_ABSENT_PERIODS,
-        )
+        # Force-closes should execute at the last known tradable price, not the
+        # fully-haircut absence mark. At the delist threshold, the absence mark
+        # reaches zero by design, which can create an artificial wipeout on names
+        # that are merely missing recent bars. We still use the haircut mark for
+        # in-period MTM/risk, but final liquidation falls back to the last known
+        # positive price when available.
+        close_price = float(state.last_known_prices.get(sym, 0.0))
         n_shares    = state.shares.get(sym, 0)
         if n_shares > 0:
             if close_price > 0:

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -1128,7 +1128,7 @@ def test_ghost_position_single_day_absence_is_preserved():
 
 
 
-def test_force_close_uses_current_absence_marked_value_without_pv_spike():
+def test_force_close_uses_last_known_price_when_symbol_hits_absence_close_threshold():
     cfg = UltimateConfig(MAX_ABSENT_PERIODS=4, ROUND_TRIP_SLIPPAGE_BPS=0.0)
     state = PortfolioState(cash=0.0)
     state.shares = {"GHOST": 10}
@@ -1147,7 +1147,7 @@ def test_force_close_uses_current_absence_marked_value_without_pv_spike():
         )
         assert state.cash + current_mtm == pytest.approx(expected_mtm)
 
-    marked_before_close = 10 * absent_symbol_effective_price(100.0, cfg.MAX_ABSENT_PERIODS, cfg.MAX_ABSENT_PERIODS)
+    marked_before_close = 10 * 100.0
     execute_rebalance(state, target_empty, np.array([]), [], cfg)
 
     assert "GHOST" not in state.shares
@@ -1174,9 +1174,9 @@ def test_ghost_position_delists_after_max_absent_periods():
     assert "DELISTED" not in state.shares, "Position must be closed after MAX_ABSENT_PERIODS."
     sell_trades = [t for t in trade_log if t.symbol == "DELISTED" and t.direction == "SELL"]
     assert sell_trades, "A SELL trade must be logged for the delisted position."
-    expected_close = absent_symbol_effective_price(900.0, cfg.MAX_ABSENT_PERIODS, cfg.MAX_ABSENT_PERIODS)
+    expected_close = 900.0
     assert sell_trades[-1].exec_price == pytest.approx(expected_close, rel=1e-4), \
-        "Delisted position must be closed at the same marked value used for current absence count."
+        "Delisted position must close at the last known price (not a fully-haircut zero mark)."
 
 
 def test_decay_rounds_increment_and_counter_reset():


### PR DESCRIPTION
### Motivation
- Prevent forced liquidations at a zero haircutted mark when a symbol breaches `MAX_ABSENT_PERIODS`, which can artificially wipe out equity in OOS runs.  
- Use the last observed tradable price for final liquidation while retaining haircut-based MTM during absence windows.

### Description
- Change `execute_rebalance` to use `float(state.last_known_prices.get(sym, 0.0))` as the `close_price` for symbols in `symbols_to_force_close` instead of `absent_symbol_effective_price(...)`.  
- Add an explanatory comment clarifying that haircuts are kept for in-period MTM but final liquidation falls back to the last known positive price.  
- Update tests in `test_momentum.py` to expect force-closes at the last-known price (rename one test and adjust assertions accordingly).  
- Modified files: `momentum_engine.py`, `test_momentum.py`.

### Testing
- Ran `pytest -q test_momentum.py -k "absence_close_threshold or ghost_position_delists_after_max_absent_periods"` and the focused test subset passed.  
- Test output: `2 passed, 83 deselected` (tests targeting the absence/force-close behavior succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c8a2e558832ba1bfc5733f86f873)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forced-close pricing to use last known prices instead of applying haircuts for missing market data bars. This prevents artificial position wipeouts when trading data gaps occur and ensures liquidations execute at more realistic prices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->