### PR TITLE
Fix Optuna rebalance fallback crash and OSQP inaccurate-solve exposure scaling

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -1408,9 +1408,13 @@ class InstitutionalRiskEngine:
             )
             w_sum = float(np.sum(w_opt))
             if w_sum > 1e-9:
-                w_opt = w_opt * (gamma / w_sum)
-                # Preserve hard concentration caps after inaccurate-solve rescaling.
                 w_opt = np.minimum(w_opt, adv_limit)
+                # Preserve hard concentration caps and avoid scaling up capped
+                # assets back into liquidity breaches. For inaccurate solves,
+                # correcting leverage leaks takes precedence over forcing exact γ.
+                clipped_sum = float(np.sum(w_opt))
+                if clipped_sum > 1e-9 and clipped_sum > gamma:
+                    w_opt = w_opt * (gamma / clipped_sum)
 
         portfolio_losses  = losses @ w_opt
         sorted_losses     = np.sort(portfolio_losses)

--- a/optimizer.py
+++ b/optimizer.py
@@ -253,9 +253,10 @@ def _fitness_from_metrics(
     n_rebalances = 0
 
     if rebal_log is not None and not rebal_log.empty:
-        avg_cvar = float(pd.to_numeric(rebal_log.get("realised_cvar", 0.0), errors="coerce").fillna(0.0).mean())
-        avg_exposure = float(pd.to_numeric(rebal_log.get("exposure_multiplier", 0.0), errors="coerce").fillna(0.0).mean())
-        avg_positions = float(pd.to_numeric(rebal_log.get("n_positions", 0.0), errors="coerce").fillna(0.0).mean())
+        fallback_series = pd.Series([0.0])
+        avg_cvar = float(pd.to_numeric(rebal_log.get("realised_cvar", fallback_series), errors="coerce").fillna(0.0).mean())
+        avg_exposure = float(pd.to_numeric(rebal_log.get("exposure_multiplier", fallback_series), errors="coerce").fillna(0.0).mean())
+        avg_positions = float(pd.to_numeric(rebal_log.get("n_positions", fallback_series), errors="coerce").fillna(0.0).mean())
         n_rebalances = len(rebal_log)
 
     # ── Concentration multiplier ──────────────────────────────────────────────

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -238,6 +238,26 @@ def test_build_sampler_returns_tpe_sampler(monkeypatch):
     assert isinstance(sampler_seeded, optimizer.TPESampler)
 
 
+def test_fitness_from_metrics_handles_missing_rebalance_columns_without_crash():
+    metrics = {
+        "cagr": 12.0,
+        "max_dd": 10.0,
+        "turnover": 5.0,
+        "sortino": 1.2,
+        "final": optimizer.BASE_INITIAL_CAPITAL * 1.1,
+    }
+    # Missing realised_cvar / exposure_multiplier / n_positions columns used in
+    # diagnostics extraction. Function must use a Series fallback and not raise.
+    rebal_log = pd.DataFrame({"date": pd.date_range("2024-01-01", periods=2, freq="D")})
+
+    score, diag = optimizer._fitness_from_metrics(metrics, rebal_log)
+
+    assert isinstance(score, float)
+    assert diag["avg_cvar_pct"] == pytest.approx(0.0)
+    assert diag["avg_exposure"] == pytest.approx(0.0)
+    assert diag["avg_positions"] == pytest.approx(0.0)
+
+
 
 
 def test_objective_suggests_cvar_lookback_for_non_fixed_trials(monkeypatch):


### PR DESCRIPTION
### Motivation
- Prevent Optuna runs from crashing when `rebal_log` is missing expected columns by ensuring numeric aggregation defaults behave like a Series, not a scalar. 
- Avoid liquidity/exposure leaks when OSQP returns an inaccurate solution by ensuring we do not scale assets back into ADV breaches during fallback normalization. 
- Add a regression to guard the fitness-path against regressions and to make the fix observable in CI.

### Description
- In `optimizer.py` updated `_fitness_from_metrics()` to use `fallback_series = pd.Series([0.0])` and pass that to `rebal_log.get(...)` so `.fillna()`/`.mean()` operate on a Series instead of a scalar. 
- In `momentum_engine.py` adjusted the `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b795324f84832b86ab0f2cccd00e39)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Weight optimization now enforces concentration caps and prevents leverage breaches with additional rescaling
  * Fitness calculation now handles missing metric data with fallback values for more robust operation

* **Tests**
  * Added test coverage for missing rebalance column handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->