### PR TITLE
Precompute price/volume matrices and add early trial pruning to speed up optimizer

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -639,6 +639,64 @@ def apply_halt_simulation(market_data: dict) -> dict:
     return {k: _repair_suspension_gaps(v, k) for k, v in market_data.items()}
 
 
+def build_precomputed_matrices(
+    market_data: dict,
+    cfg: Optional[UltimateConfig] = None,
+    symbols: Optional[set[str]] = None,
+) -> dict:
+    """
+    Build canonical price/volume matrices once so repeated backtests can reuse
+    them instead of rebuilding DataFrames on every run.
+    """
+    if cfg is None:
+        cfg = UltimateConfig()
+
+    target_symbols = set(symbols or set())
+    if not target_symbols:
+        for key in market_data.keys():
+            if isinstance(key, str) and key.endswith(".NS"):
+                target_symbols.add(key[:-3])
+
+    close_d, close_adj_d, open_d, high_d, low_d, div_d, split_d, volume_d = {}, {}, {}, {}, {}, {}, {}, {}
+    max_absent_periods = max(0, int(getattr(cfg, "MAX_ABSENT_PERIODS", 10)))
+
+    for sym in target_symbols:
+        if not sym:
+            continue
+        key = sym if sym.endswith(".NS") else sym + ".NS"
+        row = market_data.get(key)
+        if row is None or row.empty:
+            continue
+
+        valuation_series = row.get("Adj Close", row["Close"]) if cfg.AUTO_ADJUST_PRICES else row["Close"]
+        close_d[sym] = valuation_series.ffill(limit=max_absent_periods)
+        close_adj_d[sym] = row.get("Adj Close", row["Close"]).ffill(limit=max_absent_periods)
+        open_d[sym] = row.get("Open", row["Close"]).ffill(limit=max_absent_periods)
+        high_d[sym] = row.get("High", row["Close"]).ffill(limit=max_absent_periods)
+        low_d[sym] = row.get("Low", row["Close"]).ffill(limit=max_absent_periods)
+        div_d[sym] = row.get("Dividends", pd.Series(0.0, index=row.index)).fillna(0.0)
+        split_d[sym] = row.get("Stock Splits", pd.Series(0.0, index=row.index)).fillna(0.0)
+        volume_d[sym] = row["Volume"]
+
+    if not close_d:
+        return {}
+
+    close = pd.DataFrame(close_d).sort_index()
+    close_adj = pd.DataFrame(close_adj_d).sort_index()
+
+    return {
+        "close": close,
+        "close_adj": close_adj,
+        "open": pd.DataFrame(open_d).sort_index(),
+        "high": pd.DataFrame(high_d).sort_index(),
+        "low": pd.DataFrame(low_d).sort_index(),
+        "dividends": pd.DataFrame(div_d).sort_index().fillna(0.0),
+        "splits": pd.DataFrame(split_d).sort_index().fillna(0.0),
+        "volume": pd.DataFrame(volume_d).sort_index(),
+        "returns": close_adj.pct_change(fill_method=None).clip(lower=-0.99),
+    }
+
+
 def run_backtest(
     market_data:   dict,
     universe_type: Optional[str] = None,
@@ -647,6 +705,7 @@ def run_backtest(
     cfg:           Optional[UltimateConfig] = None,
     sector_map:    Optional[dict]           = None,
     universe:      Optional[List[str]]      = None,
+    precomputed_matrices: Optional[dict]    = None,
 ) -> BacktestResults:
     """
     Run a backtest over [start_date, end_date].
@@ -735,37 +794,33 @@ def run_backtest(
                 "verify universe snapshots or date range."
             )
 
-    close_d, close_adj_d, open_d, high_d, low_d, div_d, split_d, volume_d = {}, {}, {}, {}, {}, {}, {}, {}
-    max_absent_periods = max(0, int(getattr(cfg, "MAX_ABSENT_PERIODS", 10)))
-    for sym in union_universe:
-        if not sym:
-            continue
-        key = sym if sym.endswith(".NS") else sym + ".NS"
-        if key not in market_data:
-            continue
-        row = market_data[key]
-        valuation_series = row.get("Adj Close", row["Close"]) if cfg.AUTO_ADJUST_PRICES else row["Close"]
-        close_d[sym]     = valuation_series.ffill(limit=max_absent_periods)
-        close_adj_d[sym] = row.get("Adj Close", row["Close"]).ffill(limit=max_absent_periods)
-        open_d[sym]      = row.get("Open",  row["Close"]).ffill(limit=max_absent_periods)
-        high_d[sym]      = row.get("High",  row["Close"]).ffill(limit=max_absent_periods)
-        low_d[sym]       = row.get("Low",   row["Close"]).ffill(limit=max_absent_periods)
-        div_d[sym]       = row.get("Dividends",    pd.Series(0.0, index=row.index)).fillna(0.0)
-        split_d[sym]     = row.get("Stock Splits", pd.Series(0.0, index=row.index)).fillna(0.0)
-        volume_d[sym]    = row["Volume"]
-
-    if not close_d:
-        raise ValueError("No valid symbols found in market_data for the dynamic historical universe.")
-
-    close     = pd.DataFrame(close_d).sort_index()
-    close_adj = pd.DataFrame(close_adj_d).sort_index()
-    open_px   = pd.DataFrame(open_d).sort_index()
-    high_px   = pd.DataFrame(high_d).sort_index()
-    low_px    = pd.DataFrame(low_d).sort_index()
-    dividends = pd.DataFrame(div_d).sort_index().fillna(0.0)
-    splits    = pd.DataFrame(split_d).sort_index().fillna(0.0)
-    volume    = pd.DataFrame(volume_d).sort_index()
-    returns   = close_adj.pct_change(fill_method=None).clip(lower=-0.99)
+    matrices = precomputed_matrices
+    if matrices:
+        selected = [sym for sym in union_universe if sym in matrices["close"].columns]
+        if not selected:
+            raise ValueError("No valid symbols found in precomputed matrices for the dynamic historical universe.")
+        close = matrices["close"][selected]
+        close_adj = matrices["close_adj"][selected]
+        open_px = matrices["open"][selected]
+        high_px = matrices["high"][selected]
+        low_px = matrices["low"][selected]
+        dividends = matrices["dividends"][selected]
+        splits = matrices["splits"][selected]
+        volume = matrices["volume"][selected]
+        returns = matrices["returns"][selected]
+    else:
+        matrices = build_precomputed_matrices(market_data, cfg=cfg, symbols=union_universe)
+        if not matrices:
+            raise ValueError("No valid symbols found in market_data for the dynamic historical universe.")
+        close = matrices["close"]
+        close_adj = matrices["close_adj"]
+        open_px = matrices["open"]
+        high_px = matrices["high"]
+        low_px = matrices["low"]
+        dividends = matrices["dividends"]
+        splits = matrices["splits"]
+        volume = matrices["volume"]
+        returns = matrices["returns"]
 
     trading_index = pd.DatetimeIndex(close.index).sort_values()
     valid = []

--- a/optimizer.py
+++ b/optimizer.py
@@ -43,7 +43,7 @@ _load_dotenv_if_present()
 
 # Local imports from your v11.48 architecture
 from momentum_engine import UltimateConfig, OptimizationError
-from backtest_engine import run_backtest, apply_halt_simulation
+from backtest_engine import run_backtest, apply_halt_simulation, build_precomputed_matrices
 from data_cache import load_or_fetch
 from universe_manager import get_nifty500, fetch_nse_equity_universe, get_historical_universe
 
@@ -366,10 +366,17 @@ def _fitness_from_metrics(
 
 
 class MomentumObjective:
-    def __init__(self, market_data: dict, universe_type: str, search_space: dict | None = None):
+    def __init__(
+        self,
+        market_data: dict,
+        universe_type: str,
+        search_space: dict | None = None,
+        precomputed_matrices: dict | None = None,
+    ):
         self.market_data = market_data
         self.universe_type = universe_type
         self.search_space = search_space or SEARCH_SPACE_BOUNDS
+        self.precomputed_matrices = precomputed_matrices
 
     def __call__(self, trial: optuna.Trial) -> float:
         # 1. Base Configuration
@@ -470,6 +477,7 @@ class MomentumObjective:
                 # back to in the post-repair path (close_d etc. are new Series derived from
                 # .ffill() on the frame values, not in-place mutations of the frames).
                 market_data=self.market_data,
+                precomputed_matrices=self.precomputed_matrices,
                 universe_type=self.universe_type,
                 start_date=wf_oos_start,
                 end_date=wf_oos_end,
@@ -502,6 +510,9 @@ class MomentumObjective:
             )
 
             if not pd.notna(score):
+                raise optuna.TrialPruned()
+
+            if diag.get("dd_gate_hit") or score <= -2.0:
                 raise optuna.TrialPruned()
 
             if not exclude_from_score:
@@ -625,8 +636,15 @@ def pre_load_data(universe_type: str, cfg: UltimateConfig | None = None) -> dict
     # 500 tickers × 300 trials × 4 slices = 600,000 DataFrame allocations per run.
     market_data = apply_halt_simulation(market_data)
 
+    precomputed_matrices = None
+    if all(isinstance(v, pd.DataFrame) for v in market_data.values()):
+        precomputed_matrices = build_precomputed_matrices(market_data, cfg=cfg)
+
     logger.info("Data pre-load complete. Commencing Bayesian Optimization.")
-    return market_data
+    return {
+        "market_data": market_data,
+        "precomputed_matrices": precomputed_matrices,
+    }
 
 
 def save_optimal_config(best_params: dict, filepath: str = "data/optimal_cfg.json"):
@@ -702,7 +720,13 @@ def run_optimization(
     print(f"\033[90mTrials            : {N_TRIALS}\033[0m\n")
 
     logger.info(f"Optimization universe: {universe_type}")
-    market_data = pre_load_data(universe_type)
+    preloaded = pre_load_data(universe_type)
+    if isinstance(preloaded, dict) and "market_data" in preloaded:
+        market_data = preloaded["market_data"]
+        precomputed_matrices = preloaded.get("precomputed_matrices")
+    else:
+        market_data = preloaded
+        precomputed_matrices = None
 
     # 1. Setup Optuna Study
     os.makedirs("data", exist_ok=True) # Ensure the data folder exists
@@ -717,7 +741,11 @@ def run_optimization(
         load_if_exists=True
     )
      
-    objective = MomentumObjective(market_data, universe_type)
+    objective = MomentumObjective(
+        market_data,
+        universe_type,
+        precomputed_matrices=precomputed_matrices,
+    )
 
     # 2. Run In-Sample Optimization
     logger.info(f"Starting {N_TRIALS} Bayesian Trials (This may take a while)...")
@@ -906,6 +934,7 @@ def run_optimization(
         try:
             oos_result = run_backtest(
                 market_data=market_data,
+                precomputed_matrices=precomputed_matrices,
                 universe_type=universe_type,
                 start_date=TEST_START,
                 end_date=TEST_END,

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -157,7 +157,8 @@ def test_pre_load_data_deduplicates_inputs_and_appends_crsldx_index(monkeypatch)
 
     result = optimizer.pre_load_data("  NSE_TOTAL ")
 
-    assert result == {"ok": True}
+    assert result["market_data"] == {"ok": True}
+    assert result["precomputed_matrices"] is None
     assert captured["required_start"] == "2020-01-01"
     assert captured["required_end"] == "2020-12-31"
     assert captured["tickers"].count("ABC") == 1
@@ -193,7 +194,8 @@ def test_pre_load_data_includes_historical_union_for_nifty500(monkeypatch):
 
     result = optimizer.pre_load_data("nifty500")
 
-    assert result == {"ok": True}
+    assert result["market_data"] == {"ok": True}
+    assert result["precomputed_matrices"] is None
     assert captured["required_start"] == "2020-01-01"
     assert captured["required_end"] == "2020-03-31"
     assert "LIVEONLY" in captured["tickers"]


### PR DESCRIPTION
### Motivation
- Optimizer was rebuilding large price/volume/returns DataFrames on every trial/slice which caused massive repeated allocations and slow iterations.
- Trials that catastrophically failed on an early WFO slice still simulated remaining slices, wasting compute.
- The change aims to reuse a single canonical set of matrices across backtests and stop evaluating hopeless trials early to drastically reduce runtime.

### Description
- Added `build_precomputed_matrices` in `backtest_engine.py` to assemble canonical `close`, `close_adj`, `open`, `high`, `low`, `dividends`, `splits`, `volume`, and `returns` DataFrames once for reuse by backtests. 
- Extended `run_backtest` to accept an optional `precomputed_matrices` argument and to slice those matrices for the active `union_universe`, skipping repeated dict→DataFrame assembly when provided. 
- Modified `pre_load_data` in `optimizer.py` to return both repaired `market_data` and optional `precomputed_matrices`, and wired `MomentumObjective` and OOS validation calls to pass `precomputed_matrices` into `run_backtest`. 
- Added early Optuna pruning inside the WFO loop by raising `optuna.TrialPruned()` if a slice hits the DD gate or the score is the terminal floor (`<= -2.0`), and updated tests to reflect the new `pre_load_data` return contract. 

### Testing
- Ran `pytest -q test_optimizer.py test_backtest_engine.py` which completed successfully. 
- Test run result: `41 passed, 4 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7c0375738832bac070c1c01b9c46f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Enabled optional precomputation of market data matrices to accelerate backtesting and optimization workflows.
  * Enhanced rebalance date collision handling for more robust universe construction.

* **Tests**
  * Updated test expectations to reflect new data structure in validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->