### PR TITLE
Fix decay force-close liquidation pricing

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -649,7 +649,9 @@ def execute_rebalance(
                 )
                 exit_slip_rate = (cfg.ROUND_TRIP_SLIPPAGE_BPS / 2) / 10_000
                 for sym, n_shares in state.shares.items():
-                    if sym in active_idx:
+                    if sym in symbols_to_force_close:
+                        px_exec = float(state.last_known_prices.get(sym, 0.0))
+                    elif sym in active_idx:
                         px_exec = float(local_prices[active_idx[sym]])
                     else:
                         px_exec = absent_symbol_effective_price(

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -1252,7 +1252,7 @@ def test_gated_position_force_closed_on_first_decay_bar():
     assert b_sells, "A SELL trade for B must be recorded."
 
 
-def test_decay_liquidation_restores_force_close_proceeds(monkeypatch):
+def test_decay_liquidation_restores_force_close_proceeds():
     cfg = UltimateConfig(MAX_ABSENT_PERIODS=3, CVAR_DAILY_LIMIT=0.01, ROUND_TRIP_SLIPPAGE_BPS=10.0)
     state = PortfolioState(cash=0.0)
     state.shares = {"LIVE": 1, "GHOST": 2}
@@ -1260,15 +1260,11 @@ def test_decay_liquidation_restores_force_close_proceeds(monkeypatch):
     state.last_known_prices = {"LIVE": 100.0, "GHOST": 50.0}
     state.absent_periods = {"GHOST": cfg.MAX_ABSENT_PERIODS - 1}
 
-    original_absent_price = absent_symbol_effective_price
-
-    monkeypatch.setattr(
-        "momentum_engine.absent_symbol_effective_price",
-        lambda last_known_price, absent_periods, max_absent_periods: (
-            25.0 if absent_periods >= max_absent_periods else
-            original_absent_price(last_known_price, absent_periods, max_absent_periods)
-        ),
-    )
+    assert absent_symbol_effective_price(
+        50.0,
+        cfg.MAX_ABSENT_PERIODS,
+        cfg.MAX_ABSENT_PERIODS,
+    ) == 0.0
 
     total_slip = execute_rebalance(
         state=state,
@@ -1280,7 +1276,7 @@ def test_decay_liquidation_restores_force_close_proceeds(monkeypatch):
         scenario_losses=np.array([[1.0], [1.0], [1.0]]),
     )
 
-    expected_gross = 100.0 + (2 * 25.0)
+    expected_gross = 100.0 + (2 * 50.0)
     expected_cash = expected_gross - total_slip
     assert state.shares == {}
     assert state.cash == pytest.approx(expected_cash)


### PR DESCRIPTION
### Motivation
- Prevent force-closed positions from receiving zero proceeds when `absent_symbol_effective_price(..., MAX_ABSENT_PERIODS)` decays to `0.0` during the decay CVaR hard-breach early-return path.
- Align the early-return liquidation pricing semantics with the already-correct Phase 2 force-close behavior so force-closed names always restore proceeds using their last-known price.

### Description
- In `momentum_engine.py` changed the decay CVaR hard-breach liquidation loop to use `state.last_known_prices` for symbols in `symbols_to_force_close` instead of calling `absent_symbol_effective_price` for them, i.e. use `px_exec = float(state.last_known_prices.get(sym, 0.0))` for force-close candidates before other branches.
- Updated `test_momentum.py::test_decay_liquidation_restores_force_close_proceeds` to remove the monkeypatch of `absent_symbol_effective_price`, assert that the helper returns `0.0` at the max absence threshold, and verify that the force-closed position still restores proceeds at the last-known price.
- Modified only `momentum_engine.py` and `test_momentum.py` to implement the fix and tighten regression coverage.

### Testing
- Ran the targeted test suite with `pytest -q test_momentum.py -k 'decay_liquidation_restores_force_close_proceeds or force_close'`, which completed successfully (`3 passed, 83 deselected`).
- The updated regression test now exercises the real zero-price decay behavior and confirms proceeds are correctly restored for force-closed names.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd11bf9340832bbabef197f3b84341)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of pricing calculations for liquidated holdings during rebalancing.
  * Enhanced correctness of cash proceeds calculations from forced liquidations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->