### PR TITLE
Harden cache parsing for object-typed yfinance corporate actions

### DIFF
--- a/data_cache.py
+++ b/data_cache.py
@@ -688,6 +688,31 @@ def _ensure_price_columns(df: pd.DataFrame) -> pd.DataFrame:
     out = df.copy()
     out = out.loc[:, out.columns.notna()]
 
+    numeric_cols = [
+        "Open", "High", "Low", "Close", "Adj Close",
+        "Volume", "Dividends", "Stock Splits",
+    ]
+
+    def _coerce_numeric_series(series: pd.Series) -> pd.Series:
+        if pd.api.types.is_numeric_dtype(series):
+            return series
+
+        # yfinance occasionally returns object-typed corporate-action values
+        # such as "2.6 INR". Strip known textual/formatting artifacts before
+        # numeric coercion so parquet writes never fail on object payloads.
+        cleaned = (
+            series.astype(str)
+            .str.replace(",", "", regex=False)
+            .str.replace("INR", "", regex=False)
+            .str.strip()
+        )
+        cleaned = cleaned.mask(cleaned.isin(["", "nan", "None"]))
+        return pd.to_numeric(cleaned, errors="coerce")
+
+    for col in numeric_cols:
+        if col in out.columns:
+            out[col] = _coerce_numeric_series(out[col])
+
     if "Adj Close" not in out.columns:
         if "Close" in out.columns:
             out["Adj Close"] = out["Close"]

--- a/test_data_cache.py
+++ b/test_data_cache.py
@@ -138,7 +138,7 @@ def test_extract_ticker_frame_fills_adj_close_for_multiindex_payload():
     )
     out = data_cache._extract_ticker_frame(raw, "ABC.NS")
     assert out is not None
-    assert out["Adj Close"].equals(out["Close"])
+    assert (out["Adj Close"] == out["Close"]).all()
 
 
 def test_is_valid_dataframe_allows_index_ticker_with_nan_volume():
@@ -183,3 +183,23 @@ def test_load_local_env_file_sets_missing_keys_only(tmp_path, monkeypatch):
 
     assert os.getenv("GROWW_API_TOKEN") == "from_file"
     assert os.getenv("EXISTING_KEY") == "already_set"
+
+
+def test_ensure_price_columns_coerces_object_dividends_and_prices():
+    idx = pd.date_range("2024-01-01", periods=3, freq="D")
+    raw = pd.DataFrame(
+        {
+            "Close": ["100", "101.5", "102"],
+            "Adj Close": ["100", "101.5", "102"],
+            "Volume": ["1,000", "2,000", "3,000"],
+            "Dividends": ["0", "2.6 INR", None],
+            "Stock Splits": ["0", "0", "0"],
+        },
+        index=idx,
+    )
+
+    out = data_cache._ensure_price_columns(raw)
+
+    assert out["Dividends"].dtype.kind in "fc"
+    assert out["Dividends"].iloc[1] == 2.6
+    assert out["Volume"].iloc[0] == 1000


### PR DESCRIPTION
### Motivation
- yfinance sometimes returns object-typed values for prices and corporate actions (e.g. `"2.6 INR"` or comma-formatted numbers) which can break numeric validation and parquet persistence during cache writes.
- The cache must normalize these provider quirks so downstream validators and persistence never see object-typed numeric columns.

### Description
- Added numeric coercion in `data_cache._ensure_price_columns` for `Open`, `High`, `Low`, `Close`, `Adj Close`, `Volume`, `Dividends`, and `Stock Splits` that strips commas and `INR`, trims whitespace, masks empty-like values, and converts to numeric with `errors="coerce"`.
- Ensured existing `Adj Close` filling logic still runs after coercion to preserve adjustment behavior.
- Replaced a strict Series-equality assertion in a test with a value-based equality check to be robust to dtype changes.
- Added a regression test `test_ensure_price_columns_coerces_object_dividends_and_prices` that verifies `Dividends` and `Volume` are coerced to numeric values.

### Testing
- Ran `pytest -q test_data_cache.py` and all tests in that module passed (11 passed).
- Ran `pytest -q test_optimizer.py` in this environment which produced a skip for the module (1 skipped) and no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d158fa30832b866f0f9094bd286d)