### PR TITLE
Make dotenv optional and bump version to 11.48

### DIFF
--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -6,8 +6,12 @@ Features robust capital management, direct Screener.in web scraping,
 Dividend Sweeping, and Impact-Aligned Rebalancing.
 """
 from __future__ import annotations
-from dotenv import load_dotenv
-load_dotenv()
+import importlib.util
+
+if importlib.util.find_spec("dotenv") is not None:
+    from dotenv import load_dotenv
+
+    load_dotenv()
 
 import argparse
 import copy
@@ -50,7 +54,7 @@ from data_cache import get_cache_summary, invalidate_cache, load_or_fetch
 from backtest_engine import run_backtest, print_backtest_results
 from signals import generate_signals, compute_adv, compute_regime_score
 
-__version__ = "11.46"
+__version__ = "11.48"
 
 BACKUP_GENERATIONS = 3
 PAPER_MODE = False


### PR DESCRIPTION
### Motivation
- Allow `daily_workflow.py` to run even when `python-dotenv` is not installed by avoiding an unconditional import and load, and update the module version.

### Description
- Use `importlib.util.find_spec` to conditionally import and call `load_dotenv()` only if the `dotenv` package is available, replacing the previous unconditional `from dotenv import load_dotenv` and `load_dotenv()`; also update `__version__` from `11.46` to `11.48`.

### Testing
- Performed an import smoke test by running `python -c "import daily_workflow"` with and without `dotenv` installed and ran the project's unit test suite; the import smoke test and unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6f3c4a298832ba77adc106bcab1d1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced application stability through intelligent dependency handling. The system now gracefully manages optional packages, continuing operation even when certain dependencies are unavailable, ensuring a more reliable user experience.

* **Chores**
  * Version updated to 11.48.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->