### PR TITLE
Improve yfinance resilience with per-ticker fallback

### DIFF
--- a/data_cache.py
+++ b/data_cache.py
@@ -408,21 +408,60 @@ class GrowwProvider(DataProvider):
 
 class YFinanceProvider(DataProvider):
     def download(self, tickers: List[str], start: str, end: str) -> Optional[pd.DataFrame]:
-        result = yf.download(
-            tickers,
-            start=start,
-            end=end,
-            progress=False,
-            auto_adjust=False,
-            actions=True,
-        )
+        result = self._download_batch(tickers, start, end)
         if result is None:
             return None
+
+        # yfinance can occasionally return an empty frame for an otherwise valid
+        # multi-ticker request (crumb/rate-limit/session glitches). When that
+        # happens, degrade to one-by-one requests so healthy symbols are still
+        # captured instead of dropping the full chunk.
+        if len(tickers) > 1 and result.empty:
+            recovered = self._download_individual(tickers, start, end)
+            if recovered is not None and not recovered.empty:
+                return recovered
+
         if result.empty:
             return result
         if len(tickers) > 1 and not isinstance(result.columns, pd.MultiIndex):
             return None
         return result
+
+    def _download_batch(self, tickers: List[str], start: str, end: str) -> Optional[pd.DataFrame]:
+        try:
+            return yf.download(
+                tickers,
+                start=start,
+                end=end,
+                progress=False,
+                auto_adjust=False,
+                actions=True,
+            )
+        except Exception as exc:
+            logger.warning("[Cache] yfinance batch download failed for %d tickers: %s", len(tickers), exc)
+            return None
+
+    def _download_individual(self, tickers: List[str], start: str, end: str) -> Optional[pd.DataFrame]:
+        frames: Dict[str, pd.DataFrame] = {}
+        for ticker in tickers:
+            single = self._download_batch([ticker], start, end)
+            if single is None or single.empty:
+                continue
+
+            frame = _extract_ticker_frame(single, ticker, is_single_request=True)
+            if frame is None or frame.empty:
+                continue
+            frames[ticker] = frame
+
+        if not frames:
+            return None
+
+        combined = pd.concat(frames, axis=1)
+        combined.columns = pd.MultiIndex.from_tuples(
+            [(col, ticker) for ticker, col in combined.columns],
+            names=["Price", "Ticker"],
+        )
+        return _normalize_history_index(combined.swaplevel(0, 1, axis=1).sort_index(axis=1))
 
 
 class SecondaryProvider(DataProvider):


### PR DESCRIPTION
### Motivation
- Large multi-ticker downloads from yfinance can intermittently return an empty DataFrame (crumb/rate-limit/session glitches), causing entire chunks of symbols to be treated as failures and skipped. 
- The optimizer's universe coverage and downstream results were degraded when those transient batch failures wiped out otherwise-healthy symbols. 
- The change aims to preserve partial successes and reduce avoidable data loss during cache population.

### Description
- Refactored `YFinanceProvider.download` to call a new helper ` _download_batch` that wraps `yfinance.download` and logs batch-level exceptions. 
- When a multi-ticker batch returns an empty DataFrame, the provider now falls back to `_download_individual`, which requests each ticker one-by-one and extracts valid frames via `_extract_ticker_frame`. 
- `_download_individual` merges per-ticker results into the expected `(field, ticker)` `MultiIndex` layout and normalizes the index with `_normalize_history_index` before returning. 
- This preserves schema compatibility while improving resilience and observability (warning log on batch failure).

### Testing
- Ran `python -m pytest -q test_data_cache.py`, and all tests passed (`11 passed`).
- Ran `python -m pytest -q test_optimizer.py` in this environment and the suite reported the module as skipped (`1 skipped`).
- No regressions observed in the cache unit tests after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d3e492cc832b8cc6d5bac8319f10)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data download reliability with enhanced fallback mechanisms for multi-ticker data retrieval.
  * Better error handling to ensure more complete results when downloads encounter issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->