### PR TITLE
Fix deletion liquidation path, absent-price decay trigger, and execution fallback order

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -203,6 +203,10 @@ class BacktestEngine:
         active_prices = prices_t
         if member_universe is not None:
             member_set = {str(sym) for sym in member_universe}
+            # Keep currently held symbols active so they can be explicitly
+            # assigned a zero target weight and liquidated if they have
+            # dropped out of the index universe.
+            member_set.update(self.state.shares.keys())
             active_symbols = [sym for sym in symbols if sym in member_set]
             if not active_symbols:
                 return
@@ -542,16 +546,19 @@ def _execution_prices(
     high_px: Optional[pd.DataFrame],
     low_px: Optional[pd.DataFrame],
 ) -> np.ndarray:
-    if open_px is not None and date in open_px.index:
-        opens = open_px.loc[date].reindex(symbols).values.astype(float)
-        if np.isfinite(opens).any():
-            return np.where(np.isfinite(opens) & (opens > 0), opens, close_prices)
+    exec_px = close_prices.copy()
+
     if high_px is not None and low_px is not None and date in high_px.index and date in low_px.index:
         highs = high_px.loc[date].reindex(symbols).values.astype(float)
         lows  = low_px.loc[date].reindex(symbols).values.astype(float)
         vwap  = (highs + lows + close_prices) / 3.0
-        return np.where(np.isfinite(vwap) & (vwap > 0), vwap, close_prices)
-    return close_prices
+        exec_px = np.where(np.isfinite(vwap) & (vwap > 0), vwap, exec_px)
+
+    if open_px is not None and date in open_px.index:
+        opens = open_px.loc[date].reindex(symbols).values.astype(float)
+        exec_px = np.where(np.isfinite(opens) & (opens > 0), opens, exec_px)
+
+    return exec_px
 
 
 def _repair_suspension_gaps(df: pd.DataFrame, ticker: str) -> pd.DataFrame:
@@ -729,6 +736,7 @@ def run_backtest(
             )
 
     close_d, close_adj_d, open_d, high_d, low_d, div_d, split_d, volume_d = {}, {}, {}, {}, {}, {}, {}, {}
+    max_absent_periods = max(0, int(getattr(cfg, "MAX_ABSENT_PERIODS", 10)))
     for sym in union_universe:
         if not sym:
             continue
@@ -737,11 +745,11 @@ def run_backtest(
             continue
         row = market_data[key]
         valuation_series = row.get("Adj Close", row["Close"]) if cfg.AUTO_ADJUST_PRICES else row["Close"]
-        close_d[sym]     = valuation_series.ffill()
-        close_adj_d[sym] = row.get("Adj Close", row["Close"]).ffill()
-        open_d[sym]      = row.get("Open",  row["Close"]).ffill()
-        high_d[sym]      = row.get("High",  row["Close"]).ffill()
-        low_d[sym]       = row.get("Low",   row["Close"]).ffill()
+        close_d[sym]     = valuation_series.ffill(limit=max_absent_periods)
+        close_adj_d[sym] = row.get("Adj Close", row["Close"]).ffill(limit=max_absent_periods)
+        open_d[sym]      = row.get("Open",  row["Close"]).ffill(limit=max_absent_periods)
+        high_d[sym]      = row.get("High",  row["Close"]).ffill(limit=max_absent_periods)
+        low_d[sym]       = row.get("Low",   row["Close"]).ffill(limit=max_absent_periods)
         div_d[sym]       = row.get("Dividends",    pd.Series(0.0, index=row.index)).fillna(0.0)
         split_d[sym]     = row.get("Stock Splits", pd.Series(0.0, index=row.index)).fillna(0.0)
         volume_d[sym]    = row["Volume"]

--- a/test_backtest_engine.py
+++ b/test_backtest_engine.py
@@ -206,3 +206,110 @@ def test_repair_suspension_gaps_preserves_adj_close_scale():
     ratio = repaired.loc[gap_rows, "Adj Close"] / repaired.loc[gap_rows, "Close"]
     # Synthetic Adj Close should preserve pre-gap adjusted scale, not be copied from raw Close.
     assert np.allclose(ratio.values, 0.1, atol=1e-6)
+
+
+def test_rebalance_keeps_dropped_holding_in_active_symbols(monkeypatch):
+    cfg = UltimateConfig(CVAR_MIN_HISTORY=9999)
+    engine = InstitutionalRiskEngine(cfg)
+    bt = be.BacktestEngine(engine, initial_cash=100.0)
+    bt.state.shares["ZZZ"] = 5
+    bt.state.last_known_prices["ZZZ"] = 10.0
+
+    dates = pd.DatetimeIndex([pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")])
+    close = pd.DataFrame({"AAA": [10.0, 10.0], "ZZZ": [10.0, 10.0]}, index=dates)
+    volume = pd.DataFrame({"AAA": [1_000_000, 1_000_000], "ZZZ": [1_000_000, 1_000_000]}, index=dates)
+    returns = close.pct_change(fill_method=None).fillna(0.0)
+
+    captured = {}
+
+    def _fake_generate_signals(*_args, **_kwargs):
+        # No selected symbols -> decay path should create liquidation target.
+        return np.array([0.0, 0.0]), np.array([0.0, 0.0]), [], {}
+
+    def _fake_execute_rebalance(state, target_weights, _exec_prices, active_symbols, _cfg, **_kwargs):
+        captured["active_symbols"] = list(active_symbols)
+        captured["target_weights"] = np.asarray(target_weights)
+
+    monkeypatch.setattr(be, "generate_signals", _fake_generate_signals)
+    monkeypatch.setattr(be, "compute_regime_score", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(be, "compute_book_cvar", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(be, "execute_rebalance", _fake_execute_rebalance)
+
+    bt._run_rebalance(
+        pd.Timestamp("2020-01-02"),
+        close,
+        volume,
+        returns,
+        ["AAA", "ZZZ"],
+        close.loc[pd.Timestamp("2020-01-02")].values.astype(float),
+        idx_df=None,
+        sector_map=None,
+        open_px=close,
+        high_px=close,
+        low_px=close,
+        member_universe={"AAA"},
+    )
+
+    assert captured["active_symbols"] == ["AAA", "ZZZ"]
+    assert captured["target_weights"][1] == 0.0
+
+
+def test_execution_prices_uses_vwap_when_open_missing():
+    symbols = ["AAA", "BBB"]
+    date = pd.Timestamp("2020-01-02")
+    close_prices = np.array([100.0, 200.0])
+
+    idx = pd.DatetimeIndex([date])
+    open_px = pd.DataFrame({"AAA": [np.nan], "BBB": [190.0]}, index=idx)
+    high_px = pd.DataFrame({"AAA": [120.0], "BBB": [210.0]}, index=idx)
+    low_px = pd.DataFrame({"AAA": [90.0], "BBB": [180.0]}, index=idx)
+
+    out = be._execution_prices(symbols, date, close_prices, open_px, high_px, low_px)
+
+    # AAA uses VWAP fallback because open is missing.
+    assert np.isclose(out[0], (120.0 + 90.0 + 100.0) / 3.0)
+    # BBB uses open price when available.
+    assert np.isclose(out[1], 190.0)
+
+
+def test_run_backtest_limits_forward_fill_to_max_absent_periods(monkeypatch):
+    cfg = UltimateConfig(MAX_ABSENT_PERIODS=1, REBALANCE_FREQ="W-FRI")
+
+    idx = pd.bdate_range("2020-01-01", periods=4)
+    market_data = {
+        "AAA.NS": pd.DataFrame(
+            {
+                "Close": [100.0, np.nan, np.nan, np.nan],
+                "Adj Close": [100.0, np.nan, np.nan, np.nan],
+                "Open": [100.0, np.nan, np.nan, np.nan],
+                "High": [100.0, np.nan, np.nan, np.nan],
+                "Low": [100.0, np.nan, np.nan, np.nan],
+                "Volume": [1_000_000, 0.0, 0.0, 0.0],
+                "Dividends": [0.0, 0.0, 0.0, 0.0],
+                "Stock Splits": [0.0, 0.0, 0.0, 0.0],
+            },
+            index=idx,
+        ),
+        "^NSEI": pd.DataFrame({"Close": [1.0, 1.0, 1.0, 1.0]}, index=idx),
+    }
+
+    captured = {}
+
+    def _fake_run(self, close, *_args, **_kwargs):
+        captured["close"] = close.copy()
+        return pd.DataFrame({"equity": pd.Series(dtype=float)})
+
+    import unittest.mock as mock
+    with mock.patch.object(be.BacktestEngine, "run", _fake_run):
+        be.run_backtest(
+            market_data=market_data,
+            start_date="2020-01-01",
+            end_date="2020-01-06",
+            cfg=cfg,
+            universe=["AAA"],
+        )
+
+    series = captured["close"]["AAA"]
+    assert pd.notna(series.iloc[0])
+    assert pd.notna(series.iloc[1])
+    assert pd.isna(series.iloc[2])


### PR DESCRIPTION
### Motivation
- Prevent “zombie” holdings that were dropped from the universe but still held by ensuring held symbols remain visible to the rebalance/optimizer. 
- Ensure delisted or long-absent symbols stop being forward-filled indefinitely so the existing absent-symbol decay logic can mark them down. 
- Make the VWAP execution fallback reachable when Open prices are partially missing by fixing the early-return ordering.

### Description
- Keep currently held symbols in the rebalance member set by updating `member_set` with `self.state.shares.keys()` in `_run_rebalance` so dropped-but-held tickers receive explicit zero-weight targets. (backtest_engine.py)
- Refactor `_execution_prices` to compute VWAP as a secondary fallback first and then overwrite with valid Open prices where available, returning a single composed `exec_px` array. (backtest_engine.py)
- Limit forward-fill when building the close/adj/open/high/low matrices in `run_backtest` to `cfg.MAX_ABSENT_PERIODS` so prolonged absences become `NaN` and trigger `_ffill_price`/decay behavior. (backtest_engine.py)
- Add unit tests covering: kept inclusion of dropped-but-held symbols during rebalance, VWAP fallback use when Open is missing, and capped forward-fill respecting `MAX_ABSENT_PERIODS`. (test_backtest_engine.py)

### Testing
- Ran the backtest engine unit test suite with `pytest -q test_backtest_engine.py` and all tests passed. (10 passed)
- New tests include `test_rebalance_keeps_dropped_holding_in_active_symbols`, `test_execution_prices_uses_vwap_when_open_missing`, and `test_run_backtest_limits_forward_fill_to_max_absent_periods`, and they validated the intended behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7b60f1ebc832b99dd0c200760ae87)