### PR TITLE
Support stepped HALFLIFE bounds in optimizer search space

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -92,8 +92,8 @@ OOS_MAX_DD_CAP = 40.0  # Raised: 35% was too tight (rejected Calmar=1.10 for 36%
 
 # Search space bounds are configurable to support high-risk/high-turnover variants.
 SEARCH_SPACE_BOUNDS = {
-    "HALFLIFE_FAST":    (10, 40),
-    "HALFLIFE_SLOW":    (50, 120),
+    "HALFLIFE_FAST":    (10, 40, 5),
+    "HALFLIFE_SLOW":    (50, 120, 5),
     "CONTINUITY_BONUS": (0.05, 0.30, 0.01),
     # Floor raised 5.0 → 10.0: at RA < 10 the OSQP solver concentrates into
     # 4 positions at the MAX_SINGLE_NAME_WEIGHT cap (25% × 4 = 100% allocation).
@@ -322,10 +322,27 @@ class MomentumObjective:
         cfg = UltimateConfig()
 
         # 2. Define the Search Space (Group A: Alpha & Turnover)
-        halflife_fast_min, halflife_fast_max = self.search_space["HALFLIFE_FAST"]
-        halflife_slow_min, halflife_slow_max = self.search_space["HALFLIFE_SLOW"]
-        cfg.HALFLIFE_FAST = trial.suggest_int("HALFLIFE_FAST", halflife_fast_min, halflife_fast_max)
-        cfg.HALFLIFE_SLOW = trial.suggest_int("HALFLIFE_SLOW", halflife_slow_min, halflife_slow_max)
+        halflife_fast_bounds = self.search_space["HALFLIFE_FAST"]
+        halflife_slow_bounds = self.search_space["HALFLIFE_SLOW"]
+
+        if len(halflife_fast_bounds) == 3:
+            halflife_fast_min, halflife_fast_max, halflife_fast_step = halflife_fast_bounds
+        else:
+            halflife_fast_min, halflife_fast_max = halflife_fast_bounds
+            halflife_fast_step = 1
+
+        if len(halflife_slow_bounds) == 3:
+            halflife_slow_min, halflife_slow_max, halflife_slow_step = halflife_slow_bounds
+        else:
+            halflife_slow_min, halflife_slow_max = halflife_slow_bounds
+            halflife_slow_step = 1
+
+        cfg.HALFLIFE_FAST = trial.suggest_int(
+            "HALFLIFE_FAST", halflife_fast_min, halflife_fast_max, step=halflife_fast_step
+        )
+        cfg.HALFLIFE_SLOW = trial.suggest_int(
+            "HALFLIFE_SLOW", halflife_slow_min, halflife_slow_max, step=halflife_slow_step
+        )
         
         # Logical Constraint: Fast must be strictly faster than slow.
         # FIX O4: With current bounds (FAST max=40, SLOW min=50) this branch is

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -264,6 +264,36 @@ def test_objective_uses_configurable_search_space(monkeypatch):
     assert round(objective(trial), 6) == round(expected, 6)
 
 
+def test_objective_accepts_halflife_bounds_with_step(monkeypatch):
+    class _Result:
+        metrics = {"cagr": 10.0, "max_dd": 5.0, "turnover": 0.0}
+        rebal_log = None
+
+    monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
+
+    custom_space = {
+        "HALFLIFE_FAST": (10, 40, 5),
+        "HALFLIFE_SLOW": (50, 120, 5),
+        "CONTINUITY_BONUS": (0.1, 0.1, 0.01),
+        "RISK_AVERSION": (10.0, 10.0, 0.5),
+        "CVAR_DAILY_LIMIT": (0.04, 0.04, 0.005),
+    }
+    objective = optimizer.MomentumObjective(
+        market_data={}, universe_type="nifty500", search_space=custom_space
+    )
+    trial = optuna.trial.FixedTrial(
+        {
+            "HALFLIFE_FAST": 15,
+            "HALFLIFE_SLOW": 55,
+            "CONTINUITY_BONUS": 0.1,
+            "RISK_AVERSION": 10.0,
+            "CVAR_DAILY_LIMIT": 0.04,
+        }
+    )
+
+    assert isinstance(objective(trial), numbers.Real)
+
+
 def test_run_optimization_forces_single_job(monkeypatch):
     monkeypatch.setattr(optimizer, "N_TRIALS", 1)
     monkeypatch.setattr(optimizer, "N_JOBS", 3)


### PR DESCRIPTION
### Motivation
- The optimizer crashed when `SEARCH_SPACE_BOUNDS` used 3-tuple stepped ranges for `HALFLIFE_FAST`/`HALFLIFE_SLOW` (e.g. `(10, 40, 5)`), so the search-space parsing needed to accept a `step` element.

### Description
- Updated `SEARCH_SPACE_BOUNDS` to use stepped integer ranges for `HALFLIFE_FAST` and `HALFLIFE_SLOW` (`(10, 40, 5)` and `(50, 120, 5)`).
- Modified `MomentumObjective.__call__` to accept either 2-tuple `(min, max)` or 3-tuple `(min, max, step)` for HALFLIFE bounds and forward the resolved `step` into `trial.suggest_int(...)` to avoid the crash while preserving backward compatibility.
- Added a regression test `test_objective_accepts_halflife_bounds_with_step` in `test_optimizer.py` that supplies a custom search space with stepped HALFLIFE bounds and asserts the objective returns a numeric score.

### Testing
- Ran `pytest -q test_optimizer.py -k "configurable_search_space or allows_equal_halflife_values or suggests_cvar_lookback"`, result: `3 passed, 25 deselected` (with optuna FixedTrial warnings about out-of-range fixed values).
- Ran `pytest -q test_optimizer.py -k "accepts_halflife_bounds_with_step or configurable_search_space"`, result: `2 passed, 27 deselected`.
- All exercised automated tests passed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5a611069c832bbeec7708c3537e72)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable step sizes in halflife parameter bounds, enabling finer-grained hyperparameter optimization.
  * Halflife bounds now accept optional step parameters for more precise tuning within specified ranges.
  * Backward compatible: existing configurations without step sizes continue to work with a default step value of 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->