### PR TITLE
Fix scan context, rebalance accounting, backtest ADV/VWAP behavior, and split fractional slippage

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -18,8 +18,9 @@ BUG FIXES (murder board):
   the same series used for close (valuation_series) rather than always using
   close_adj. When AUTO_ADJUST_PRICES=False, signals and execution prices are
   now consistent.
-- FIX-MB-BE-03: _compute_metrics CAGR uses len(eq) not len(eq)-1 for the
-  periods count to eliminate the systematic off-by-one overstatement.
+- FIX-MB-BE-03: _compute_metrics CAGR now uses elapsed calendar time instead
+  of a bar-count proxy, eliminating the prior off-by-one overstatement and
+  making annualisation consistent across irregular trading calendars.
 - FIX-MB-C-02: run_backtest now slices precomputed_matrices to [warmup_start,
   end_date] on the time axis before handing them to BacktestEngine.run.
   Previously any caller that pre-built a full TRAIN_START→TEST_END matrix
@@ -441,6 +442,7 @@ class BacktestEngine:
 
             execute_rebalance(
                 self.state, target_weights, exec_prices, active_symbols, cfg,
+                adv_shares     = adv_vector,
                 date_context   = date,
                 trade_log      = self.trades,
                 apply_decay    = apply_decay and not _exhaust_decay,
@@ -612,15 +614,15 @@ def _execution_prices(
 ) -> np.ndarray:
     exec_px = close_prices.copy()
 
+    if open_px is not None and date in open_px.index:
+        opens = open_px.loc[date].reindex(symbols).values.astype(float)
+        exec_px = np.where(np.isfinite(opens) & (opens > 0), opens, exec_px)
+
     if high_px is not None and low_px is not None and date in high_px.index and date in low_px.index:
         highs = high_px.loc[date].reindex(symbols).values.astype(float)
         lows  = low_px.loc[date].reindex(symbols).values.astype(float)
         vwap  = (highs + lows + close_prices) / 3.0
         exec_px = np.where(np.isfinite(vwap) & (vwap > 0), vwap, exec_px)
-
-    if open_px is not None and date in open_px.index:
-        opens = open_px.loc[date].reindex(symbols).values.astype(float)
-        exec_px = np.where(np.isfinite(opens) & (opens > 0), opens, exec_px)
 
     return exec_px
 
@@ -818,7 +820,11 @@ def run_backtest(
                 row = market_data.get(sym)
             if row is not None and not row.empty and "Volume" in row.columns:
                 import numpy as _np
-                vol_dict[sym] = row["Volume"].replace(0, _np.nan).notna().cumsum()
+                valid_volume = row["Volume"].replace(0, _np.nan).notna().astype(float)
+                vol_dict[sym] = valid_volume.rolling(
+                    history_gate,
+                    min_periods=history_gate,
+                ).sum()
 
         if vol_dict:
             cum_vol_df = pd.DataFrame(vol_dict).sort_index()

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -469,7 +469,8 @@ def detect_and_apply_splits(state: PortfolioState, market_data: dict, cfg: Ultim
         new_entry = old_entry / split_ratio
 
         fractional_new_shares = max(0.0, theoretical_new_shares - new_shares)
-        fractional_value = fractional_new_shares * current_price
+        one_way_slip = (cfg.ROUND_TRIP_SLIPPAGE_BPS / 2) / 10_000.0
+        fractional_value = fractional_new_shares * current_price * max(0.0, 1.0 - one_way_slip)
         state.cash = round(state.cash + fractional_value, 10)
 
         logger.warning(
@@ -673,461 +674,466 @@ def _run_scan(
     # accumulated dead-letter symbols.  The `with` statement guarantees __exit__
     # is called on every exit path, including exceptions.
     _dead_letter = DeadLetterTracker(threshold=10)
-    with ScanContext(label=label):
-        cfg    = cfg_override if cfg_override else load_optimized_config()
-    engine = InstitutionalRiskEngine(cfg)
-    # FIX-MB2-EQUITYCAP: Only apply cfg defaults when the state field still holds
-    # its dataclass default (250 for equity_hist_cap, 12 for max_absent_periods).
-    # A user who persisted a custom value (e.g. equity_hist_cap=1000) must not have
-    # it silently reset to cfg.EQUITY_HIST_CAP=500 on every scan call.
-    if state.equity_hist_cap == 250:
-        state.equity_hist_cap = cfg.EQUITY_HIST_CAP
-    if state.max_absent_periods == 12:
-        state.max_absent_periods = cfg.MAX_ABSENT_PERIODS
 
-    today = pd.Timestamp(datetime.today().date())
-    next_due = _next_rebalance_due(state.last_rebalance_date, cfg.REBALANCE_FREQ)
-    rebalance_allowed = next_due is None or today >= next_due
-    if not rebalance_allowed:
-        logger.info(
-            "[Scan] Cadence gate active: last rebalance %s, next due %s (%s). Scan will mark-to-market only.",
-            state.last_rebalance_date,
-            next_due.strftime("%Y-%m-%d"),
-            cfg.REBALANCE_FREQ,
-        )
+    def _scan_body(cfg: UltimateConfig) -> tuple:
+        global _CONSECUTIVE_EMPTY_SCANS
+        engine = InstitutionalRiskEngine(cfg)
+        # FIX-MB2-EQUITYCAP: Only apply cfg defaults when the state field still holds
+        # its dataclass default (250 for equity_hist_cap, 12 for max_absent_periods).
+        # A user who persisted a custom value (e.g. equity_hist_cap=1000) must not have
+        # it silently reset to cfg.EQUITY_HIST_CAP=500 on every scan call.
+        if state.equity_hist_cap == 250:
+            state.equity_hist_cap = cfg.EQUITY_HIST_CAP
+        if state.max_absent_periods == 12:
+            state.max_absent_periods = cfg.MAX_ABSENT_PERIODS
 
-    end_date   = datetime.today().strftime("%Y-%m-%d")
-    start_date = (datetime.today() - timedelta(days=400)).strftime("%Y-%m-%d")
-
-    held_syms  = {to_ns(s) for s in state.shares.keys()}
-    all_syms   = list({to_ns(t) for t in universe} | held_syms | {"^NSEI", "^CRSLDX"})
-    _print_stage_status(
-        "Download",
-        0.35,
-        f"Fetching/caching OHLCV data ({start_date} → {end_date}) for {len(all_syms):,} instruments...",
-    )
-    market_data = load_or_fetch(all_syms, start_date, end_date, cfg=cfg)
-    _print_stage_status("Download", 1.0, f"Data ready. Starting iteration and signal analysis for {label}.")
-    _print_stage_status("Analysis", 0.10, "Normalizing market snapshots and benchmark regime inputs...")
-
-    idx_df = market_data.get("^CRSLDX")
-    if idx_df is None or idx_df.empty:
-        idx_df = market_data.get("^NSEI")
-
-    idx_slice    = idx_df.iloc[:-1] if idx_df is not None and not idx_df.empty else None
-
-    split_syms = detect_and_apply_splits(state, market_data, cfg)
-    if split_syms:
-        logger.warning("[Scan] Applied split adjustments for: %s", split_syms)
-
-    use_adj = getattr(cfg, "AUTO_ADJUST_PRICES", True)
-
-    close_d: Dict[str, pd.Series] = {}
-    for sym in universe:
-        ns = to_ns(sym)
-        if ns in market_data:
-            col = "Adj Close" if use_adj and "Adj Close" in market_data[ns].columns else "Close"
-            close_d[to_bare(ns)] = market_data[ns][col].ffill()
-
-    if not close_d:
-        # PROD-FIX-3: Circuit breaker — count consecutive empty-universe scans.
-        _CONSECUTIVE_EMPTY_SCANS += 1
-        _save_circuit_breaker_count(_CONSECUTIVE_EMPTY_SCANS)  # persist across restarts
-        logger.warning(
-            "[Scan] No data available for any universe symbol "
-            "(consecutive empty scans: %d / halt threshold: %d).",
-            _CONSECUTIVE_EMPTY_SCANS, _EMPTY_UNIVERSE_HALT_AFTER,
-        )
-        if _CONSECUTIVE_EMPTY_SCANS >= _EMPTY_UNIVERSE_HALT_AFTER:
-            raise RuntimeError(
-                f"[Scan] CIRCUIT BREAKER TRIPPED: {_CONSECUTIVE_EMPTY_SCANS} consecutive "
-                f"scans returned an empty universe (threshold={_EMPTY_UNIVERSE_HALT_AFTER}). "
-                "Possible data provider outage or misconfigured universe.  "
-                "Halting to prevent unintended full-cash drift.  "
-                "Set EMPTY_UNIVERSE_HALT_AFTER env var to adjust threshold."
-            )
-        for held_sym in list(state.shares.keys()):
-            if held_sym not in close_d:
-                state.absent_periods[held_sym] = int(state.absent_periods.get(held_sym, 0)) + 1
-        # PROD-FIX-5: flush dead-letter on early exit; ScanContext exits automatically
-        _dead_letter.flush()
-        return state, market_data
-
-    # PROD-FIX-3: Reset empty-universe circuit breaker — we have data.
-    _CONSECUTIVE_EMPTY_SCANS = 0
-    _save_circuit_breaker_count(0)  # persist reset so restarts start clean
-
-    _print_stage_status("Analysis", 0.35, f"Built close-price matrix for {len(close_d):,} active symbols.")
-
-    close    = pd.DataFrame(close_d).sort_index()
-    active   = list(close.columns)
-    prices   = close.iloc[-1].values.astype(float)
-    active_idx = {sym: i for i, sym in enumerate(active)}
-
-    # FIX-NEW-DW-02: replace NaN or non-positive prices with last_known_prices
-    # before any downstream computation (compute_book_cvar, execute_rebalance,
-    # record_eod).  compute_book_cvar does not guard against NaN in its prices
-    # argument — a NaN propagates into notional → pv → weights → CVaR, producing
-    # an incorrect (often zero) CVaR that suppresses the risk gate.
-    for _sym, _i in active_idx.items():
-        if not np.isfinite(prices[_i]) or prices[_i] <= 0:
-            _lkp = state.last_known_prices.get(_sym, 0.0)
-            prices[_i] = float(_lkp) if np.isfinite(_lkp) and _lkp > 0 else 0.0
-            # PROD-FIX-5: accumulate stale-price symbols for dead-letter report
-            _dead_letter.add(
-                _sym,
-                reason="stale_price" if (np.isfinite(_lkp) and _lkp > 0) else "no_price",
-                detail=f"last_known={_lkp:.4f}" if np.isfinite(_lkp) else "no_last_known",
+        today = pd.Timestamp(datetime.today().date())
+        next_due = _next_rebalance_due(state.last_rebalance_date, cfg.REBALANCE_FREQ)
+        rebalance_allowed = next_due is None or today >= next_due
+        if not rebalance_allowed:
+            logger.info(
+                "[Scan] Cadence gate active: last rebalance %s, next due %s (%s). Scan will mark-to-market only.",
+                state.last_rebalance_date,
+                next_due.strftime("%Y-%m-%d"),
+                cfg.REBALANCE_FREQ,
             )
 
-    mtm_notional = 0.0
-    for sym in state.shares:
-        if sym in active_idx:
-            px = prices[active_idx[sym]]
-            if np.isnan(px) or px <= 0:
-                px = float(state.last_known_prices.get(sym, 0.0))
-            mtm_notional += state.shares.get(sym, 0) * px
-    for _absent_sym in state.shares:
-        if _absent_sym not in active_idx:
-            _fallback_px = state.last_known_prices.get(_absent_sym, 0.0)
-            if _fallback_px > 0:
-                _absent_n = int(state.absent_periods.get(_absent_sym, 0))
-                _mtm_px = absent_symbol_effective_price(_fallback_px, _absent_n, cfg.MAX_ABSENT_PERIODS)
-                mtm_notional += state.shares[_absent_sym] * _mtm_px
-                logger.warning(
-                    "[Scan] Held symbol '%s' absent from current market data "
-                    "(possibly delisted/suspended). Absent %d/%d periods; "
-                    "last-known ₹%.2f haircut to ₹%.2f for PV. "
-                    "Force-close triggers at %d consecutive absent periods.",
-                    _absent_sym,
-                    _absent_n,
-                    cfg.MAX_ABSENT_PERIODS,
-                    _fallback_px,
-                    _mtm_px,
-                    cfg.MAX_ABSENT_PERIODS,
+        end_date   = datetime.today().strftime("%Y-%m-%d")
+        start_date = (datetime.today() - timedelta(days=400)).strftime("%Y-%m-%d")
+
+        held_syms  = {to_ns(s) for s in state.shares.keys()}
+        all_syms   = list({to_ns(t) for t in universe} | held_syms | {"^NSEI", "^CRSLDX"})
+        _print_stage_status(
+            "Download",
+            0.35,
+            f"Fetching/caching OHLCV data ({start_date} → {end_date}) for {len(all_syms):,} instruments...",
+        )
+        market_data = load_or_fetch(all_syms, start_date, end_date, cfg=cfg)
+        _print_stage_status("Download", 1.0, f"Data ready. Starting iteration and signal analysis for {label}.")
+        _print_stage_status("Analysis", 0.10, "Normalizing market snapshots and benchmark regime inputs...")
+
+        idx_df = market_data.get("^CRSLDX")
+        if idx_df is None or idx_df.empty:
+            idx_df = market_data.get("^NSEI")
+
+        idx_slice    = idx_df.iloc[:-1] if idx_df is not None and not idx_df.empty else None
+
+        split_syms = detect_and_apply_splits(state, market_data, cfg)
+        if split_syms:
+            logger.warning("[Scan] Applied split adjustments for: %s", split_syms)
+
+        use_adj = getattr(cfg, "AUTO_ADJUST_PRICES", True)
+
+        close_d: Dict[str, pd.Series] = {}
+        for sym in universe:
+            ns = to_ns(sym)
+            if ns in market_data:
+                col = "Adj Close" if use_adj and "Adj Close" in market_data[ns].columns else "Close"
+                close_d[to_bare(ns)] = market_data[ns][col].ffill()
+
+        if not close_d:
+            # PROD-FIX-3: Circuit breaker — count consecutive empty-universe scans.
+            _CONSECUTIVE_EMPTY_SCANS += 1
+            _save_circuit_breaker_count(_CONSECUTIVE_EMPTY_SCANS)  # persist across restarts
+            logger.warning(
+                "[Scan] No data available for any universe symbol "
+                "(consecutive empty scans: %d / halt threshold: %d).",
+                _CONSECUTIVE_EMPTY_SCANS, _EMPTY_UNIVERSE_HALT_AFTER,
+            )
+            if _CONSECUTIVE_EMPTY_SCANS >= _EMPTY_UNIVERSE_HALT_AFTER:
+                raise RuntimeError(
+                    f"[Scan] CIRCUIT BREAKER TRIPPED: {_CONSECUTIVE_EMPTY_SCANS} consecutive "
+                    f"scans returned an empty universe (threshold={_EMPTY_UNIVERSE_HALT_AFTER}). "
+                    "Possible data provider outage or misconfigured universe.  "
+                    "Halting to prevent unintended full-cash drift.  "
+                    "Set EMPTY_UNIVERSE_HALT_AFTER env var to adjust threshold."
                 )
-    pv = mtm_notional + state.cash
-    initial_cash = state.cash
-    initial_gross_exposure = mtm_notional / pv if pv > 0 else 1.0
-
-    close_hist    = close.iloc[:-1]
-    regime_score = compute_regime_score(idx_slice, cfg=cfg, universe_close_hist=close_hist)
-    log_rets      = np.log1p(close_hist.pct_change(fill_method=None).clip(lower=-0.99)).replace([np.inf, -np.inf], np.nan)
-    adv_arr       = compute_adv(market_data, active, cfg=cfg)
-    prev_w_arr    = np.array([state.weights.get(sym, 0.0) for sym in active])
-    _print_stage_status("Analysis", 0.55, "Running momentum iterations, liquidity filters, and risk gates...")
-
-    state.update_exposure(
-        regime_score,
-        state.realised_cvar(min_obs=cfg.CVAR_MIN_HISTORY),
-        cfg,
-        gross_exposure=initial_gross_exposure,
-    )
-
-    weights              = np.zeros(len(active))
-    apply_decay          = False
-    optimization_succeeded = False
-    total_slippage       = 0.0
-    trade_log: List[Trade] = []
-    sel_idx: List[int]   = []
-    _force_full_cash     = False
-    _soft_cvar_breach    = False
-    rebalanced_this_scan = False
-
-    # ── Book CVaR screen ──────────────────────────────────────────────────────
-    if state.shares:
-        book_cvar = compute_book_cvar(state, prices, active, log_rets, cfg)
-        hard_multiplier = getattr(cfg, "CVAR_HARD_BREACH_MULTIPLIER", 1.5)
-        hard_breach_threshold = cfg.CVAR_DAILY_LIMIT * hard_multiplier
-
-        if book_cvar > hard_breach_threshold:
-            logger.warning(
-                "[Scan] Book CVaR %.4f%% exceeds HARD limit %.4f%% (%.1fx) — "
-                "skipping optimization, forcing immediate liquidation.",
-                book_cvar * 100, hard_breach_threshold * 100, hard_multiplier,
-            )
-            state.consecutive_failures += 1
-            apply_decay      = True
-            _force_full_cash = True
-            activate_override_on_stress(state, cfg)
-        elif book_cvar > cfg.CVAR_DAILY_LIMIT + 1e-6:
-            _soft_cvar_breach = True
-            logger.info(
-                "[Scan] Book CVaR soft breach %.4f%% (limit %.4f%%, hard %.4f%%) — "
-                "running optimizer with CVaR constraint active.",
-                book_cvar * 100, cfg.CVAR_DAILY_LIMIT * 100, hard_breach_threshold * 100,
-            )
-
-    if rebalance_allowed and not _force_full_cash:
-        try:
-            raw_daily, adj_scores, sel_idx, gate_counts = generate_signals(
-                log_rets, adv_arr, cfg, prev_weights=state.weights
-            )
-            # FIX-MB-GATENAMES: Keys renamed to "history_failed" / "adv_failed" /
-            # "knife_failed". Log message now clearly states "removed by" each gate
-            # so operators can distinguish a data-provider outage (many history
-            # failures) from a volatility spike (many knife-gate removals).
-            logger.info(
-                "[Scan] Universe funnel: %d total → %d removed by history gate → "
-                "%d removed by ADV gate → %d removed by knife gate → %d selected.",
-                gate_counts.get("total", 0),
-                gate_counts.get("history_failed", 0),
-                gate_counts.get("adv_failed", 0),
-                gate_counts.get("knife_failed", 0),
-                gate_counts.get("selected", 0),
-            )
-            if not sel_idx:
-                raise OptimizationError("No valid universe candidates.", OptimizationErrorType.DATA)
-            sel_syms      = [active[i] for i in sel_idx]
-            sector_map    = get_sector_map(sel_syms, cfg=cfg)
-            known_sectors  = sorted(s for s in set(sector_map.values()) if s != "Unknown")
-            sec_idx        = {s: i for i, s in enumerate(known_sectors)}
-            sector_labels  = np.array(
-                [sec_idx.get(sector_map[sym], -1) for sym in sel_syms], dtype=int
-            )
-
-            weights_sel = engine.optimize(
-                expected_returns    = raw_daily[sel_idx],
-                historical_returns  = log_rets[[active[i] for i in sel_idx]],
-                execution_date      = pd.Timestamp(end_date),
-                adv_shares          = adv_arr[sel_idx],
-                prices              = prices[sel_idx],
-                portfolio_value     = pv,
-                prev_w              = prev_w_arr[sel_idx],
-                exposure_multiplier = state.exposure_multiplier,
-                sector_labels       = sector_labels,
-            )
-            weights[sel_idx]               = weights_sel
-            state.consecutive_failures     = 0
-            state.decay_rounds             = 0
-            optimization_succeeded         = True
-
-        except (OptimizationError, ValueError) as exc:
-            is_data_error = isinstance(exc, ValueError) or (
-                isinstance(exc, OptimizationError) and exc.error_type == OptimizationErrorType.DATA
-            )
-            if not is_data_error:
+            for held_sym in list(state.shares.keys()):
+                if held_sym not in close_d:
+                    state.absent_periods[held_sym] = int(state.absent_periods.get(held_sym, 0)) + 1
+            return state, market_data
+    
+        # PROD-FIX-3: Reset empty-universe circuit breaker — we have data.
+        _CONSECUTIVE_EMPTY_SCANS = 0
+        _save_circuit_breaker_count(0)  # persist reset so restarts start clean
+    
+        _print_stage_status("Analysis", 0.35, f"Built close-price matrix for {len(close_d):,} active symbols.")
+    
+        close    = pd.DataFrame(close_d).sort_index()
+        active   = list(close.columns)
+        prices   = close.iloc[-1].values.astype(float)
+        active_idx = {sym: i for i, sym in enumerate(active)}
+    
+        # FIX-NEW-DW-02: replace NaN or non-positive prices with last_known_prices
+        # before any downstream computation (compute_book_cvar, execute_rebalance,
+        # record_eod).  compute_book_cvar does not guard against NaN in its prices
+        # argument — a NaN propagates into notional → pv → weights → CVaR, producing
+        # an incorrect (often zero) CVaR that suppresses the risk gate.
+        for _sym, _i in active_idx.items():
+            if not np.isfinite(prices[_i]) or prices[_i] <= 0:
+                _lkp = state.last_known_prices.get(_sym, 0.0)
+                prices[_i] = float(_lkp) if np.isfinite(_lkp) and _lkp > 0 else 0.0
+                # PROD-FIX-5: accumulate stale-price symbols for dead-letter report
+                _dead_letter.add(
+                    _sym,
+                    reason="stale_price" if (np.isfinite(_lkp) and _lkp > 0) else "no_price",
+                    detail=f"last_known={_lkp:.4f}" if np.isfinite(_lkp) else "no_last_known",
+                )
+    
+        mtm_notional = 0.0
+        for sym in state.shares:
+            if sym in active_idx:
+                px = prices[active_idx[sym]]
+                if np.isnan(px) or px <= 0:
+                    px = float(state.last_known_prices.get(sym, 0.0))
+                mtm_notional += state.shares.get(sym, 0) * px
+        for _absent_sym in state.shares:
+            if _absent_sym not in active_idx:
+                _fallback_px = state.last_known_prices.get(_absent_sym, 0.0)
+                if _fallback_px > 0:
+                    _absent_n = int(state.absent_periods.get(_absent_sym, 0))
+                    _mtm_px = absent_symbol_effective_price(_fallback_px, _absent_n, cfg.MAX_ABSENT_PERIODS)
+                    mtm_notional += state.shares[_absent_sym] * _mtm_px
+                    logger.warning(
+                        "[Scan] Held symbol '%s' absent from current market data "
+                        "(possibly delisted/suspended). Absent %d/%d periods; "
+                        "last-known ₹%.2f haircut to ₹%.2f for PV. "
+                        "Force-close triggers at %d consecutive absent periods.",
+                        _absent_sym,
+                        _absent_n,
+                        cfg.MAX_ABSENT_PERIODS,
+                        _fallback_px,
+                        _mtm_px,
+                        cfg.MAX_ABSENT_PERIODS,
+                    )
+        pv = mtm_notional + state.cash
+        initial_cash = state.cash
+        initial_gross_exposure = mtm_notional / pv if pv > 0 else 1.0
+    
+        close_hist    = close.iloc[:-1]
+        regime_score = compute_regime_score(idx_slice, cfg=cfg, universe_close_hist=close_hist)
+        log_rets      = np.log1p(close_hist.pct_change(fill_method=None).clip(lower=-0.99)).replace([np.inf, -np.inf], np.nan)
+        adv_arr       = compute_adv(market_data, active, cfg=cfg)
+        prev_w_arr    = np.array([state.weights.get(sym, 0.0) for sym in active])
+        _print_stage_status("Analysis", 0.55, "Running momentum iterations, liquidity filters, and risk gates...")
+    
+        state.update_exposure(
+            regime_score,
+            state.realised_cvar(min_obs=cfg.CVAR_MIN_HISTORY),
+            cfg,
+            gross_exposure=initial_gross_exposure,
+        )
+    
+        weights              = np.zeros(len(active))
+        apply_decay          = False
+        optimization_succeeded = False
+        total_slippage       = 0.0
+        trade_log: List[Trade] = []
+        sel_idx: List[int]   = []
+        _force_full_cash     = False
+        _soft_cvar_breach    = False
+        rebalanced_this_scan = False
+    
+        # ── Book CVaR screen ──────────────────────────────────────────────────────
+        if state.shares:
+            book_cvar = compute_book_cvar(state, prices, active, log_rets, cfg)
+            hard_multiplier = getattr(cfg, "CVAR_HARD_BREACH_MULTIPLIER", 1.5)
+            hard_breach_threshold = cfg.CVAR_DAILY_LIMIT * hard_multiplier
+    
+            if book_cvar > hard_breach_threshold:
+                logger.warning(
+                    "[Scan] Book CVaR %.4f%% exceeds HARD limit %.4f%% (%.1fx) — "
+                    "skipping optimization, forcing immediate liquidation.",
+                    book_cvar * 100, hard_breach_threshold * 100, hard_multiplier,
+                )
                 state.consecutive_failures += 1
-                logger.error("Solver failure #%d: %s. Freezing state.", state.consecutive_failures, exc)
-                if _soft_cvar_breach:
-                    logger.warning(
-                        "Solver failure during active soft CVaR breach — "
-                        "bypassing 3-failure wait, triggering immediate decay."
-                    )
-                    apply_decay = True
-                elif state.consecutive_failures >= 3:
-                    logger.warning(
-                        "3 consecutive solver failures — triggering gate-filtered "
-                        "pro-rata liquidation (%.0f%% of gate-passing positions).",
-                        cfg.DECAY_FACTOR * 100,
-                    )
-                    apply_decay = True
+                apply_decay      = True
+                _force_full_cash = True
+                activate_override_on_stress(state, cfg)
+            elif book_cvar > cfg.CVAR_DAILY_LIMIT + 1e-6:
+                _soft_cvar_breach = True
+                logger.info(
+                    "[Scan] Book CVaR soft breach %.4f%% (limit %.4f%%, hard %.4f%%) — "
+                    "running optimizer with CVaR constraint active.",
+                    book_cvar * 100, cfg.CVAR_DAILY_LIMIT * 100, hard_breach_threshold * 100,
+                )
+    
+        if rebalance_allowed and not _force_full_cash:
+            try:
+                raw_daily, adj_scores, sel_idx, gate_counts = generate_signals(
+                    log_rets, adv_arr, cfg, prev_weights=state.weights
+                )
+                # FIX-MB-GATENAMES: Keys renamed to "history_failed" / "adv_failed" /
+                # "knife_failed". Log message now clearly states "removed by" each gate
+                # so operators can distinguish a data-provider outage (many history
+                # failures) from a volatility spike (many knife-gate removals).
+                logger.info(
+                    "[Scan] Universe funnel: %d total → %d removed by history gate → "
+                    "%d removed by ADV gate → %d removed by knife gate → %d selected.",
+                    gate_counts.get("total", 0),
+                    gate_counts.get("history_failed", 0),
+                    gate_counts.get("adv_failed", 0),
+                    gate_counts.get("knife_failed", 0),
+                    gate_counts.get("selected", 0),
+                )
+                if not sel_idx:
+                    raise OptimizationError("No valid universe candidates.", OptimizationErrorType.DATA)
+                sel_syms      = [active[i] for i in sel_idx]
+                sector_map    = get_sector_map(sel_syms, cfg=cfg)
+                known_sectors  = sorted(s for s in set(sector_map.values()) if s != "Unknown")
+                sec_idx        = {s: i for i, s in enumerate(known_sectors)}
+                sector_labels  = np.array(
+                    [sec_idx.get(sector_map[sym], -1) for sym in sel_syms], dtype=int
+                )
+    
+                weights_sel = engine.optimize(
+                    expected_returns    = raw_daily[sel_idx],
+                    historical_returns  = log_rets[[active[i] for i in sel_idx]],
+                    execution_date      = pd.Timestamp(end_date),
+                    adv_shares          = adv_arr[sel_idx],
+                    prices              = prices[sel_idx],
+                    portfolio_value     = pv,
+                    prev_w              = prev_w_arr[sel_idx],
+                    exposure_multiplier = state.exposure_multiplier,
+                    sector_labels       = sector_labels,
+                )
+                weights[sel_idx]               = weights_sel
+                state.consecutive_failures     = 0
+                state.decay_rounds             = 0
+                optimization_succeeded         = True
+    
+            except (OptimizationError, ValueError) as exc:
+                is_data_error = isinstance(exc, ValueError) or (
+                    isinstance(exc, OptimizationError) and exc.error_type == OptimizationErrorType.DATA
+                )
+                if not is_data_error:
+                    state.consecutive_failures += 1
+                    logger.error("Solver failure #%d: %s. Freezing state.", state.consecutive_failures, exc)
+                    if _soft_cvar_breach:
+                        logger.warning(
+                            "Solver failure during active soft CVaR breach — "
+                            "bypassing 3-failure wait, triggering immediate decay."
+                        )
+                        apply_decay = True
+                    elif state.consecutive_failures >= 3:
+                        logger.warning(
+                            "3 consecutive solver failures — triggering gate-filtered "
+                            "pro-rata liquidation (%.0f%% of gate-passing positions).",
+                            cfg.DECAY_FACTOR * 100,
+                        )
+                        apply_decay = True
+                else:
+                    logger.warning("Data error (empty universe / thin history): %s. Resetting counters and freezing state.", exc)
+                    state.consecutive_failures = 0
+                    state.decay_rounds = 0
+    
+        # ── Gate-filtered decay target computation ────────────────────────────────
+        _exhaust_decay = False
+        if apply_decay and not optimization_succeeded:
+            if _force_full_cash or state.decay_rounds >= cfg.MAX_DECAY_ROUNDS:
+                weights = np.zeros(len(active), dtype=float)
+                logger.warning(
+                    "[Scan] %s — forcing full liquidation to cash.",
+                    "Book CVaR breach" if _force_full_cash else
+                    f"MAX_DECAY_ROUNDS={cfg.MAX_DECAY_ROUNDS} exhausted",
+                )
+                _exhaust_decay = True
             else:
-                logger.warning("Data error (empty universe / thin history): %s. Resetting counters and freezing state.", exc)
-                state.consecutive_failures = 0
+                weights = compute_decay_targets(state, sel_idx, active, cfg, current_prices=prices, pv=pv)
+    
+        # FIX-MB-RESIDUALCASH: The residual-cash allocation is handled entirely inside
+        # execute_rebalance via its multi-pass proportional allocation loop, which
+        # operates on the actual post-sell cash balance. We must NOT attempt to size
+        # additional buys here against pv_exec (computed before sells execute) because
+        # after sells complete the available cash is lower than pv_exec implies, and
+        # oversizing here causes state.cash to go negative after slippage deduction.
+        # The execute_rebalance call below receives the target weights and handles
+        # residual distribution correctly with no pre-call adjustment needed.
+    
+        # Fix 2: Per-symbol price staleness gate.
+        # If any HELD position's last price bar is older than 2 trading days,
+        # something is wrong with the data feed for that symbol. Running a
+        # rebalance with a stale price for a held name can produce badly wrong
+        # weight calculations — better to skip and wait for fresh data.
+        # Exception: _force_full_cash (CVaR hard breach) always executes because
+        # liquidating to cash is safe regardless of price staleness.
+        _cadence_stale_held: list = []
+        _MAX_STALE_TRADING_DAYS = 2
+        if rebalance_allowed and not _force_full_cash and not close.empty:
+            _last_bar_date = close.index[-1]
+            # Count trading days between last bar and today using the close index
+            # (business-day calendar of actual market data in the matrix).
+            _trading_days_since_last = int(
+                (close.index <= today).sum() - len(close.index[close.index <= _last_bar_date])
+            )
+            # Simpler: how many bars ago is the last row relative to today?
+            _days_stale = (today - _last_bar_date).days
+            for _hsym in state.shares:
+                if _hsym not in active_idx:
+                    continue  # absent symbols handled by absent_periods
+                _sym_series = close.get(_hsym)
+                if _sym_series is None:
+                    continue
+                _last_valid = _sym_series.last_valid_index()
+                if _last_valid is None:
+                    _cadence_stale_held.append(_hsym)
+                    continue
+                # BUG-FIX-MONDAY: count bars in the close index that fall
+                # strictly after _last_valid and up to today.  This is NSE-calendar
+                # aware and never falsely fires on Monday (Friday close = 0 bars
+                # elapsed over the weekend, 1 bar elapsed by Monday close).
+                _bars_elapsed = int((close.index > _last_valid).sum())
+                if _bars_elapsed > _MAX_STALE_TRADING_DAYS:
+                    _cadence_stale_held.append(_hsym)
+            if _cadence_stale_held:
+                logger.warning(
+                    "[Scan] STALENESS GATE: skipping rebalance because %d held symbol(s) "
+                    "have prices older than %d trading days: %s. "
+                    "Wait for fresh market data before rebalancing.",
+                    len(_cadence_stale_held), _MAX_STALE_TRADING_DAYS, _cadence_stale_held,
+                )
+                rebalance_allowed = False
+    
+        # FIX-STALE-PRICE: Before executing a rebalance, check whether any held
+        # position has a price that is older than _STALE_PRICE_DAYS trading days.
+        # A rebalance using a 3-day-old price is likely worse than no rebalance,
+        # because the optimizer will size incorrectly relative to the current
+        # portfolio value. Force-liquidations (CVaR breach) are exempt — it is
+        # always safer to exit a position than to hold it with a stale price.
+        _STALE_PRICE_DAYS = 2  # trading days
+        _rebalance_stale_held: list = []
+        if optimization_succeeded and not _force_full_cash:
+            for _chk_sym in state.shares:
+                if _chk_sym not in active_idx:
+                    continue  # absent symbols handled by execute_rebalance itself
+                _chk_col = to_ns(_chk_sym)
+                _chk_df  = market_data.get(_chk_col) if market_data else None
+                if _chk_df is not None and not _chk_df.empty:
+                    _last_ts = _chk_df.index[-1]
+                    # Normalise timezone before comparison
+                    if hasattr(_last_ts, "tzinfo") and _last_ts.tzinfo is not None:
+                        _last_ts = _last_ts.tz_convert("UTC").tz_localize(None)
+                    _last_ts = pd.Timestamp(_last_ts)
+                    # BUG-FIX-MONDAY: use the close index (actual NSE trading
+                    # calendar) as the business-day ruler rather than raw calendar
+                    # days.  A Friday close evaluated on Monday gives 0 bars elapsed
+                    # (the weekend produced no trading bars), correctly passing the
+                    # gate.  Calendar-day arithmetic (today - last_ts).days would
+                    # yield 3, suppressing every Monday rebalance as a false alarm.
+                    _trading_bars_elapsed = int((close.index > _last_ts).sum())
+                    if _trading_bars_elapsed > _STALE_PRICE_DAYS:
+                        _rebalance_stale_held.append((_chk_sym, _trading_bars_elapsed))
+            if _rebalance_stale_held:
+                logger.warning(
+                    "[Scan] REBALANCE SUPPRESSED: %d held symbol(s) have prices "
+                    "older than %d trading bar(s) in the NSE close index: %s. "
+                    "Skipping rebalance to avoid sizing on stale data. "
+                    "Will retry on next scan once provider returns fresh data.",
+                    len(_rebalance_stale_held),
+                    _STALE_PRICE_DAYS,
+                    [(s, f"{d}d") for s, d in _rebalance_stale_held],
+                )
+                optimization_succeeded = False
+    
+        if (rebalance_allowed or _force_full_cash) and (optimization_succeeded or apply_decay):
+            _T_cvar = min(len(log_rets), cfg.CVAR_LOOKBACK)
+            _scenario_losses = -(
+                log_rets.iloc[-_T_cvar:]
+                .reindex(columns=active, fill_value=0.0)
+                .values
+            )
+            total_slippage = execute_rebalance(
+                state, weights, prices, active, cfg,
+                adv_shares=adv_arr,
+                date_context=today, trade_log=trade_log,
+                apply_decay    = apply_decay and not _exhaust_decay,
+                scenario_losses = None if _exhaust_decay else _scenario_losses,
+                force_rebalance_trades = _soft_cvar_breach,
+            )
+            state.last_rebalance_date = today.strftime("%Y-%m-%d")
+            rebalanced_this_scan = True
+            if _exhaust_decay:
                 state.decay_rounds = 0
-
-    # ── Gate-filtered decay target computation ────────────────────────────────
-    _exhaust_decay = False
-    if apply_decay and not optimization_succeeded:
-        if _force_full_cash or state.decay_rounds >= cfg.MAX_DECAY_ROUNDS:
-            weights = np.zeros(len(active), dtype=float)
-            logger.warning(
-                "[Scan] %s — forcing full liquidation to cash.",
-                "Book CVaR breach" if _force_full_cash else
-                f"MAX_DECAY_ROUNDS={cfg.MAX_DECAY_ROUNDS} exhausted",
-            )
-            _exhaust_decay = True
-        else:
-            weights = compute_decay_targets(state, sel_idx, active, cfg, current_prices=prices, pv=pv)
-
-    # FIX-MB-RESIDUALCASH: The residual-cash allocation is handled entirely inside
-    # execute_rebalance via its multi-pass proportional allocation loop, which
-    # operates on the actual post-sell cash balance. We must NOT attempt to size
-    # additional buys here against pv_exec (computed before sells execute) because
-    # after sells complete the available cash is lower than pv_exec implies, and
-    # oversizing here causes state.cash to go negative after slippage deduction.
-    # The execute_rebalance call below receives the target weights and handles
-    # residual distribution correctly with no pre-call adjustment needed.
-
-    # Fix 2: Per-symbol price staleness gate.
-    # If any HELD position's last price bar is older than 2 trading days,
-    # something is wrong with the data feed for that symbol. Running a
-    # rebalance with a stale price for a held name can produce badly wrong
-    # weight calculations — better to skip and wait for fresh data.
-    # Exception: _force_full_cash (CVaR hard breach) always executes because
-    # liquidating to cash is safe regardless of price staleness.
-    _stale_held: list = []
-    _MAX_STALE_TRADING_DAYS = 2
-    if rebalance_allowed and not _force_full_cash and not close.empty:
-        _last_bar_date = close.index[-1]
-        # Count trading days between last bar and today using the close index
-        # (business-day calendar of actual market data in the matrix).
-        _trading_days_since_last = int(
-            (close.index <= today).sum() - len(close.index[close.index <= _last_bar_date])
+                state.consecutive_failures = 0
+    
+        _print_stage_status("Analysis", 0.85, "Applying rebalance decisions and updating portfolio marks...")
+    
+        price_dict = {sym: prices[active_idx[sym]] for sym in active}
+        state.record_eod(price_dict)
+    
+        # FIX-MB-H-04: execute_rebalance already increments absent_periods for
+        # every held symbol not found in active_idx (and clears it for symbols
+        # that ARE present).  Running the same loop here after a rebalance causes
+        # a double-increment, halving the effective MAX_ABSENT_PERIODS grace period.
+        #
+        # Rule: absent_periods accounting belongs exclusively to execute_rebalance
+        # on rebalance days.  This post-scan loop only runs on mark-to-market-only
+        # days (cadence gate blocked the rebalance) so that absent positions are
+        # still tracked even when no rebalance fires.
+        if not rebalanced_this_scan:
+            for held_sym in list(state.shares.keys()):
+                if held_sym not in active_idx:
+                    state.absent_periods[held_sym] = int(state.absent_periods.get(held_sym, 0)) + 1
+                else:
+                    state.absent_periods.pop(held_sym, None)
+    
+        final_pv = state.equity_hist[-1] if state.equity_hist else pv
+    
+        logger.info(
+            "%s%s%s | Regime: %.2f | CVaR: %.2f%% | Failures: %d | "
+            "Equity: %s₹%s%s | Slippage: %s₹%s%s",
+            C.BLU, label, C.RST,
+            regime_score,
+            state.realised_cvar(min_obs=cfg.CVAR_MIN_HISTORY) * 100,
+            state.consecutive_failures,
+            C.GRN, f"{final_pv:,.0f}", C.RST,
+            C.RED, f"{total_slippage:,.0f}", C.RST,
         )
-        # Simpler: how many bars ago is the last row relative to today?
-        _days_stale = (today - _last_bar_date).days
-        for _hsym in state.shares:
-            if _hsym not in active_idx:
-                continue  # absent symbols handled by absent_periods
-            _sym_series = close.get(_hsym)
-            if _sym_series is None:
-                continue
-            _last_valid = _sym_series.last_valid_index()
-            if _last_valid is None:
-                _stale_held.append(_hsym)
-                continue
-            # BUG-FIX-MONDAY: count bars in the close index that fall
-            # strictly after _last_valid and up to today.  This is NSE-calendar
-            # aware and never falsely fires on Monday (Friday close = 0 bars
-            # elapsed over the weekend, 1 bar elapsed by Monday close).
-            _bars_elapsed = int((close.index > _last_valid).sum())
-            if _bars_elapsed > _MAX_STALE_TRADING_DAYS:
-                _stale_held.append(_hsym)
-        if _stale_held:
-            logger.warning(
-                "[Scan] STALENESS GATE: skipping rebalance because %d held symbol(s) "
-                "have prices older than %d trading days: %s. "
-                "Wait for fresh market data before rebalancing.",
-                len(_stale_held), _MAX_STALE_TRADING_DAYS, _stale_held,
-            )
-            rebalance_allowed = False
-
-    # FIX-STALE-PRICE: Before executing a rebalance, check whether any held
-    # position has a price that is older than _STALE_PRICE_DAYS trading days.
-    # A rebalance using a 3-day-old price is likely worse than no rebalance,
-    # because the optimizer will size incorrectly relative to the current
-    # portfolio value. Force-liquidations (CVaR breach) are exempt — it is
-    # always safer to exit a position than to hold it with a stale price.
-    _STALE_PRICE_DAYS = 2  # trading days
-    _stale_held: list = []
-    if optimization_succeeded and not _force_full_cash:
-        for _chk_sym in state.shares:
-            if _chk_sym not in active_idx:
-                continue  # absent symbols handled by execute_rebalance itself
-            _chk_col = to_ns(_chk_sym)
-            _chk_df  = market_data.get(_chk_col) if market_data else None
-            if _chk_df is not None and not _chk_df.empty:
-                _last_ts = _chk_df.index[-1]
-                # Normalise timezone before comparison
-                if hasattr(_last_ts, "tzinfo") and _last_ts.tzinfo is not None:
-                    _last_ts = _last_ts.tz_convert("UTC").tz_localize(None)
-                _last_ts = pd.Timestamp(_last_ts)
-                # BUG-FIX-MONDAY: use the close index (actual NSE trading
-                # calendar) as the business-day ruler rather than raw calendar
-                # days.  A Friday close evaluated on Monday gives 0 bars elapsed
-                # (the weekend produced no trading bars), correctly passing the
-                # gate.  Calendar-day arithmetic (today - last_ts).days would
-                # yield 3, suppressing every Monday rebalance as a false alarm.
-                _trading_bars_elapsed = int((close.index > _last_ts).sum())
-                if _trading_bars_elapsed > _STALE_PRICE_DAYS:
-                    _stale_held.append((_chk_sym, _trading_bars_elapsed))
-        if _stale_held:
-            logger.warning(
-                "[Scan] REBALANCE SUPPRESSED: %d held symbol(s) have prices "
-                "older than %d trading bar(s) in the NSE close index: %s. "
-                "Skipping rebalance to avoid sizing on stale data. "
-                "Will retry on next scan once provider returns fresh data.",
-                len(_stale_held),
-                _STALE_PRICE_DAYS,
-                [(s, f"{d}d") for s, d in _stale_held],
-            )
-            optimization_succeeded = False
-
-    if (rebalance_allowed or _force_full_cash) and (optimization_succeeded or apply_decay):
-        _T_cvar = min(len(log_rets), cfg.CVAR_LOOKBACK)
-        _scenario_losses = -(
-            log_rets.iloc[-_T_cvar:]
-            .reindex(columns=active, fill_value=0.0)
-            .values
-        )
-        total_slippage = execute_rebalance(
-            state, weights, prices, active, cfg,
-            adv_shares=adv_arr,
-            date_context=today, trade_log=trade_log,
-            apply_decay    = apply_decay and not _exhaust_decay,
-            scenario_losses = None if _exhaust_decay else _scenario_losses,
-            force_rebalance_trades = _soft_cvar_breach,
-        )
-        state.last_rebalance_date = today.strftime("%Y-%m-%d")
-        rebalanced_this_scan = True
-        if _exhaust_decay:
-            state.decay_rounds = 0
-            state.consecutive_failures = 0
-
-    _print_stage_status("Analysis", 0.85, "Applying rebalance decisions and updating portfolio marks...")
-
-    price_dict = {sym: prices[active_idx[sym]] for sym in active}
-    state.record_eod(price_dict)
-
-    # FIX-MB-H-04: execute_rebalance already increments absent_periods for
-    # every held symbol not found in active_idx (and clears it for symbols
-    # that ARE present).  Running the same loop here after a rebalance causes
-    # a double-increment, halving the effective MAX_ABSENT_PERIODS grace period.
-    #
-    # Rule: absent_periods accounting belongs exclusively to execute_rebalance
-    # on rebalance days.  This post-scan loop only runs on mark-to-market-only
-    # days (cadence gate blocked the rebalance) so that absent positions are
-    # still tracked even when no rebalance fires.
-    if not rebalanced_this_scan:
-        for held_sym in list(state.shares.keys()):
-            if held_sym not in active_idx:
-                state.absent_periods[held_sym] = int(state.absent_periods.get(held_sym, 0)) + 1
-            else:
-                state.absent_periods.pop(held_sym, None)
-
-    final_pv = state.equity_hist[-1] if state.equity_hist else pv
-
-    logger.info(
-        "%s%s%s | Regime: %.2f | CVaR: %.2f%% | Failures: %d | "
-        "Equity: %s₹%s%s | Slippage: %s₹%s%s",
-        C.BLU, label, C.RST,
-        regime_score,
-        state.realised_cvar(min_obs=cfg.CVAR_MIN_HISTORY) * 100,
-        state.consecutive_failures,
-        C.GRN, f"{final_pv:,.0f}", C.RST,
-        C.RED, f"{total_slippage:,.0f}", C.RST,
-    )
-
-    elapsed = time.perf_counter() - scan_started_at
-    _print_stage_status("Analysis", 1.0, f"{label} completed in {elapsed:.1f}s.")
-
-    if trade_log:
-        final_mtm = sum(state.shares.get(sym, 0) * prices[active_idx[sym]] for sym in state.shares if sym in active_idx)
-        final_gross_exposure = final_mtm / final_pv if final_pv > 0 else 0.0
-        net_cash_delta = state.cash - initial_cash
-
-        print(f"\n  {C.B_CYN}=== PHASE A: TRADE INTENT SUMMARY ==={C.RST}")
-        print(f"  {C.GRY}{'─' * 66}{C.RST}")
-        print(f"  {C.BLD}Gross Exp Before:{C.RST} {initial_gross_exposure:>7.1%}")
-        print(f"  {C.BLD}Gross Exp After: {C.RST} {final_gross_exposure:>7.1%}")
-        cash_color = C.B_GRN if net_cash_delta >= 0 else C.B_RED
-        print(f"  {C.BLD}Net Cash Delta:  {C.RST} {cash_color}₹{net_cash_delta:+,.0f}{C.RST}")
-        print(f"  {C.BLD}Total Slippage:  {C.RST} {C.RED}₹{total_slippage:,.0f}{C.RST}")
-
-        largest_trade = max(trade_log, key=lambda t: abs(t.delta_shares) * t.exec_price, default=None)
-        if largest_trade:
-            notional = abs(largest_trade.delta_shares) * largest_trade.exec_price
-            print(f"  {C.BLD}Largest Change:  {C.RST} {largest_trade.direction} {largest_trade.symbol} (₹{notional:,.0f})")
-
-        print(f"\n  {C.B_CYN}=== PHASE B: EXECUTION ACTION SHEET ==={C.RST}")
-        print(f"  {C.GRY}{'─' * 66}{C.RST}")
-
-        sorted_trades = sorted(trade_log, key=lambda t: state.weights.get(t.symbol, 0.0), reverse=True)
-
-        for t in sorted_trades:
-            action_color = C.B_GRN if t.direction == "BUY" else C.B_RED
-            target_weight = state.weights.get(t.symbol, 0.0)
-            print(
-                f"  {action_color}{t.direction:<4}{C.RST} | {C.BLD}{t.symbol:<12}{C.RST} | "
-                f"{abs(t.delta_shares):>6,d} shares @ ≈ ₹{t.exec_price:>9,.2f} | Tgt: {C.CYN}{target_weight:>5.1%}{C.RST}"
-            )
-        print(f"  {C.GRY}{'─' * 66}{C.RST}\n")
-
-    # PROD-FIX-5: flush dead-letter tracker; ScanContext.__exit__ runs automatically
-        _dead_letter.flush()
-    return state, market_data
+    
+        elapsed = time.perf_counter() - scan_started_at
+        _print_stage_status("Analysis", 1.0, f"{label} completed in {elapsed:.1f}s.")
+    
+        if trade_log:
+            final_mtm = sum(state.shares.get(sym, 0) * prices[active_idx[sym]] for sym in state.shares if sym in active_idx)
+            final_gross_exposure = final_mtm / final_pv if final_pv > 0 else 0.0
+            net_cash_delta = state.cash - initial_cash
+    
+            print(f"\n  {C.B_CYN}=== PHASE A: TRADE INTENT SUMMARY ==={C.RST}")
+            print(f"  {C.GRY}{'─' * 66}{C.RST}")
+            print(f"  {C.BLD}Gross Exp Before:{C.RST} {initial_gross_exposure:>7.1%}")
+            print(f"  {C.BLD}Gross Exp After: {C.RST} {final_gross_exposure:>7.1%}")
+            cash_color = C.B_GRN if net_cash_delta >= 0 else C.B_RED
+            print(f"  {C.BLD}Net Cash Delta:  {C.RST} {cash_color}₹{net_cash_delta:+,.0f}{C.RST}")
+            print(f"  {C.BLD}Total Slippage:  {C.RST} {C.RED}₹{total_slippage:,.0f}{C.RST}")
+    
+            largest_trade = max(trade_log, key=lambda t: abs(t.delta_shares) * t.exec_price, default=None)
+            if largest_trade:
+                notional = abs(largest_trade.delta_shares) * largest_trade.exec_price
+                print(f"  {C.BLD}Largest Change:  {C.RST} {largest_trade.direction} {largest_trade.symbol} (₹{notional:,.0f})")
+    
+            print(f"\n  {C.B_CYN}=== PHASE B: EXECUTION ACTION SHEET ==={C.RST}")
+            print(f"  {C.GRY}{'─' * 66}{C.RST}")
+    
+            sorted_trades = sorted(trade_log, key=lambda t: state.weights.get(t.symbol, 0.0), reverse=True)
+    
+            for t in sorted_trades:
+                action_color = C.B_GRN if t.direction == "BUY" else C.B_RED
+                target_weight = state.weights.get(t.symbol, 0.0)
+                print(
+                    f"  {action_color}{t.direction:<4}{C.RST} | {C.BLD}{t.symbol:<12}{C.RST} | "
+                    f"{abs(t.delta_shares):>6,d} shares @ ≈ ₹{t.exec_price:>9,.2f} | Tgt: {C.CYN}{target_weight:>5.1%}{C.RST}"
+                )
+            print(f"  {C.GRY}{'─' * 66}{C.RST}\n")
+    
+        return state, market_data
+    
+    with ScanContext(label=label):
+        cfg = cfg_override if cfg_override else load_optimized_config()
+        try:
+            return _scan_body(cfg)
+        finally:
+            # PROD-FIX-5: flush the tracker while the scan correlation_id is still active.
+            _dead_letter.flush()
 
 
 # ─── Status display ───────────────────────────────────────────────────────────

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -658,10 +658,13 @@ def execute_rebalance(
                             cfg.MAX_ABSENT_PERIODS,
                         )
                     if px_exec > 0 and n_shares > 0:
-                        # MB-C-03: do NOT add force-close proceeds to pv_exec here.
-                        # Phase 2 (below) unconditionally handles all symbols_to_force_close.
-                        # Adding them here as well would double-count their proceeds and
-                        # inflate state.cash by up to 2x the force-closed notional.
+                        # FIX-MB-C-03: full-liquidation returns before Phase 2,
+                        # so any force-close candidate excluded from Phase 1
+                        # must have its proceeds restored here exactly once.
+                        # Active/retained names are already included in pv_exec;
+                        # only symbols explicitly excluded from Phase 1 need this.
+                        if sym in symbols_to_force_close:
+                            pv_exec += n_shares * px_exec
                         slip            = n_shares * px_exec * exit_slip_rate
                         total_slippage += slip
                         if trade_log is not None:

--- a/signals.py
+++ b/signals.py
@@ -456,11 +456,6 @@ def generate_signals(
                 stale_denied,
                 liquidity_denied,
             )
-            logging.getLogger().debug(
-                "[Signals] Continuity denied for %d stale and %d illiquid symbols.",
-                stale_denied,
-                liquidity_denied,
-            )
 
     # FIX-NAN-ARGSORT: replace any residual NaN in adj_scores with -inf before
     # sorting.  NumPy places NaN at the END of an argsort result (highest indices),

--- a/test_backtest_engine.py
+++ b/test_backtest_engine.py
@@ -50,6 +50,46 @@ def test_rebalance_values_portfolio_from_previous_close(monkeypatch):
     assert captured["pv"] == 200.0
 
 
+def test_run_rebalance_passes_adv_vector_to_execute_rebalance(monkeypatch):
+    cfg = UltimateConfig(CVAR_MIN_HISTORY=9999)
+    engine = InstitutionalRiskEngine(cfg)
+    bt = be.BacktestEngine(engine, initial_cash=100.0)
+
+    dates = pd.DatetimeIndex([pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")])
+    close = pd.DataFrame({"AAA": [10.0, 11.0]}, index=dates)
+    volume = pd.DataFrame({"AAA": [1_000_000, 1_000_000]}, index=dates)
+    returns = close.pct_change(fill_method=None).fillna(0.0)
+    captured = {}
+
+    monkeypatch.setattr(be, "generate_signals", lambda *_args, **_kwargs: (np.array([0.01]), np.array([0.01]), [0], {}))
+    monkeypatch.setattr(be, "compute_regime_score", lambda *_args, **_kwargs: 0.5)
+    monkeypatch.setattr(be, "compute_book_cvar", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(be, "_build_adv_vector", lambda *_args, **_kwargs: np.array([12345.0]))
+    monkeypatch.setattr(engine, "optimize", lambda **_kwargs: np.array([1.0]))
+
+    def _fake_execute_rebalance(*_args, **kwargs):
+        captured["adv_shares"] = kwargs.get("adv_shares")
+        return 0.0
+
+    monkeypatch.setattr(be, "execute_rebalance", _fake_execute_rebalance)
+
+    bt._run_rebalance(
+        pd.Timestamp("2020-01-02"),
+        close,
+        volume,
+        returns,
+        ["AAA"],
+        close.loc[pd.Timestamp("2020-01-02")].values.astype(float),
+        idx_df=None,
+        sector_map=None,
+        open_px=close,
+        high_px=close,
+        low_px=close,
+    )
+
+    assert np.array_equal(captured["adv_shares"], np.array([12345.0]))
+
+
 def test_run_skips_corporate_actions_when_auto_adjust_prices_enabled(monkeypatch):
     cfg = UltimateConfig(AUTO_ADJUST_PRICES=True, DIVIDEND_SWEEP=True, CVAR_MIN_HISTORY=9999)
     engine = InstitutionalRiskEngine(cfg)
@@ -124,6 +164,63 @@ def test_run_backtest_uses_adjusted_close_for_valuation_when_auto_adjust_enabled
         )
 
     assert list(captured["close"]["AAA"]) == [100.0, 100.0]
+
+
+def test_execution_prices_prefers_vwap_when_intraday_range_available():
+    date = pd.Timestamp("2020-01-02")
+    symbols = ["AAA"]
+    close_prices = np.array([12.0])
+    open_px = pd.DataFrame({"AAA": [10.0]}, index=[date])
+    high_px = pd.DataFrame({"AAA": [15.0]}, index=[date])
+    low_px = pd.DataFrame({"AAA": [9.0]}, index=[date])
+
+    exec_px = be._execution_prices(symbols, date, close_prices, open_px, high_px, low_px)
+
+    assert exec_px[0] == 12.0
+
+
+def test_run_backtest_custom_universe_requires_recent_contiguous_volume():
+    cfg = UltimateConfig(HISTORY_GATE=3, REBALANCE_FREQ="D")
+    idx = pd.DatetimeIndex([
+        pd.Timestamp("2020-01-01"),
+        pd.Timestamp("2020-01-02"),
+        pd.Timestamp("2020-01-03"),
+        pd.Timestamp("2020-01-10"),
+        pd.Timestamp("2020-01-13"),
+    ])
+    market_data = {
+        "AAA.NS": pd.DataFrame(
+            {
+                "Close": [10.0, 10.0, 10.0, 10.0, 10.0],
+                "Adj Close": [10.0, 10.0, 10.0, 10.0, 10.0],
+                "Open": [10.0, 10.0, 10.0, 10.0, 10.0],
+                "High": [10.0, 10.0, 10.0, 10.0, 10.0],
+                "Low": [10.0, 10.0, 10.0, 10.0, 10.0],
+                "Volume": [100.0, 100.0, 100.0, 0.0, 100.0],
+                "Dividends": [0.0] * 5,
+                "Stock Splits": [0.0] * 5,
+            },
+            index=idx,
+        ),
+        "^NSEI": pd.DataFrame({"Close": [1.0] * 5}, index=idx),
+    }
+    captured = {}
+
+    def _fake_run(self, close, volume, returns, rebalance_dates, start_date, **kwargs):
+        captured["universe_by_rebalance_date"] = kwargs["universe_by_rebalance_date"]
+        return pd.DataFrame({"equity": pd.Series(dtype=float)})
+
+    import unittest.mock as mock
+    with mock.patch.object(be.BacktestEngine, "run", _fake_run):
+        be.run_backtest(
+            market_data=market_data,
+            start_date="2020-01-10",
+            end_date="2020-01-13",
+            cfg=cfg,
+            universe=["AAA"],
+        )
+
+    assert captured["universe_by_rebalance_date"][pd.Timestamp("2020-01-13")] == set()
 
 
 def test_backtest_run_handles_empty_close_dataframe():

--- a/test_daily_workflow.py
+++ b/test_daily_workflow.py
@@ -9,6 +9,7 @@ import pytest
 
 import daily_workflow as dw
 from momentum_engine import PortfolioState, UltimateConfig, execute_rebalance
+from log_config import current_correlation_id
 
 
 def test_prompt_menu_choice_retries_until_valid(monkeypatch):
@@ -71,6 +72,53 @@ def test_run_scan_returns_early_when_universe_has_no_data(monkeypatch):
     assert returned_state is state
     assert "^NSEI" in market_data
     assert captured["cfg"] is cfg
+
+
+def test_run_scan_keeps_context_active_and_flushes_dead_letter_without_trades(monkeypatch):
+    idx = pd.date_range("2024-01-01", periods=6)
+    md = {
+        "ABC.NS": pd.DataFrame({"Close": [float("nan")] * 6, "Dividends": [0.0] * 6}, index=idx),
+        "^NSEI": pd.DataFrame({"Close": [100.0] * 6}, index=idx),
+        "^CRSLDX": pd.DataFrame({"Close": [100.0] * 6}, index=idx),
+    }
+    captured = {"engine_corr": None, "flush_corr": None, "flush_calls": 0}
+
+    class _FakeDeadLetterTracker:
+        def __init__(self, threshold=10):
+            self.entries = []
+
+        def add(self, symbol, reason, detail=""):
+            self.entries.append((symbol, reason, detail))
+
+        def flush(self, logger_name="dead_letter"):
+            captured["flush_calls"] += 1
+            captured["flush_corr"] = current_correlation_id()
+
+    class _Engine:
+        def __init__(self, _cfg):
+            captured["engine_corr"] = current_correlation_id()
+
+    monkeypatch.setattr(dw, "DeadLetterTracker", _FakeDeadLetterTracker)
+    monkeypatch.setattr(dw, "InstitutionalRiskEngine", _Engine)
+    monkeypatch.setattr(dw, "load_or_fetch", lambda *_args, **_kwargs: md)
+    monkeypatch.setattr(dw, "_print_stage_status", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(dw, "detect_and_apply_splits", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(dw, "compute_regime_score", lambda *_args, **_kwargs: 0.5)
+
+    state = PortfolioState(
+        shares={"ABC": 10},
+        entry_prices={"ABC": 100.0},
+        last_known_prices={"ABC": 99.0},
+        last_rebalance_date=datetime.today().strftime("%Y-%m-%d"),
+    )
+    cfg = UltimateConfig(REBALANCE_FREQ="W-FRI")
+
+    out_state, _ = dw._run_scan(["ABC"], state, "TEST", cfg_override=cfg)
+
+    assert out_state is state
+    assert captured["engine_corr"] is not None
+    assert captured["flush_calls"] == 1
+    assert captured["flush_corr"] == captured["engine_corr"]
 
 
 
@@ -190,6 +238,7 @@ def test_detect_and_apply_splits_applies_when_stock_splits_column_marks_event():
     assert adjusted == ["ABC"]
     assert state.shares["ABC"] == 20
     assert state.entry_prices["ABC"] == 500.0
+    assert state.cash == pytest.approx(0.0)
 
 
 def test_run_scan_cadence_gate_skips_rebalance(monkeypatch):
@@ -326,3 +375,28 @@ def test_detect_and_apply_splits_handles_tz_aware_split_index():
 
     assert adjusted == ["ABC"]
     assert state.shares["ABC"] == 20
+
+
+def test_detect_and_apply_splits_fractional_cash_applies_one_way_slippage():
+    cfg = UltimateConfig(AUTO_ADJUST_PRICES=False, ROUND_TRIP_SLIPPAGE_BPS=10.0)
+    state = PortfolioState(
+        shares={"ABC": 3},
+        entry_prices={"ABC": 100.0},
+        last_known_prices={"ABC": 100.0},
+        cash=0.0,
+    )
+    market_data = {
+        "ABC.NS": pd.DataFrame(
+            {
+                "Close": [200.0],
+                "Dividends": [0.0],
+                "Stock Splits": [0.5],
+            }
+        )
+    }
+
+    adjusted = dw.detect_and_apply_splits(state, market_data, cfg)
+
+    assert adjusted == ["ABC"]
+    assert state.shares["ABC"] == 1
+    assert state.cash == pytest.approx(99.95)

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -730,10 +730,14 @@ def test_detect_and_apply_splits_fractional_cash():
     state.last_known_prices = {"A": 100.0}
 
     market_data = {"A": pd.DataFrame({"Close": [200.0], "Stock Splits": [0.5]})}
-    detect_and_apply_splits(state, market_data, UltimateConfig(AUTO_ADJUST_PRICES=False))
+    detect_and_apply_splits(
+        state,
+        market_data,
+        UltimateConfig(AUTO_ADJUST_PRICES=False, ROUND_TRIP_SLIPPAGE_BPS=10.0),
+    )
 
     assert state.shares["A"] == 50, "Shares should floor correctly on splits."
-    assert state.cash == 100.0, "Fractional value must be safely routed to Cash."
+    assert state.cash == pytest.approx(99.95), "Fractional value must deduct one-way slippage."
 
 def test_detect_and_apply_splits_runs_even_when_auto_adjust_enabled():
     state = PortfolioState(cash=0.0)
@@ -1245,6 +1249,40 @@ def test_gated_position_force_closed_on_first_decay_bar():
 
     b_sells = [t for t in trade_log if t.symbol == "B" and t.direction == "SELL"]
     assert b_sells, "A SELL trade for B must be recorded."
+
+
+def test_decay_liquidation_restores_force_close_proceeds(monkeypatch):
+    cfg = UltimateConfig(MAX_ABSENT_PERIODS=3, CVAR_DAILY_LIMIT=0.01, ROUND_TRIP_SLIPPAGE_BPS=10.0)
+    state = PortfolioState(cash=0.0)
+    state.shares = {"LIVE": 1, "GHOST": 2}
+    state.entry_prices = {"LIVE": 100.0, "GHOST": 50.0}
+    state.last_known_prices = {"LIVE": 100.0, "GHOST": 50.0}
+    state.absent_periods = {"GHOST": cfg.MAX_ABSENT_PERIODS - 1}
+
+    original_absent_price = absent_symbol_effective_price
+
+    monkeypatch.setattr(
+        "momentum_engine.absent_symbol_effective_price",
+        lambda last_known_price, absent_periods, max_absent_periods: (
+            25.0 if absent_periods >= max_absent_periods else
+            original_absent_price(last_known_price, absent_periods, max_absent_periods)
+        ),
+    )
+
+    total_slip = execute_rebalance(
+        state=state,
+        target_weights=np.array([1.0]),
+        prices=np.array([100.0]),
+        active_symbols=["LIVE"],
+        cfg=cfg,
+        apply_decay=True,
+        scenario_losses=np.array([[1.0], [1.0], [1.0]]),
+    )
+
+    expected_gross = 100.0 + (2 * 25.0)
+    expected_cash = expected_gross - total_slip
+    assert state.shares == {}
+    assert state.cash == pytest.approx(expected_cash)
 
 
 def test_decay_rounds_reset_on_solver_success():


### PR DESCRIPTION
### Motivation
- Address several regressions where scan correlation IDs were not active for the full scan body and dead-letter entries could be flushed outside the context, causing loss of correlation and missing reports.
- Prevent cash destruction and accounting mismatches during decay-triggered full liquidations where force-close proceeds were omitted.
- Reconcile backtest vs live execution parity for ADV propagation, execution price selection, and recent-history PIT gating.
- Remove duplicated logging and align split handling so fractional-share credits apply the same one-way slippage used elsewhere.

### Description
- Move the full `_run_scan` body to execute inside `ScanContext` and flush `_dead_letter` inside a `finally` while the correlation ID remains active, and split stale-held tracking into separate cadence / rebalance checks to avoid shadowing issues (`daily_workflow.py`).
- Restore force-close proceeds in the decay full-liquidation path so force-close candidates excluded from Phase 1 have their proceeds added back before the early return (`momentum_engine.py`).
- Pass `adv_shares` through to `execute_rebalance` in the backtest path, change `_execution_prices` so VWAP takes precedence over open when intraday range is present, and tighten the custom-universe PIT volume gate to require recent contiguous volume (rolling sum over `HISTORY_GATE`) instead of cumulative counts (`backtest_engine.py`).
- Deduct one-way slippage from fractional-share cash credits on stock-split handling so live and backtest paths match (`daily_workflow.py`).
- Remove duplicate root-logger debug emission in continuity denial so the message is emitted once (`signals.py`).
- Added and updated focused regression tests that assert context/correlation behavior, split fractional slippage, decay liquidation proceeds, ADV propagation into execution, execution-price precedence, and recent-history PIT gating (`test_daily_workflow.py`, `test_momentum.py`, `test_backtest_engine.py`).

### Testing
- Performed syntax/compile check: `python -m py_compile daily_workflow.py backtest_engine.py momentum_engine.py signals.py test_daily_workflow.py test_backtest_engine.py test_momentum.py` — succeeded.
- Ran a focused pytest selection to validate the fixes: `pytest -q` for the targeted tests `test_run_scan_returns_early_when_universe_has_no_data`, `test_run_scan_keeps_context_active_and_flushes_dead_letter_without_trades`, `test_run_scan_increments_absent_periods_when_symbol_missing`, `test_detect_and_apply_splits_fractional_cash_applies_one_way_slippage`, `test_detect_and_apply_splits_fractional_cash`, `test_decay_liquidation_restores_force_close_proceeds`, `test_run_rebalance_passes_adv_vector_to_execute_rebalance`, `test_execution_prices_prefers_vwap_when_intraday_range_available`, `test_run_backtest_custom_universe_requires_recent_contiguous_volume` — all 9 tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd024b314c832ba34c4d1dc02eeed8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fractional share cash adjustment to properly account for execution slippage.
  * Fixed force-close proceeds accounting in decay liquidation scenarios.
  * Improved CAGR annualization to use elapsed calendar time for consistent results across irregular schedules.
  * Enhanced volume eligibility detection using rolling-window analysis.

* **Tests**
  * Added comprehensive test coverage for execution pricing, volume gating, split handling, and liquidation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->