### PR TITLE
Align optimizer data preload with PIT historical universe

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -26,7 +26,7 @@ from optuna.samplers import TPESampler
 from momentum_engine import UltimateConfig, OptimizationError
 from backtest_engine import run_backtest, apply_halt_simulation
 from data_cache import load_or_fetch
-from universe_manager import get_nifty500, fetch_nse_equity_universe
+from universe_manager import get_nifty500, fetch_nse_equity_universe, get_historical_universe
 
 # Suppress solver/sklearn warnings during the thousands of iterations
 warnings.filterwarnings("ignore")
@@ -542,9 +542,6 @@ def pre_load_data(universe_type: str, cfg: UltimateConfig | None = None) -> dict
         logger.warning(f"Unknown universe_type '{universe_type}', falling back to nifty500")
         base_universe = get_nifty500() 
         
-    # Ensure index data is present for regime scoring
-    symbols_to_fetch = list(dict.fromkeys(base_universe + ["^NSEI", "^CRSLDX"]))
-
     if cfg is None:
         cfg = UltimateConfig()
         cvar_bounds = SEARCH_SPACE_BOUNDS.get("CVAR_LOOKBACK")
@@ -560,6 +557,39 @@ def pre_load_data(universe_type: str, cfg: UltimateConfig | None = None) -> dict
             halflife_calendar_days = halflife_slow_max * 4 * 365 // 252
             current_cvar_padding = max(400, cfg.CVAR_LOOKBACK * 2)
             cfg._pre_load_padding_days = max(current_cvar_padding, halflife_calendar_days)
+
+    # MB-18 FIX: Build the optimization preload from the SAME point-in-time
+    # historical membership snapshots that run_backtest uses.
+    #
+    # Root cause fixed:
+    # pre_load_data previously fetched only today's base universe. During
+    # run_backtest, the engine dynamically switches members by historical
+    # rebalance date. Any historical member absent from today's list had no
+    # market_data frame and was logged as "missing data", causing noisy logs
+    # and optimizer OOS vs daily_workflow backtest mismatches.
+    #
+    # By unioning historical members across TRAIN_START→TEST_END at the exact
+    # rebalance cadence, optimizer and daily_workflow now hydrate the same
+    # symbol set and produce consistent replay conditions.
+    historical_union: set[str] = set()
+    try:
+        all_target_dates = pd.date_range(TRAIN_START, TEST_END, freq=cfg.REBALANCE_FREQ)
+        for target_date in all_target_dates:
+            historical_union.update(get_historical_universe(normalized_universe, pd.Timestamp(target_date)))
+    except Exception as exc:
+        logger.warning(
+            "Historical universe preload failed for %s (%s). Falling back to base universe only.",
+            normalized_universe,
+            exc,
+        )
+
+    if historical_union:
+        preload_universe = list(dict.fromkeys(base_universe + sorted(historical_union)))
+    else:
+        preload_universe = list(base_universe)
+
+    # Ensure index data is present for regime scoring
+    symbols_to_fetch = list(dict.fromkeys(preload_universe + ["^NSEI", "^CRSLDX"]))
 
     logger.info(f"Fetching {len(symbols_to_fetch)} symbols from {TRAIN_START} to {TEST_END}...")
     kwargs = dict(tickers=symbols_to_fetch, required_start=TRAIN_START, required_end=TEST_END)

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -188,6 +188,45 @@ def test_pre_load_data_deduplicates_inputs_and_appends_crsldx_index(monkeypatch)
     assert "^CRSLDX" in captured["tickers"]
 
 
+def test_pre_load_data_includes_historical_union_for_nifty500(monkeypatch):
+    monkeypatch.setattr(optimizer, "TRAIN_START", "2020-01-01")
+    monkeypatch.setattr(optimizer, "TEST_END", "2020-03-31")
+    monkeypatch.setattr(optimizer, "get_nifty500", lambda: ["LIVEONLY"])
+    monkeypatch.setattr(optimizer, "apply_halt_simulation", lambda md: md)
+
+    def _fake_hist(universe_type, date):
+        assert universe_type == "nifty500"
+        if pd.Timestamp(date) == pd.Timestamp("2020-01-31"):
+            return ["OLD1", "OLD2"]
+        if pd.Timestamp(date) == pd.Timestamp("2020-02-29"):
+            return ["OLD2", "OLD3"]
+        return []
+
+    monkeypatch.setattr(optimizer, "get_historical_universe", _fake_hist)
+
+    captured = {}
+
+    def _fake_load_or_fetch(*, tickers, required_start, required_end, cfg=None):
+        captured["tickers"] = tickers
+        captured["required_start"] = required_start
+        captured["required_end"] = required_end
+        return {"ok": True}
+
+    monkeypatch.setattr(optimizer, "load_or_fetch", _fake_load_or_fetch)
+
+    result = optimizer.pre_load_data("nifty500")
+
+    assert result == {"ok": True}
+    assert captured["required_start"] == "2020-01-01"
+    assert captured["required_end"] == "2020-03-31"
+    assert "LIVEONLY" in captured["tickers"]
+    assert "OLD1" in captured["tickers"]
+    assert "OLD2" in captured["tickers"]
+    assert "OLD3" in captured["tickers"]
+    assert "^NSEI" in captured["tickers"]
+    assert "^CRSLDX" in captured["tickers"]
+
+
 def test_build_sampler_returns_tpe_sampler(monkeypatch):
     monkeypatch.setattr(optimizer, "OPTUNA_SEED", None)
     sampler_unseeded = optimizer._build_sampler()


### PR DESCRIPTION
### Motivation
- The optimizer previously preloaded only the current universe members which caused missing-market-data logs and mismatched backtest/OOS behavior when `run_backtest` used point-in-time (PIT) historical constituents. 
- Daily workflow/backtest builds a union of historical constituents per rebalance date, so the optimizer needed to hydrate the same symbol set to ensure consistent replay conditions. 
- The Groww provider and provider chain can still fall back for older history, but the core bug was symbols absent from the optimizer's preload set rather than a missing API token.

### Description
- Updated `pre_load_data` in `optimizer.py` to import and call `get_historical_universe` and union PIT members across `TRAIN_START -> TEST_END` at the configured `REBALANCE_FREQ` to form `historical_union`.
- Built `preload_universe` = `base_universe` + sorted `historical_union` (with deterministic deduplication) and used that plus indices `^NSEI` and `^CRSLDX` as `symbols_to_fetch` for `load_or_fetch` so optimizer and backtest hydrate the same set of tickers.
- Added a safe fallback: if historical snapshot iteration fails, the code falls back to the original `base_universe` behavior and logs a warning.
- Added a regression test `test_pre_load_data_includes_historical_union_for_nifty500` in `test_optimizer.py` to assert that `pre_load_data('nifty500')` requests both live and historical-only symbols.
- Added explanatory comments documenting the root cause and the MB-18 fix in `optimizer.py`.

### Testing
- Ran static/compile check with `python -m py_compile optimizer.py test_optimizer.py`, which completed successfully.
- Ran `pytest -q test_optimizer.py` in this environment; the test module was skipped (1 skipped) due to the test harness using `pytest.importorskip('optimizer')`, so tests were not executed here; the new regression test is included and will run where full runtime dependencies are available.
- Attempted running the two specific pre-load tests directly; the environment returned no collectors for the targeted `pytest` invocation so those targeted runs did not execute here (this is an environment/test-harness artifact, not a logic failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6cd88acc0832b9fdae26a2f0d9fc0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Historical universe data now integrated into preload operations for improved consistency.
  * Enhanced symbol coverage ensures all relevant data is available during optimization.

* **Bug Fixes**
  * Improved consistency between optimizer preload and backtest execution.
  * Added robust error handling with fallback for data preload operations.

* **Tests**
  * Added test coverage for historical universe integration in data preloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->