### PR TITLE
Fix volatility-regime knife gate, ADV lookahead, and continuity bonus scaling

### DIFF
--- a/signals.py
+++ b/signals.py
@@ -209,7 +209,12 @@ def compute_single_adv(df: pd.DataFrame, cfg: Optional['UltimateConfig'] = None)
         return 0.0
 
 
-def compute_adv(market_data: dict, active_symbols: List[str], cfg: Optional['UltimateConfig'] = None) -> np.ndarray:
+def compute_adv(
+    market_data: dict,
+    active_symbols: List[str],
+    cfg: Optional['UltimateConfig'] = None,
+    target_date: Optional[str] = None,
+) -> np.ndarray:
     """
     Compute Average Daily Notional Volume for every symbol in a single
     vectorized pass.
@@ -227,6 +232,8 @@ def compute_adv(market_data: dict, active_symbols: List[str], cfg: Optional['Ult
 
     Symbols absent from market_data receive a value of 0.0.
     Lookback defaults to 20 days when cfg is not supplied.
+    When target_date is supplied, ADV is computed using rows up to and
+    including that date.
     """
     from momentum_engine import to_ns
 
@@ -241,6 +248,11 @@ def compute_adv(market_data: dict, active_symbols: List[str], cfg: Optional['Ult
         return np.zeros(len(active_symbols), dtype=float)
 
     notional_df = pd.DataFrame(notional_cols)
+    if target_date is not None:
+        notional_df = notional_df.loc[:target_date]
+
+    if notional_df.empty:
+        return np.zeros(len(active_symbols), dtype=float)
     adv_lookback = int(getattr(cfg, "ADV_LOOKBACK", 20)) if cfg else 20
     min_periods = max(1, adv_lookback // 2)
 
@@ -374,7 +386,8 @@ def generate_signals(
         # log_rets.std() therefore contains no look-ahead. We document this
         # invariant explicitly so future callers do not accidentally pass an
         # unsliced DataFrame.
-        _signal_date_vols = log_rets.std()  # strictly signal-date-bounded per caller contract
+        recent_lookback = min(len(log_rets), 126)
+        _signal_date_vols = log_rets.iloc[-recent_lookback:].std()
         _full_daily_vols = _signal_date_vols.values
 
         for i, cumulative_ret in enumerate(recent_cumulative_returns):
@@ -387,22 +400,13 @@ def generate_signals(
             if cumulative_ret < vol_adj_threshold:
                 adj_scores[i] = -np.inf
 
-    # 3. FIX: Dispersion-Normalized Continuity Bonus
-    # Standardizing the bonus against the current cross-sectional dispersion
-    # ensures it isn't over-dominant in tight low-vol markets or invisible in wide high-vol ones.
+    # 3. Continuity Bonus
+    # Apply directly in Z-score units; scores are already cross-sectionally normalized.
     valid_mask = np.isfinite(adj_scores)
     
     if prev_weights and valid_mask.any():
-        # Guard: nanstd on a single-element array returns NaN (0/0 in ddof=1 mode),
-        # which would poison base_bonus.  Default strictly to the floor when fewer
-        # than 2 finite scores are available (e.g. extreme crash states where all but
-        # one asset is gated out).
-        if valid_mask.sum() >= 2:
-            current_dispersion = max(np.nanstd(adj_scores[valid_mask]), cfg.CONTINUITY_DISPERSION_FLOOR)
-        else:
-            current_dispersion = cfg.CONTINUITY_DISPERSION_FLOOR
         cap = float(getattr(cfg, "CONTINUITY_MAX_SCALAR", 0.20))
-        base_bonus = min(cfg.CONTINUITY_BONUS, cap) * current_dispersion
+        base_bonus = min(cfg.CONTINUITY_BONUS, cap)
 
         activity_window = max(int(getattr(cfg, "CONTINUITY_ACTIVITY_WINDOW", 5)), 1)
         stale_sessions = max(int(getattr(cfg, "CONTINUITY_STALE_SESSIONS", 10)), 1)

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -118,9 +118,7 @@ def test_generate_signals_continuity_decay_scales_with_prev_weight():
     large_bonus = float(scores[1] - scores[2])
 
     raw_scores, _, _, _ = generate_signals(log_rets, adv, cfg)
-    finite = raw_scores[np.isfinite(raw_scores)]
-    dispersion = max(np.nanstd(finite), cfg.CONTINUITY_DISPERSION_FLOOR)
-    base_bonus = min(cfg.CONTINUITY_BONUS, cfg.CONTINUITY_MAX_SCALAR) * dispersion
+    base_bonus = min(cfg.CONTINUITY_BONUS, cfg.CONTINUITY_MAX_SCALAR)
 
     assert small_bonus == pytest.approx(base_bonus * 0.25, abs=1e-9)
     assert large_bonus == pytest.approx(base_bonus * 1.0, abs=1e-9)
@@ -1425,6 +1423,49 @@ def test_volume_first_day_adv_is_zero_no_lookahead():
     assert np.allclose(adv_day0, 0.0)
 
 
+
+
+def test_compute_adv_respects_target_date_no_lookahead():
+    idx = pd.date_range("2024-01-01", periods=6, freq="B")
+    market_data = {
+        "ABC.NS": pd.DataFrame(
+            {"Close": [100.0] * 6, "Volume": [1, 2, 3, 4, 5, 100]},
+            index=idx,
+        )
+    }
+
+    adv_all = compute_adv(market_data, ["ABC"], cfg=UltimateConfig(ADV_LOOKBACK=3))
+    adv_t3 = compute_adv(
+        market_data,
+        ["ABC"],
+        cfg=UltimateConfig(ADV_LOOKBACK=3),
+        target_date=idx[3].strftime("%Y-%m-%d"),
+    )
+
+    assert adv_all[0] == pytest.approx((4 + 5 + 100) / 3 * 100.0)
+    assert adv_t3[0] == pytest.approx((2 + 3 + 4) / 3 * 100.0)
+
+
+def test_generate_signals_knife_gate_uses_recent_vol_regime():
+    n = 300
+    stable = np.full(n, 0.002)
+    # high-vol ancient history, quiet recent regime
+    stable[:174] = np.where(np.arange(174) % 2 == 0, 0.03, -0.03)
+    stable[-20:] = np.log1p(-0.01)
+
+    crisis = np.full(n, 0.002)
+    # quiet ancient history, high-vol recent regime
+    crisis[-126:-20] = np.where(np.arange(106) % 2 == 0, 0.03, -0.03)
+    crisis[-20:] = np.log1p(-0.01)
+
+    log_rets = pd.DataFrame({"STABLE": stable, "CRISIS": crisis})
+    adv = np.array([1e9, 1e9], dtype=float)
+    cfg = UltimateConfig(HISTORY_GATE=20, MAX_POSITIONS=2, KNIFE_THRESHOLD=-0.15, KNIFE_WINDOW=20)
+
+    _, scores, _, _ = generate_signals(log_rets, adv, cfg)
+
+    assert not np.isfinite(scores[0]), "Low recent-vol symbol should be knife-gated."
+    assert np.isfinite(scores[1]), "High recent-vol symbol should survive a modest drop."
 def test_compute_adv_respects_configurable_lookback():
     idx = pd.date_range("2024-01-01", periods=5, freq="B")
     market_data = {


### PR DESCRIPTION
### Motivation
- Prevent volatility gating from anchoring to stale full-history volatility which can miss recent regime changes.
- Eliminate chronological look-ahead in vectorized ADV computation so historical slices cannot see future liquidity.
- Remove a redundant dispersion re-scaling in the continuity bonus because adj_scores are already Z-scored.

### Description
- Add an optional `target_date` parameter to `compute_adv(...)` and slice the notional DataFrame to `:target_date` before computing the ADV, returning zeros if the slice is empty to avoid look-ahead.
- Change the falling-knife volatility scalar in `generate_signals` to use a recent volatility regime window (`recent_lookback = min(len(log_rets), 126)`) instead of lifetime std, so thresholds adapt to current volatility.
- Simplify continuity bonus logic by removing the additional cross-sectional dispersion multiplication and applying `base_bonus = min(cfg.CONTINUITY_BONUS, CONTINUITY_MAX_SCALAR)` directly.
- Update unit tests in `test_momentum.py` to reflect the new continuity expectation and add regression tests for `compute_adv(target_date=...)` and the recent-volatility knife-gate behavior.

### Testing
- Ran `pytest -q test_momentum.py -k "compute_adv_respects_target_date_no_lookahead or generate_signals_knife_gate_uses_recent_vol_regime or continuity_decay_scales_with_prev_weight or compute_adv_respects_configurable_lookback"` which completed with `4 passed, 83 deselected`.
- Ran `pytest -q test_momentum.py -k "generate_signals"` which completed with `8 passed, 79 deselected`.
- Iterated on a failing regression locally and re-ran the targeted test suite until all introduced/modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7b4b53960832b94abce587f7c1c9a)