### PR TITLE
Soft-fail on data-provider chunk failures to avoid aborting backtests

### DIFF
--- a/data_cache.py
+++ b/data_cache.py
@@ -592,9 +592,16 @@ def load_or_fetch(
                 if recovered == len(chunk):
                     continue
 
-                raise DataFetchError(
-                    f"Failed to fetch data for chunk starting with {chunk[0]} after all providers."
+                missing = len(chunk) - recovered
+                logger.error(
+                    "[Cache] Skipping %d symbols from chunk starting with %s after all providers failed.",
+                    missing,
+                    chunk[0],
                 )
+                # Soft-fail to keep scans/backtests running when upstream providers
+                # temporarily reject/rename a subset of symbols. Callers already
+                # handle sparse market_data dictionaries.
+                continue
                 
             for ticker in chunk:
                 try:

--- a/test_data_cache.py
+++ b/test_data_cache.py
@@ -73,22 +73,19 @@ def test_secondary_provider_returns_none_without_api_key(monkeypatch):
     assert out is None
 
 
-def test_load_or_fetch_raises_on_chunk_failure(monkeypatch):
+def test_load_or_fetch_skips_symbols_on_chunk_failure(monkeypatch):
     monkeypatch.setattr(data_cache, "_load_manifest", lambda: {"schema_version": 1, "entries": {}})
     monkeypatch.setattr(data_cache, "_save_manifest", lambda _manifest: None)
     monkeypatch.setattr(data_cache, "_download_with_timeout", lambda *args, **kwargs: pd.DataFrame())
 
-    try:
-        data_cache.load_or_fetch(
-            tickers=["ABC"],
-            required_start="2024-01-01",
-            required_end="2024-01-31",
-            force_refresh=True,
-        )
-    except data_cache.DataFetchError:
-        return
+    out = data_cache.load_or_fetch(
+        tickers=["ABC"],
+        required_start="2024-01-01",
+        required_end="2024-01-31",
+        force_refresh=True,
+    )
 
-    raise AssertionError("Expected DataFetchError for an empty chunk response")
+    assert out == {}
 
 
 


### PR DESCRIPTION
### Motivation
- Backtests and scans were aborting with `DataFetchError` when an entire download chunk failed due to delisted/renamed or temporarily unavailable symbols, reducing resilience of long-running workflows.
- The intent is to allow the system to proceed with available data instead of hard-failing on a subset of missing symbols.

### Description
- Modified `load_or_fetch` in `data_cache.py` to stop raising `DataFetchError` when a download chunk fails after all providers and stale parquet fallbacks are incomplete, and instead log the number of skipped symbols and `continue` processing remaining chunks.
- Added a computed `missing` count and an error log message when skipping symbols, with a short comment explaining the soft-fail rationale.
- Updated `test_data_cache.py` to reflect the new behavior by renaming and changing `test_load_or_fetch_raises_on_chunk_failure` to `test_load_or_fetch_skips_symbols_on_chunk_failure` and asserting that `load_or_fetch` returns an empty dict for an all-failed chunk.

### Testing
- Ran the unit test module with `pytest -q test_data_cache.py`, and all tests passed: `9 passed, 1 warning` (warning is a pandas future warning unrelated to behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4d9a0f68c832b8245da11727d844e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data retrieval resilience: when one or more data sources fail to provide information for a chunk, the system now gracefully handles partial failures by continuing with available results instead of raising an error. Missing symbols are logged for reference, allowing operations to complete with recovered data where possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->