### PR TITLE
Penalize forced-to-cash events in fitness; tighten search bounds and OOS pass logic

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -459,6 +459,12 @@ class BacktestEngine:
                 "override_active":    self.state.override_active,
                 "n_positions":        len(self.state.shares),
                 "apply_decay":        apply_decay,
+                "forced_to_cash":     bool(_force_full_cash or _exhaust_decay),
+                "force_cash_reason":  (
+                    "book_cvar_breach" if _force_full_cash else
+                    "max_decay_rounds" if _exhaust_decay else
+                    ""
+                ),
             })
 
 

--- a/optimizer.py
+++ b/optimizer.py
@@ -94,6 +94,7 @@ TEST_END = os.environ.get("OPTIMIZER_OOS_CUTOFF", "2025-12-31")
 
 N_TRIALS       = 200
 OOS_MAX_DD_CAP = 35.0
+OOS_SOFT_MAX_DD_CAP = 38.0
 OOS_TOP_K = 10
 
 # Minimum IS calendar days a fold must have before the OOS window.
@@ -101,12 +102,12 @@ OOS_TOP_K = 10
 _MIN_IS_CALENDAR_DAYS = 365
 
 SEARCH_SPACE_BOUNDS = {
-    "HALFLIFE_FAST":    (10, 30, 2),
-    "HALFLIFE_SLOW":    (40, 100, 5),
-    "CONTINUITY_BONUS": (0.06, 0.30, 0.03),
-    "RISK_AVERSION":    (10.0, 20.0, 0.5),
-    "CVAR_DAILY_LIMIT": (0.040, 0.070, 0.005),
-    "CVAR_LOOKBACK":    (50, 120, 10),
+    "HALFLIFE_FAST":    (15, 30, 2),
+    "HALFLIFE_SLOW":    (60, 100, 5),
+    "CONTINUITY_BONUS": (0.06, 0.20, 0.03),
+    "RISK_AVERSION":    (12.0, 20.0, 0.5),
+    "CVAR_DAILY_LIMIT": (0.040, 0.060, 0.005),
+    "CVAR_LOOKBACK":    (60, 120, 10),
 }
 
 N_JOBS = int(os.getenv("OPTUNA_N_JOBS", "1"))
@@ -211,6 +212,7 @@ def _fitness_from_metrics(
     avg_exposure = 1.0
     avg_positions = 0.0
     n_rebalances = 0
+    forced_cash_penalty = 0.0
 
     if rebal_log is not None and not rebal_log.empty:
         fallback_series = pd.Series([0.0])
@@ -218,6 +220,17 @@ def _fitness_from_metrics(
         avg_exposure = float(pd.to_numeric(rebal_log.get("exposure_multiplier", fallback_series), errors="coerce").fillna(0.0).mean())
         avg_positions = float(pd.to_numeric(rebal_log.get("n_positions", fallback_series), errors="coerce").fillna(0.0).mean())
         n_rebalances = len(rebal_log)
+
+        forced_cash_flags = rebal_log.get("forced_to_cash")
+        if forced_cash_flags is not None:
+            forced_cash_count = int(pd.Series(forced_cash_flags).fillna(False).astype(bool).sum())
+        else:
+            n_positions = pd.to_numeric(rebal_log.get("n_positions", fallback_series), errors="coerce").fillna(0.0)
+            apply_decay = pd.Series(rebal_log.get("apply_decay", False)).fillna(False).astype(bool)
+            forced_cash_count = int(((n_positions <= 0) & apply_decay).sum())
+
+        forced_cash_fraction = forced_cash_count / max(n_rebalances, 1)
+        forced_cash_penalty = forced_cash_fraction * 1.5
 
     _pos_deficit = max(0.0, 6.0 - avg_positions)
     concentration_mult = 1.0 + _pos_deficit * 0.30
@@ -237,8 +250,8 @@ def _fitness_from_metrics(
 
     risk_penalty = (max_dd + (avg_cvar * 100.0 * 2.0) + 1.0) * concentration_mult
 
-    IS_DD_GATE        = 40.0
-    IS_DD_PENALTY_PCT = 15.0
+    IS_DD_GATE        = 35.0
+    IS_DD_PENALTY_PCT = 12.0
 
     if max_dd > IS_DD_GATE:
         raw = -(max_dd / 5.0)
@@ -251,6 +264,7 @@ def _fitness_from_metrics(
             "n_rebalances": n_rebalances, "concentration_mult": round(concentration_mult, 4),
             "sortino_quality": round(sortino_quality, 4), "risk_penalty": round(risk_penalty, 4),
             "exposure_penalty": 0.0, "dd_penalty": 0.0,
+            "forced_cash_penalty": round(forced_cash_penalty, 4),
             "raw_score": round(raw, 6), "score": round(score, 6),
             "ceiling_hit": False, "dd_gate_hit": True, "anomaly_hit": False,
         }
@@ -283,7 +297,7 @@ def _fitness_from_metrics(
         ceiling_hit = False
         dd_gate_hit = False
     else:
-        raw = (cagr_net / risk_penalty) * sortino_quality - exposure_penalty - dd_penalty
+        raw = (cagr_net / risk_penalty) * sortino_quality - exposure_penalty - dd_penalty - forced_cash_penalty
         _K = 3.5
         score = (_K * raw / (_K + raw)) if raw > 0.0 else raw
         score = max(score, -2.0)
@@ -305,6 +319,7 @@ def _fitness_from_metrics(
         "risk_penalty":        round(risk_penalty, 4),
         "exposure_penalty":    round(exposure_penalty, 4),
         "dd_penalty":          round(dd_penalty, 4),
+        "forced_cash_penalty": round(forced_cash_penalty, 4),
         "raw_score":           round(raw, 6) if not (abs(cagr) < 1e-12 and max_dd == 0.0) else 0.0,
         "score":               round(score, 6),
         "ceiling_hit":         ceiling_hit,
@@ -438,36 +453,42 @@ class MomentumObjective:
             slice_diags.append(diag)
 
             _ceiling_tag  = " ⚠ CEILING HIT" if diag["ceiling_hit"] else ""
-            _ddgate_tag   = " ⚠ DD-GATE (>40%)" if diag["dd_gate_hit"] else ""
+            _ddgate_tag   = " ⚠ DD-GATE (>35%)" if diag["dd_gate_hit"] else ""
             _anomaly_tag  = " ⚠ ANOMALOUS-RETURNS" if diag.get("anomaly_hit") else ""
+            _cashpen_tag  = (
+                f" ⚠ FORCED-CASH={diag.get('forced_cash_penalty', 0.0):.2f}"
+                if diag.get("forced_cash_penalty", 0.0) > 0.1 else ""
+            )
             logger.info(
                 "[Trial %s | %d] CAGR=%+.1f%%  DD=%.1f%%  Turn=%.2fx  "
                 "AvgExp=%.2f  AvgPos=%.1f  AvgCVaR=%.3f%%  "
-                "RiskPenalty=%.2f  ExpPenalty=%.2f  DDPenalty=%.4f  RawScore=%.4f  Score=%.4f%s%s%s",
+                "RiskPenalty=%.2f  ExpPenalty=%.2f  DDPenalty=%.4f  ForcedCashPen=%.4f  "
+                "RawScore=%.4f  Score=%.4f%s%s%s%s",
                 trial_id, oos_year,
                 diag["cagr"], abs(diag["max_dd"]), diag["turnover"],
                 diag["avg_exposure"], diag["avg_positions"], diag["avg_cvar_pct"],
                 diag["risk_penalty"], diag["exposure_penalty"], diag.get("dd_penalty", 0.0),
+                diag.get("forced_cash_penalty", 0.0),
                 diag["raw_score"], diag["score"],
-                _ceiling_tag, _ddgate_tag, _anomaly_tag,
+                _ceiling_tag, _ddgate_tag, _anomaly_tag, _cashpen_tag,
             )
 
             if not pd.notna(score):
                 raise optuna.TrialPruned()
 
-            # FIX-MB-M-02: count gate hits; prune only when MORE THAN ONE fold
-            # triggers dd_gate_hit or anomaly_hit.  A single bad fold is
-            # tolerated as market noise; only pervasively bad strategies prune.
-            # NaN-score and score <= -2.0 remain immediate hard prunes.
+            # Count gate hits; include the first gate-hit fold score in the
+            # aggregate so fragile strategies are penalised rather than silently
+            # averaging only their good years. Prune when MORE THAN ONE fold
+            # triggers a gate.
             is_gate_hit = diag.get("dd_gate_hit") or diag.get("anomaly_hit") or score <= -2.0
             if is_gate_hit:
                 n_gate_hits += 1
+                scores.append(float(score))
                 if n_gate_hits > 1:
                     raise optuna.TrialPruned()
-                # Single gate hit: log and skip this fold's score from aggregate.
                 logger.debug(
-                    "[Trial %s | %d] Single gate-hit fold tolerated "
-                    "(dd_gate=%s anomaly=%s score=%.4f); excluding from aggregate.",
+                    "[Trial %s | %d] Single gate-hit fold included in aggregate "
+                    "(dd_gate=%s anomaly=%s score=%.4f).",
                     trial_id, oos_year,
                     diag.get("dd_gate_hit"), diag.get("anomaly_hit"), score,
                 )
@@ -764,22 +785,23 @@ def run_optimization(
             logger.info("    %-28s %s", k, v)
 
         logger.info("")
-        logger.info("  %-6s  %-8s  %-8s  %-8s  %-8s  %-8s  %-10s  %s",
-                    "Year", "CAGR%", "DD%", "Turn", "AvgPos", "AvgExp", "Score", "Flags")
-        logger.info("  " + "-"*70)
+        logger.info("  %-6s  %-8s  %-8s  %-8s  %-8s  %-8s  %-10s  %-10s  %s",
+                    "Year", "CAGR%", "DD%", "Turn", "AvgPos", "AvgExp", "ForcedCash", "Score", "Flags")
+        logger.info("  " + "-"*82)
         for d in diags:
             flags = []
             if d.get("ceiling_hit"):    flags.append("CEIL")
             if d.get("dd_gate_hit"):    flags.append("DD-GATE")
             if d.get("anomaly_hit"):    flags.append("ANOM")
             logger.info(
-                "  %-6s  %+7.1f%%  %6.1f%%  %6.2fx  %6.1f  %7.3f  %9.4f  %s",
+                "  %-6s  %+7.1f%%  %6.1f%%  %6.2fx  %6.1f  %7.3f  %9.4f  %9.4f  %s",
                 d["year"],
                 d["cagr"], abs(d["max_dd"]), d["turnover"],
                 d["avg_positions"], d["avg_exposure"],
+                d.get("forced_cash_penalty", 0.0),
                 d["score"], " ".join(flags) if flags else "—",
             )
-        logger.info("  " + "-"*70)
+        logger.info("  " + "-"*82)
         if diags:
             avg_cagr = sum(d["cagr"]       for d in diags) / len(diags)
             avg_dd   = sum(abs(d["max_dd"]) for d in diags) / len(diags)
@@ -868,7 +890,9 @@ def run_optimization(
     # OOS Top-K tournament
     print(f"\n\033[1;36m=== INITIATING OUT-OF-SAMPLE (OOS) VALIDATION — TOP-{OOS_TOP_K} TOURNAMENT ===\033[0m")
     print(f"\033[90mEvaluating top {OOS_TOP_K} IS trials on unseen data {TEST_START} → {TEST_END}\033[0m")
-    print(f"\033[90mWinner = best OOS Calmar (not best IS score)\033[0m\n")
+    print(f"\033[90mWinner = best OOS Calmar (not best IS score)\033[0m")
+    print(f"\033[90mHard pass = Calmar > 0.5 and MaxDD <= {OOS_MAX_DD_CAP:.1f}% | "
+          f"Soft pass = Calmar > 0.5 and MaxDD <= {OOS_SOFT_MAX_DD_CAP:.1f}%\033[0m\n")
 
     top_k_trials = sorted(completed, key=lambda t: t.value or -999, reverse=True)[:OOS_TOP_K]
 
@@ -884,7 +908,7 @@ def run_optimization(
     # percentage consistent with the column header "OOS MaxDD".
     print(f"  {'Rank':>4}  {'Trial':>6}  {'IS Score':>9}  {'OOS CAGR':>9}  "
           f"{'OOS MaxDD':>9}  {'OOS Calmar':>10}  {'Status'}")
-    print(f"  {'─'*75}")
+    print(f"  {'─'*79}")
 
     oos_results_list = []
 
@@ -916,7 +940,16 @@ def run_optimization(
                 oos_calmar > 0.5
                 and abs(oos_maxdd) <= OOS_MAX_DD_CAP
             )
-            status = "\033[32mPASS\033[0m" if passes else "\033[31mFAIL\033[0m"
+            soft_pass = (
+                oos_calmar > 0.5
+                and abs(oos_maxdd) <= OOS_SOFT_MAX_DD_CAP
+            )
+            if passes:
+                status = "\033[32mPASS\033[0m"
+            elif soft_pass:
+                status = "\033[33mNEAR\033[0m"
+            else:
+                status = "\033[31mFAIL\033[0m"
 
             # FIX-MB-OPT-03: display abs(oos_maxdd) for positive readability
             print(
@@ -938,7 +971,7 @@ def run_optimization(
                 f"{'ERROR':>9}  {'—':>9}  {'—':>10}  \033[31mERROR: {exc}\033[0m"
             )
 
-    print(f"  {'─'*75}\n")
+    print(f"  {'─'*79}\n")
 
     if not oos_results_list:
         raise RuntimeError(

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -113,8 +113,15 @@ def test_objective_propagates_unexpected_errors(monkeypatch):
 
 def test_objective_returns_numeric_score_without_hard_drawdown_prune(monkeypatch):
     class _Result:
-        metrics = {"cagr": 10.0, "max_dd": 30.0, "turnover": 0.0}
-        rebal_log = None
+        metrics = {"cagr": 10.0, "max_dd": 20.0, "turnover": 0.0}
+        rebal_log = pd.DataFrame(
+            {
+                "realised_cvar": [0.01, 0.01, 0.01],
+                "exposure_multiplier": [1.0, 1.0, 1.0],
+                "n_positions": [8, 8, 8],
+                "apply_decay": [False, False, False],
+            }
+        )
 
     monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
 
@@ -122,14 +129,51 @@ def test_objective_returns_numeric_score_without_hard_drawdown_prune(monkeypatch
     trial = optuna.trial.FixedTrial(
         {
             "HALFLIFE_FAST": 21,
-            "HALFLIFE_SLOW": 63,
+            "HALFLIFE_SLOW": 65,
             "CONTINUITY_BONUS": 0.15,
-            "RISK_AVERSION": 5.0,
+            "RISK_AVERSION": 12.0,
             "CVAR_DAILY_LIMIT": 0.04,
         }
     )
 
     assert isinstance(objective(trial), numbers.Real)
+
+
+def test_fitness_penalizes_explicit_forced_cash_events():
+    metrics = {"cagr": 12.0, "max_dd": 10.0, "turnover": 0.0}
+    base_rebal = pd.DataFrame(
+        {
+            "realised_cvar": [0.01, 0.01, 0.01, 0.01],
+            "exposure_multiplier": [1.0, 1.0, 1.0, 1.0],
+            "n_positions": [8, 8, 8, 8],
+            "apply_decay": [False, False, False, False],
+        }
+    )
+    forced_rebal = base_rebal.assign(forced_to_cash=[False, True, False, True], n_positions=[8, 0, 8, 0])
+
+    base_score, base_diag = optimizer._fitness_from_metrics(metrics, base_rebal)
+    forced_score, forced_diag = optimizer._fitness_from_metrics(metrics, forced_rebal)
+
+    assert forced_diag["forced_cash_penalty"] > 0.0
+    assert forced_score < base_score
+    assert base_diag["forced_cash_penalty"] == 0.0
+
+
+def test_fitness_falls_back_to_decay_and_zero_positions_when_forced_cash_flag_missing():
+    metrics = {"cagr": 12.0, "max_dd": 10.0, "turnover": 0.0}
+    rebal_log = pd.DataFrame(
+        {
+            "realised_cvar": [0.01, 0.01, 0.01, 0.01],
+            "exposure_multiplier": [1.0, 1.0, 1.0, 1.0],
+            "n_positions": [8, 0, 8, 0],
+            "apply_decay": [False, True, False, True],
+        }
+    )
+
+    score, diag = optimizer._fitness_from_metrics(metrics, rebal_log)
+
+    assert score < 0.75
+    assert diag["forced_cash_penalty"] == pytest.approx(0.75)
 
 
 def test_save_optimal_config_replaces_existing_file_atomically(tmp_path: Path):
@@ -180,8 +224,8 @@ def test_pre_load_data_deduplicates_inputs_and_appends_crsldx_index(monkeypatch)
 
     result = optimizer.pre_load_data("  NSE_TOTAL ")
 
-    assert result == {"ok": True}
-    assert captured["required_start"] == "2020-01-01"
+    assert result == {"market_data": {"ok": True}, "precomputed_matrices": None}
+    assert captured["required_start"] == optimizer._compute_warmup_start("2020-01-01", optimizer.UltimateConfig())
     assert captured["required_end"] == "2020-12-31"
     assert captured["tickers"].count("ABC") == 1
     assert "^NSEI" in captured["tickers"]
@@ -216,8 +260,8 @@ def test_pre_load_data_includes_historical_union_for_nifty500(monkeypatch):
 
     result = optimizer.pre_load_data("nifty500")
 
-    assert result == {"ok": True}
-    assert captured["required_start"] == "2020-01-01"
+    assert result == {"market_data": {"ok": True}, "precomputed_matrices": None}
+    assert captured["required_start"] == optimizer._compute_warmup_start("2020-01-01", optimizer.UltimateConfig())
     assert captured["required_end"] == "2020-03-31"
     assert "LIVEONLY" in captured["tickers"]
     assert "OLD1" in captured["tickers"]
@@ -347,15 +391,27 @@ def test_run_optimization_forces_single_job(monkeypatch):
     captured = {}
 
     class _Study:
-        best_trials = [object()]
         best_params = {
             "HALFLIFE_FAST": 21,
-            "HALFLIFE_SLOW": 63,
+            "HALFLIFE_SLOW": 65,
             "CONTINUITY_BONUS": 0.15,
-            "RISK_AVERSION": 5.0,
+            "RISK_AVERSION": 12.0,
             "CVAR_DAILY_LIMIT": 0.04,
         }
         best_value = 1.23
+        best_trial = optuna.trial.create_trial(
+            params=best_params,
+            distributions={
+                "HALFLIFE_FAST": optuna.distributions.IntDistribution(15, 30, step=1),
+                "HALFLIFE_SLOW": optuna.distributions.IntDistribution(60, 100, step=1),
+                "CONTINUITY_BONUS": optuna.distributions.FloatDistribution(0.06, 0.20),
+                "RISK_AVERSION": optuna.distributions.FloatDistribution(12.0, 20.0),
+                "CVAR_DAILY_LIMIT": optuna.distributions.FloatDistribution(0.04, 0.06),
+            },
+            value=1.23,
+            user_attrs={},
+        )
+        best_trials = [best_trial]
 
         def optimize(self, objective, **kwargs):
             captured.update(kwargs)
@@ -385,15 +441,27 @@ def test_run_optimization_uses_selected_universe(monkeypatch):
     monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
 
     class _Study:
-        best_trials = [object()]
         best_params = {
             "HALFLIFE_FAST": 21,
-            "HALFLIFE_SLOW": 63,
+            "HALFLIFE_SLOW": 65,
             "CONTINUITY_BONUS": 0.15,
-            "RISK_AVERSION": 5.0,
+            "RISK_AVERSION": 12.0,
             "CVAR_DAILY_LIMIT": 0.04,
         }
         best_value = 1.23
+        best_trial = optuna.trial.create_trial(
+            params=best_params,
+            distributions={
+                "HALFLIFE_FAST": optuna.distributions.IntDistribution(15, 30, step=1),
+                "HALFLIFE_SLOW": optuna.distributions.IntDistribution(60, 100, step=1),
+                "CONTINUITY_BONUS": optuna.distributions.FloatDistribution(0.06, 0.20),
+                "RISK_AVERSION": optuna.distributions.FloatDistribution(12.0, 20.0),
+                "CVAR_DAILY_LIMIT": optuna.distributions.FloatDistribution(0.04, 0.06),
+            },
+            value=1.23,
+            user_attrs={},
+        )
+        best_trials = [best_trial]
 
         def optimize(self, objective, **kwargs):
             pass
@@ -438,15 +506,27 @@ def test_run_optimization_in_memory_uses_memory_storage_and_uncapped_n_jobs(monk
     captured = {}
 
     class _Study:
-        best_trials = [object()]
         best_params = {
             "HALFLIFE_FAST": 21,
-            "HALFLIFE_SLOW": 63,
+            "HALFLIFE_SLOW": 65,
             "CONTINUITY_BONUS": 0.15,
-            "RISK_AVERSION": 5.0,
+            "RISK_AVERSION": 12.0,
             "CVAR_DAILY_LIMIT": 0.04,
         }
         best_value = 1.23
+        best_trial = optuna.trial.create_trial(
+            params=best_params,
+            distributions={
+                "HALFLIFE_FAST": optuna.distributions.IntDistribution(15, 30, step=1),
+                "HALFLIFE_SLOW": optuna.distributions.IntDistribution(60, 100, step=1),
+                "CONTINUITY_BONUS": optuna.distributions.FloatDistribution(0.06, 0.20),
+                "RISK_AVERSION": optuna.distributions.FloatDistribution(12.0, 20.0),
+                "CVAR_DAILY_LIMIT": optuna.distributions.FloatDistribution(0.04, 0.06),
+            },
+            value=1.23,
+            user_attrs={},
+        )
+        best_trials = [best_trial]
 
         def optimize(self, objective, **kwargs):
             captured.update(kwargs)


### PR DESCRIPTION
### Motivation

- Surface and record explicit "forced to cash" rebalances so the optimizer can detect fragile strategies that are repeatedly forced out of the market.
- Penalize strategies that are forced to cash during rebalances in the IS fitness to reduce selection of overfit/fragile parameter sets.
- Tighten search-space bounds and IS drawdown gates and provide a softer OOS pass tier to improve OOS validation discrimination.

### Description

- Backtest: include `forced_to_cash` and `force_cash_reason` fields in the rebalance log row emitted by `BacktestEngine` when `_force_full_cash` or `_exhaust_decay` occur.
- Fitness: add `forced_cash_penalty` computation inside `_fitness_from_metrics`, using the explicit `forced_to_cash` flag when present and falling back to `apply_decay` + zero `n_positions` heuristic when missing, then subtract this penalty from the raw score and include it in diagnostics.
- Optimization config and logging: introduce `OOS_SOFT_MAX_DD_CAP`, tighten `SEARCH_SPACE_BOUNDS` ranges, reduce `IS_DD_GATE` and `IS_DD_PENALTY_PCT`, and surface forced-cash diagnostics and flags in trial logging and the best-trial table.
- OOS tournament: add a "NEAR" soft-pass status for trials that meet a looser max-drawdown threshold and update printed help text accordingly.
- Tests: update existing tests to reflect changed defaults and behaviour, and add tests `test_fitness_penalizes_explicit_forced_cash_events` and `test_fitness_falls_back_to_decay_and_zero_positions_when_forced_cash_flag_missing` to validate forced-cash detection and fallback logic.
- Misc: make `pre_load_data` expectations use the new warmup computation by asserting `required_start` equals `_compute_warmup_start(...)` in tests and adjust some optuna `best_trial` test scaffolding.

### Testing

- Ran the unit test suite with `pytest` including the updated `test_optimizer.py` file and the newly added forced-cash tests.
- All optimizer-related unit tests executed successfully and the new assertions around `forced_cash_penalty` and warmup `required_start` passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbf6ce5db8832c8ee7c45990a44a20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced OOS drawdown classification system with PASS (hard) and NEAR (soft) statuses
  * Added forced-cash penalty metrics to optimization scoring and reporting

* **Bug Fixes**
  * Corrected fold aggregation behavior when gate/anomaly events occur

* **Chores**
  * Updated parameter search bounds across multiple optimization variables
  * Adjusted IS drawdown thresholds and gate penalties
  * Enhanced diagnostic tables with forced-cash visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->