### PR TITLE
Fix optimizer warmup & halt-sim, reconcile rate-limit retries, add sector-cache TTLs, and sync .env parsing

### DIFF
--- a/build_historical_fallback.py
+++ b/build_historical_fallback.py
@@ -55,7 +55,16 @@ def _load_env_file_fallback(env_path: Path = Path('.env')) -> None:
                 continue
             key, value = line.split('=', 1)
             key = key.strip()
-            value = value.strip().strip('"').strip("'")
+            value = value.strip()
+            if value and value[0] in ('"', "'"):
+                q = value[0]
+                if value.endswith(q) and len(value) >= 2:
+                    value = value[1:-1]
+            else:
+                for _sep in (' #', '\t#'):
+                    if _sep in value:
+                        value = value[:value.index(_sep)].rstrip()
+                        break
             if key and key not in os.environ:
                 os.environ[key] = value
     except Exception as exc:

--- a/data_cache.py
+++ b/data_cache.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 _RATE_LIMITED = object()
 
 # Maximum consecutive 429 retries per symbol before aborting
-_MAX_RATE_LIMIT_RETRIES = 10
+_MAX_RATE_LIMIT_RETRIES = 5
 
 
 def _load_local_env_file(env_path: Path = Path('.env')) -> None:
@@ -218,7 +218,7 @@ class GrowwProvider(DataProvider):
 
                 # FIX-MB-DC-02: abort after too many consecutive 429s to prevent
                 # infinite blocking (e.g. revoked token, suspended account).
-                if consecutive_rate_limits > _MAX_RATE_LIMIT_RETRIES:
+                if consecutive_rate_limits >= _MAX_RATE_LIMIT_RETRIES:
                     logger.warning(
                         "[Groww] %s: hit rate-limit %d times consecutively "
                         "(max %d). Aborting fetch — token may be revoked or "
@@ -936,7 +936,7 @@ def load_or_fetch(
         _save_manifest(manifest)
 
     padded_start_ts = pd.Timestamp(padded_start)
-    for t, df in market_data.items():
+    for t, df in list(market_data.items()):
         if df.empty:
             continue
         effective_start = min(df.index[0], padded_start_ts)

--- a/historical_builder.py
+++ b/historical_builder.py
@@ -755,7 +755,15 @@ def build_historical_csv(universe_type: str, output_path: str) -> Path:
         "Run build_historical_fallback.py first (or historical_builder.main())."
     )
 
-    # Legacy network-first fallback kept below for manual use.
+def _build_historical_csv_network_fallback(universe_type: str, output_path: str) -> Path:
+    """
+    Legacy network-first PIT builder kept for manual/offline-recovery workflows.
+
+    This path is intentionally not called by build_historical_csv(), which now
+    enforces the deterministic local-archive-first pipeline used by production
+    and tests.
+    """
+    output = Path(output_path)
 
     # ── Primary: Wayback Machine ──────────────────────────────────────────────
     print(f"\n[HistoricalBuilder] Building PIT CSV for {universe_type} via Wayback Machine...")

--- a/optimizer.py
+++ b/optimizer.py
@@ -209,7 +209,8 @@ def _fitness_from_metrics(
     forced_cash_penalty: penalises repeated forced CVaR liquidations in IS.
     Uses forced_to_cash column (backtest_engine v11.52) or infers from logs.
 
-    Score ceiling: Michaelis-Menten (_K * raw) / (_K + raw) -> asymptote _K=3.5
+    Score ceiling: Michaelis-Menten (_K * raw) / (_K + raw) -> asymptote _K=3.5.
+    A "ceiling hit" is tracked when the bounded score reaches >=99% of _K.
     Score floor  : hard -2.0
     """
     cagr         = float(metrics.get("cagr",    0.0))
@@ -323,7 +324,7 @@ def _fitness_from_metrics(
         _K    = 3.5
         score = (_K * raw / (_K + raw)) if raw > 0.0 else raw
         score = max(score, -2.0)
-        ceiling_hit = False
+        ceiling_hit = raw > 0.0 and score >= (_K * 0.99)
         dd_gate_hit = False
 
     diag = {
@@ -434,12 +435,12 @@ class MomentumObjective:
 
             fold_matrices = None
             if self.precomputed_matrices is not None:
-                is_start_ts = pd.Timestamp(wf_is_start)
+                warmup_start_ts = pd.Timestamp(_compute_warmup_start(wf_oos_start, cfg))
                 oos_end_ts  = pd.Timestamp(wf_oos_end)
                 fold_matrices = {}
                 for key, df in self.precomputed_matrices.items():
                     if isinstance(df, pd.DataFrame) and not df.empty:
-                        fold_matrices[key] = df.loc[is_start_ts:oos_end_ts]
+                        fold_matrices[key] = df.loc[warmup_start_ts:oos_end_ts]
                     else:
                         fold_matrices[key] = df
 
@@ -595,7 +596,8 @@ def pre_load_data(universe_type: str, cfg: UltimateConfig | None = None) -> dict
         kwargs.pop("cfg", None)
         market_data = load_or_fetch(**kwargs)
 
-    market_data = apply_halt_simulation(market_data)
+    if getattr(cfg, "SIMULATE_HALTS", False):
+        market_data = apply_halt_simulation(market_data)
 
     precomputed_matrices = None
     if all(isinstance(v, pd.DataFrame) for v in market_data.values()):

--- a/test_build_historical_fallback.py
+++ b/test_build_historical_fallback.py
@@ -19,3 +19,19 @@ def test_load_env_file_fallback_sets_missing_keys_only(tmp_path, monkeypatch):
 
     assert os.getenv("GROWW_API_TOKEN") == "token_from_file"
     assert os.getenv("EXISTING_KEY") == "already_set"
+
+
+def test_load_env_file_fallback_strips_inline_comments_from_unquoted_values(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "TOKEN=abc123 # prod token\nQUOTED='keep # inside quotes'\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("TOKEN", raising=False)
+    monkeypatch.delenv("QUOTED", raising=False)
+
+    bhf._load_env_file_fallback(env_file)
+
+    assert os.getenv("TOKEN") == "abc123"
+    assert os.getenv("QUOTED") == "keep # inside quotes"

--- a/universe_manager.py
+++ b/universe_manager.py
@@ -148,6 +148,30 @@ _SECTOR_MAP_CACHE_LOCK = threading.Lock()
 _HISTORICAL_UNIVERSE_DF_CACHE: Dict[Path, Tuple[float, pd.DataFrame]] = {}
 
 
+def _is_cache_entry_fresh(fetched_at: str | None, ttl_hours: int = UNIVERSE_CACHE_TTL_H) -> bool:
+    if not fetched_at:
+        return False
+    try:
+        fetched_time = datetime.fromisoformat(fetched_at)
+    except (TypeError, ValueError):
+        return False
+    return datetime.now() - fetched_time < timedelta(hours=ttl_hours)
+
+
+def _normalize_sector_cache_entry(
+    entry,
+    *,
+    fallback_fetched_at: str | None = None,
+) -> tuple[str | None, str | None]:
+    if isinstance(entry, dict):
+        sector = str(entry.get("sector", "Unknown") or "Unknown")
+        fetched_at = entry.get("fetched_at") or fallback_fetched_at
+        return sector, fetched_at
+    if isinstance(entry, str):
+        return entry or "Unknown", fallback_fetched_at
+    return None, None
+
+
 def _load_historical_universe_df(hist_file: Path) -> pd.DataFrame:
     """Load historical universe parquet with mtime-based in-memory caching."""
     mtime = hist_file.stat().st_mtime
@@ -259,12 +283,13 @@ def get_historical_universe(universe_type: str, date: pd.Timestamp) -> List[str]
     if csv_members:
         return csv_members
 
-    logger.error(
-        "[Universe] %s: No point-in-time historical record found in parquet/CSV. "
-        "Returning empty universe (survivorship bias risk if caller falls back).",
-        universe_type,
-    )
-    _NO_RECORD_WARNED[universe_type] = True
+    if not _NO_RECORD_WARNED.get(universe_type):
+        logger.error(
+            "[Universe] %s: No point-in-time historical record found in parquet/CSV. "
+            "Returning empty universe (survivorship bias risk if caller falls back).",
+            universe_type,
+        )
+        _NO_RECORD_WARNED[universe_type] = True
     return []
 
 # ─── Cache Management ─────────────────────────────────────────────────────────
@@ -511,14 +536,21 @@ def get_sector_map(tickers: List[str], use_cache: bool = True, cfg=None) -> Dict
 
     if missing_tickers and use_cache:
         cache = _load_universe_cache()
-        sector_cache = cache.get("sector_map", {}).get("sectors", {})
+        sector_map_cache = cache.get("sector_map", {})
+        sector_cache = sector_map_cache.get("sectors", {})
+        sector_cache_fetched_at = sector_map_cache.get("fetched_at")
 
         still_missing = []
         for bare_ticker in missing_tickers:
             if bare_ticker in sector_cache:
-                resolved_map[bare_ticker] = sector_cache[bare_ticker]
-            else:
-                still_missing.append(bare_ticker)
+                cached_sector, fetched_at = _normalize_sector_cache_entry(
+                    sector_cache[bare_ticker],
+                    fallback_fetched_at=sector_cache_fetched_at,
+                )
+                if cached_sector is not None and _is_cache_entry_fresh(fetched_at):
+                    resolved_map[bare_ticker] = cached_sector
+                    continue
+            still_missing.append(bare_ticker)
         missing_tickers = still_missing
 
     if missing_tickers:
@@ -602,10 +634,17 @@ def get_sector_map(tickers: List[str], use_cache: bool = True, cfg=None) -> Dict
             with _SECTOR_MAP_CACHE_LOCK:
                 current_cache = _load_universe_cache()
                 existing_sector_cache = dict(current_cache.get("sector_map", {}).get("sectors", {}))
-                existing_sector_cache.update({sym: resolved_map[sym] for sym in missing_tickers})
+                fetched_at = datetime.now().isoformat()
+                existing_sector_cache.update({
+                    sym: {
+                        "sector": resolved_map[sym],
+                        "fetched_at": fetched_at,
+                    }
+                    for sym in missing_tickers
+                })
 
                 current_cache["sector_map"] = {
-                    "fetched_at": datetime.now().isoformat(),
+                    "fetched_at": fetched_at,
                     "sectors": existing_sector_cache,
                 }
                 _save_universe_cache(current_cache)


### PR DESCRIPTION
### Motivation
- Prevent warmup-history loss in WFO folds and ensure optimizer data prep matches `run_backtest` warmup expectations. 
- Make Groww rate-limit backoff behavior match documentation and avoid dict-resize runtime errors during final slicing. 
- Ensure sector cache entries expire so previously-missing sectors can be re-fetched and reduce repeated noisy logs when PIT data is absent. 
- Remove unreachable network-fallback noise from the deterministic CSV builder path and keep the standalone fallback CLI's `.env` parsing consistent with the cache module.

### Description
- In `optimizer.py` changed WFO precomputed-matrix slicing to use the computed warmup boundary via `pd.Timestamp(_compute_warmup_start(wf_oos_start, cfg))` instead of the IS start, and gated halt simulation in `pre_load_data` behind `cfg.SIMULATE_HALTS` to match `run_backtest` behavior; also made the `ceiling_hit` diagnostic meaningful by flagging scores near the asymptote (`>= 99%`).
- In `data_cache.py` reconciled the documented rate-limit cap by setting `_MAX_RATE_LIMIT_RETRIES = 5` and changed the abort condition to `>= _MAX_RATE_LIMIT_RETRIES`; hardened the final market-data slice loop to iterate over `list(market_data.items())` to avoid `RuntimeError` if the dict grows.
- In `universe_manager.py` added `_is_cache_entry_fresh` and `_normalize_sector_cache_entry` helpers, stored per-symbol `fetched_at` timestamps in the `sector_map` cache, only use cached sector values when fresh (TTL-aware), and suppressed repeated missing-record errors by honoring `_NO_RECORD_WARNED`.
- In `historical_builder.py` extracted the legacy network-first fallback into `_build_historical_csv_network_fallback()` so `build_historical_csv()` is deterministic/offline-first and no longer contains unreachable code.
- In `build_historical_fallback.py` synchronized `.env` parsing with `data_cache._load_local_env_file` by stripping inline comments from unquoted values and preserving `#` inside quotes.
- Added a regression test `test_load_env_file_fallback_strips_inline_comments_from_unquoted_values` in `test_build_historical_fallback.py` to cover the inline-comment parsing case.

### Testing
- Ran `pytest -q test_build_historical_fallback.py`, all tests passed (`2 passed`).
- Ran `python -m py_compile optimizer.py data_cache.py universe_manager.py historical_builder.py build_historical_fallback.py`, which succeeded (files compile cleanly).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd191e47f0832ba0d9a852906bee1f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration file parsing with better quote and comment handling.
  * Enhanced data fetching reliability with adjusted rate limit controls.
  * Fixed safety issue during concurrent data updates.

* **New Features**
  * Added cache validation for improved data accuracy.
  * Introduced conditional market halt simulation option.

* **Tests**
  * Added test coverage for configuration file parsing improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->