### PR TITLE
Fix live scan adjusted-price input and absent-symbol state persistence

### DIFF
--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -503,11 +503,14 @@ def _run_scan(
     if split_syms:
         logger.warning("[Scan] Applied split adjustments for: %s", split_syms)
 
+    use_adj = getattr(cfg, "AUTO_ADJUST_PRICES", True)
+
     close_d: Dict[str, pd.Series] = {}
     for sym in universe:
         ns = to_ns(sym)
         if ns in market_data:
-            close_d[to_bare(ns)] = market_data[ns]["Close"].ffill()
+            col = "Adj Close" if use_adj and "Adj Close" in market_data[ns].columns else "Close"
+            close_d[to_bare(ns)] = market_data[ns][col].ffill()
 
     if not close_d:
         logger.warning("[Scan] No data available for any universe symbol.")
@@ -725,12 +728,11 @@ def _run_scan(
     price_dict = {sym: prices[active_idx[sym]] for sym in active}
     state.record_eod(price_dict)
 
-    if not rebalanced_this_scan:
-        for held_sym in list(state.shares.keys()):
-            if held_sym not in active_idx:
-                state.absent_periods[held_sym] = int(state.absent_periods.get(held_sym, 0)) + 1
-            else:
-                state.absent_periods.pop(held_sym, None)
+    for held_sym in list(state.shares.keys()):
+        if held_sym not in active_idx:
+            state.absent_periods[held_sym] = int(state.absent_periods.get(held_sym, 0)) + 1
+        else:
+            state.absent_periods.pop(held_sym, None)
 
     final_pv = state.equity_hist[-1] if state.equity_hist else pv
 
@@ -963,6 +965,7 @@ def _preserve_risk_metadata(source: PortfolioState, target: PortfolioState) -> N
     target.override_cooldown    = source.override_cooldown
     target.override_active      = source.override_active
     target.decay_rounds         = source.decay_rounds
+    target.absent_periods       = copy.deepcopy(source.absent_periods)
 
 
 # ─── Main menu ────────────────────────────────────────────────────────────────

--- a/test_daily_workflow.py
+++ b/test_daily_workflow.py
@@ -244,6 +244,104 @@ def test_run_scan_increments_absent_periods_when_symbol_missing(monkeypatch):
     assert out_state.absent_periods["MISSING"] == 3
 
 
+def test_run_scan_increments_absent_periods_even_when_rebalanced(monkeypatch):
+    idx = pd.date_range("2024-01-01", periods=6)
+    md = {
+        "ABC.NS": pd.DataFrame(
+            {
+                "Close": [100, 101, 102, 103, 104, 105],
+                "Dividends": [0.0] * 6,
+            },
+            index=idx,
+        ),
+        "^NSEI": pd.DataFrame({"Close": [100] * 6}, index=idx),
+        "^CRSLDX": pd.DataFrame({"Close": [100] * 6}, index=idx),
+    }
+    monkeypatch.setattr(dw, "load_or_fetch", lambda *_args, **_kwargs: md)
+    monkeypatch.setattr(dw, "_print_stage_status", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(dw, "detect_and_apply_splits", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(dw, "compute_regime_score", lambda *_args, **_kwargs: 0.5)
+    monkeypatch.setattr(dw, "compute_book_cvar", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(dw, "compute_adv", lambda *_args, **_kwargs: __import__("numpy").array([1e9]))
+    monkeypatch.setattr(dw, "get_sector_map", lambda syms, cfg=None: {s: "Unknown" for s in syms})
+    monkeypatch.setattr(dw, "generate_signals", lambda *_args, **_kwargs: (__import__("numpy").array([0.01]), __import__("numpy").array([1.0]), [0], {"total": 1, "history_gated": 1, "adv_gated": 1, "knife_gated": 1, "selected": 1}))
+
+    class _Engine:
+        def __init__(self, _cfg):
+            pass
+
+        def optimize(self, **_kwargs):
+            return __import__("numpy").array([0.0])
+
+    monkeypatch.setattr(dw, "InstitutionalRiskEngine", _Engine)
+    monkeypatch.setattr(dw, "execute_rebalance", lambda *_args, **_kwargs: 0.0)
+
+    state = PortfolioState(
+        shares={"ABC": 10, "MISSING": 5},
+        last_known_prices={"ABC": 105.0, "MISSING": 10.0},
+        absent_periods={"MISSING": 2},
+    )
+    cfg = UltimateConfig(REBALANCE_FREQ="D")
+
+    out_state, _ = dw._run_scan(["ABC"], state, "TEST", cfg_override=cfg)
+
+    assert out_state.absent_periods["MISSING"] == 3
+
+
+def test_run_scan_uses_adjusted_close_history_for_signals_when_enabled(monkeypatch):
+    idx = pd.date_range("2024-01-01", periods=6)
+    md = {
+        "ABC.NS": pd.DataFrame(
+            {
+                "Close": [100, 100, 100, 50, 50, 50],
+                "Adj Close": [100, 100, 100, 100, 100, 100],
+                "Dividends": [0.0] * 6,
+            },
+            index=idx,
+        ),
+        "^NSEI": pd.DataFrame({"Close": [100] * 6}, index=idx),
+        "^CRSLDX": pd.DataFrame({"Close": [100] * 6}, index=idx),
+    }
+    monkeypatch.setattr(dw, "load_or_fetch", lambda *_args, **_kwargs: md)
+    monkeypatch.setattr(dw, "_print_stage_status", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(dw, "detect_and_apply_splits", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(dw, "compute_regime_score", lambda *_args, **_kwargs: 0.5)
+    monkeypatch.setattr(dw, "compute_book_cvar", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(dw, "compute_adv", lambda *_args, **_kwargs: __import__("numpy").array([1e9]))
+    monkeypatch.setattr(dw, "get_sector_map", lambda syms, cfg=None: {s: "Unknown" for s in syms})
+    monkeypatch.setattr(dw, "execute_rebalance", lambda *_args, **_kwargs: 0.0)
+
+    captured = {}
+
+    def _capture_signals(log_rets, *_args, **_kwargs):
+        captured["ret"] = float(log_rets["ABC"].iloc[-2])
+        return __import__("numpy").array([0.01]), __import__("numpy").array([1.0]), [0], {
+            "total": 1,
+            "history_gated": 1,
+            "adv_gated": 1,
+            "knife_gated": 1,
+            "selected": 1,
+        }
+
+    monkeypatch.setattr(dw, "generate_signals", _capture_signals)
+
+    class _Engine:
+        def __init__(self, _cfg):
+            pass
+
+        def optimize(self, **_kwargs):
+            return __import__("numpy").array([0.0])
+
+    monkeypatch.setattr(dw, "InstitutionalRiskEngine", _Engine)
+
+    state = PortfolioState()
+    cfg = UltimateConfig(REBALANCE_FREQ="D", AUTO_ADJUST_PRICES=True)
+
+    dw._run_scan(["ABC"], state, "TEST", cfg_override=cfg)
+
+    assert captured["ret"] == pytest.approx(0.0)
+
+
 def test_run_scan_hard_cvar_breach_overrides_cadence_gate(monkeypatch):
     idx = pd.date_range("2024-01-01", periods=6)
     md = {
@@ -277,6 +375,23 @@ def test_run_scan_hard_cvar_breach_overrides_cadence_gate(monkeypatch):
 
     assert called["n"] == 1
     assert out_state.shares == {}
+
+
+def test_preserve_risk_metadata_copies_absent_periods():
+    source = PortfolioState(
+        consecutive_failures=2,
+        override_cooldown=3,
+        override_active=True,
+        decay_rounds=1,
+        absent_periods={"XYZ": 4},
+    )
+    target = PortfolioState(absent_periods={"OLD": 1})
+
+    dw._preserve_risk_metadata(source, target)
+
+    assert target.absent_periods == {"XYZ": 4}
+    source.absent_periods["XYZ"] = 5
+    assert target.absent_periods["XYZ"] == 4
 
 
 def test_execute_rebalance_initializes_dividend_marker_on_new_position():


### PR DESCRIPTION
### Motivation

- The live scanner was building the signal input matrix from the raw `Close` column regardless of `AUTO_ADJUST_PRICES`, which can create artificial returns after corporate actions and corrupt momentum signals.  
- `absent_periods` (delisted/suspended aging) only advanced when no rebalance occurred, allowing held-but-absent symbols to never reach forced-exit thresholds if the portfolio rebalanced.  
- Discarding a previewed scan (`_preserve_risk_metadata`) did not copy `absent_periods`, which caused the engine to forget real-world absence events when the user rejects trades.

### Description

- Updated `_run_scan` to respect the `AUTO_ADJUST_PRICES` flag and select the `Adj Close` column when available, otherwise falling back to `Close`, for the price history passed to signal generation.  
- Removed the `if not rebalanced_this_scan:` guard and unindented the held-symbol loop so `state.absent_periods` is incremented (or cleared) on every scan regardless of whether a rebalance occurred.  
- Changed `_preserve_risk_metadata` to deep-copy `absent_periods` from the preview `source` into the persisted `target` so absence aging survives user discards.  
- Added unit tests in `test_daily_workflow.py` covering absence-aging during rebalance, adjusted-close usage for signal history, and absence-preservation on discard.

### Testing

- Ran `pytest -q test_daily_workflow.py` and all tests passed: `16 passed` (including the three new regression tests).  
- New tests added: `test_run_scan_increments_absent_periods_even_when_rebalanced`, `test_run_scan_uses_adjusted_close_history_for_signals_when_enabled`, and `test_preserve_risk_metadata_copies_absent_periods`.  
- Existing `daily_workflow` behavior covered by the suite remains green after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7bd5107b0832bb2ab2e14619ea725)