### PR TITLE
Fix rebalance capital accounting and relax optimizer exposure penalty

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -666,8 +666,9 @@ def execute_rebalance(
             w = 0.0
         price = max(float(local_prices[i]), 1e-6)
         
-        # Sizing intent bounded precisely by T-1 values (pv_t1)
-        s = int(np.floor(w * pv_t1 / price)) if w > 0.001 else 0
+        # Size strictly against executable T+0 portfolio value to avoid oversizing
+        # into gap-down opens that can force negative cash and phantom P&L.
+        s = int(np.floor(w * pv_exec / price)) if w > 0.001 else 0
         
         # 4. LIQUIDITY CONSTRAINT ENFORCEMENT: Enforce strict ADV limit
         if adv_shares is not None and i < len(adv_shares):
@@ -695,7 +696,7 @@ def execute_rebalance(
     # after their cap is hit.  Passes repeat until residual is exhausted or no uncapped
     # assets remain.  Convergence is guaranteed: each pass either exhausts residual or
     # removes at least one asset from eligible.
-    residual_cash = max(0.0, min(pv_t1, pv_exec) - base_notional)
+    residual_cash = max(0.0, pv_exec - base_notional)
 
     if valid_targets and residual_cash > 0:
         eligible = {
@@ -727,7 +728,7 @@ def execute_rebalance(
                         to_remove.append(sym)
                     continue
 
-                headroom_notional = cfg.MAX_SINGLE_NAME_WEIGHT * pv_t1 - desired_shares[sym] * price
+                headroom_notional = cfg.MAX_SINGLE_NAME_WEIGHT * pv_exec - desired_shares[sym] * price
                 max_extra_weight  = max(0, int(headroom_notional // price))
 
                 max_extra_adv = extra  # no ADV cap by default

--- a/optimizer.py
+++ b/optimizer.py
@@ -306,7 +306,7 @@ def _fitness_from_metrics(
     dd_excess  = max(0.0, max_dd - IS_DD_PENALTY_PCT)
     dd_penalty = (dd_excess ** 2) / 50.0
 
-    exposure_penalty = 0.0 if avg_exposure >= 0.75 else (0.75 - avg_exposure) * 5.0
+    exposure_penalty = 0.0 if avg_exposure >= 0.60 else (0.60 - avg_exposure) * 3.0
     if avg_positions < 1.0:
         exposure_penalty += 0.5
 


### PR DESCRIPTION
### Motivation
- Prevent gap-down oversizing in `execute_rebalance()` that could drive `state.cash` negative and produce phantom P&L which triggers the anomaly gate. 
- Ensure residual allocation and single-name headroom are capped against the actual executable T+0 portfolio value to keep sizing conservative and realistic. 
- Reduce optimizer over-penalization of intentional de-risking (holding cash) so valid crisis hedging is not driven to negative fitness. 

### Description
- In `momentum_engine.py` updated `execute_rebalance()` base sizing to compute target shares against the executable T+0 portfolio value (`pv_exec`) instead of `pv_t1`. 
- In `momentum_engine.py` changed the residual cash baseline to use `pv_exec - base_notional` and aligned the single-name headroom cap to `pv_exec` during multi-pass residual allocation. 
- In `optimizer.py` relaxed the exposure penalty in `_fitness_from_metrics()` from `0.75`/`*5.0` to `0.60`/`*3.0` so average exposure down to 0.60 is permitted without heavy penalty. 
- Modified files: `momentum_engine.py` and `optimizer.py`.

### Testing
- Ran the full test suite with `pytest -q` which completed successfully. 
- Test result: `162 passed` (with expected warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7916e4930832bba448e48ec71b84c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected position sizing during rebalancing to use current execution prices instead of previous close values, preventing unintended oversizing during gap-down market openings.

* **Optimizations**
  * Reduced exposure penalty thresholds in the portfolio optimization algorithm, enabling more balanced asset allocations with less aggressive constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->