### PR TITLE
Fix CVaR optimizer math and tighten slack penalty

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -204,7 +204,7 @@ class UltimateConfig:
     HALFLIFE_SLOW:            int   = 63
     SIGNAL_LAG_DAYS:          int   = 21
     RISK_AVERSION:            float = 5.0
-    SLACK_PENALTY:            float = 10.0
+    SLACK_PENALTY:            float = 1000.0
     DIMENSIONALITY_MULTIPLIER:int   = 3
     MAX_SECTOR_WEIGHT:        float = 1.0
 
@@ -963,7 +963,7 @@ def compute_book_cvar(
             # drift from fixed config.  Neither depends on today's market.
             vol = float(state.last_known_volatility.get(sym, cfg.GHOST_VOL_FALLBACK))
             vol = max(vol, cfg.GHOST_VOL_FALLBACK)   # floor to config minimum only
-            daily_vol   = vol / np.sqrt(252)
+            daily_vol   = vol
             daily_drift = float(cfg.GHOST_RET_DRIFT) / 252.0  # fixed; never market-dependent
 
             sym_base_seed = _ghost_seed_for(sym)  # stable int for this symbol
@@ -1186,7 +1186,7 @@ class InstitutionalRiskEngine:
         aligned_w       = adv_w_series.reindex(clean_rets.columns).fillna(0.0).values
         aligned_w       = aligned_w / np.maximum(aligned_w.sum(), 1e-9)
         adv_weighted_rets = pd.Series(
-            clean_rets.values.dot(aligned_w), index=clean_rets.index
+            simple_rets.values.dot(aligned_w), index=simple_rets.index
         )
         var_95   = adv_weighted_rets.quantile(1 - self.cfg.CVAR_ALPHA)
         ew_cvar  = (


### PR DESCRIPTION
### Motivation
- Ghost-synthesized assets were being treated as near-risk-free due to an extra annualization (/ sqrt(252)) applied to an already-daily volatility estimate, biasing the optimizer toward halted/delisted names.
- The sentinel CVaR check aggregated log-returns instead of simple returns, producing an overstated portfolio tail loss that frequently triggered emergency deleveraging.
- The soft slack penalty was set too low so the solver could economically choose to pay slack and breach CVaR, only for the post-solve hard check to abort the rebalance.

### Description
- Increased `SLACK_PENALTY` from `10.0` to `1000.0` to align the optimizer's soft-constraint cost with downstream hard CVaR enforcement.
- Removed the erroneous annualization so `daily_vol` now uses the stored daily volatility directly via `daily_vol = vol`.
- Changed the sentinel baseline aggregation to compute `adv_weighted_rets` from `simple_rets` instead of `clean_rets` so the portfolio return series uses arithmetic returns consistent with the optimizer.

### Testing
- Compiled the module with `python -m py_compile momentum_engine.py` and the file compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7b3be3dfc832bbaedf163ceced149)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated penalty parameters in optimization calculations for improved weighting
  * Modified volatility computation methodology for ghost synthesis
  * Adjusted return calculation approach in portfolio weight optimization to align computational consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->