### PR TITLE
Fix optimizer ceiling-hit diagnostics and update pre_load_data halt-simulation tests

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -210,7 +210,7 @@ def _fitness_from_metrics(
     Uses forced_to_cash column (backtest_engine v11.52) or infers from logs.
 
     Score ceiling: Michaelis-Menten (_K * raw) / (_K + raw) -> asymptote _K=3.5.
-    A "ceiling hit" is tracked when the bounded score reaches >=99% of _K.
+    A "ceiling hit" is tracked when the bounded score reaches >=90% of _K.
     Score floor  : hard -2.0
     """
     cagr         = float(metrics.get("cagr",    0.0))
@@ -324,7 +324,7 @@ def _fitness_from_metrics(
         _K    = 3.5
         score = (_K * raw / (_K + raw)) if raw > 0.0 else raw
         score = max(score, -2.0)
-        ceiling_hit = raw > 0.0 and score >= (_K * 0.99)
+        ceiling_hit = raw > 0.0 and score >= (_K * 0.90)
         dd_gate_hit = False
 
     diag = {

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -176,6 +176,25 @@ def test_fitness_falls_back_to_decay_and_zero_positions_when_forced_cash_flag_mi
     assert diag["forced_cash_penalty"] == pytest.approx(0.75)
 
 
+def test_fitness_marks_reachable_score_plateaus_as_ceiling_hits():
+    metrics = {"cagr": 32.0, "max_dd": 0.01, "turnover": 0.0, "sortino": 10.0}
+    rebal_log = pd.DataFrame(
+        {
+            "realised_cvar": [0.0, 0.0, 0.0, 0.0],
+            "exposure_multiplier": [1.0, 1.0, 1.0, 1.0],
+            "n_positions": [8, 8, 8, 8],
+            "apply_decay": [False, False, False, False],
+        }
+    )
+
+    score, diag = optimizer._fitness_from_metrics(metrics, rebal_log)
+
+    assert score >= 3.15
+    assert score < 3.5
+    assert diag["anomaly_hit"] is False
+    assert diag["ceiling_hit"] is True
+
+
 def test_save_optimal_config_replaces_existing_file_atomically(tmp_path: Path):
     output_path = tmp_path / "optimal_cfg.json"
     output_path.write_text('{"old": 1}', encoding="utf-8")
@@ -208,9 +227,6 @@ def test_pre_load_data_deduplicates_inputs_and_appends_crsldx_index(monkeypatch)
     monkeypatch.setattr(optimizer, "TRAIN_START", "2020-01-01")
     monkeypatch.setattr(optimizer, "TEST_END", "2020-12-31")
     monkeypatch.setattr(optimizer, "fetch_nse_equity_universe", lambda: ["ABC", "^NSEI", "ABC"])
-    # apply_halt_simulation is a no-op for this test — it would crash because the
-    # fake load_or_fetch returns {"ok": True} (not real DataFrames).
-    monkeypatch.setattr(optimizer, "apply_halt_simulation", lambda md: md)
 
     captured = {}
 
@@ -236,7 +252,6 @@ def test_pre_load_data_includes_historical_union_for_nifty500(monkeypatch):
     monkeypatch.setattr(optimizer, "TRAIN_START", "2020-01-01")
     monkeypatch.setattr(optimizer, "TEST_END", "2020-03-31")
     monkeypatch.setattr(optimizer, "get_nifty500", lambda: ["LIVEONLY"])
-    monkeypatch.setattr(optimizer, "apply_halt_simulation", lambda md: md)
 
     def _fake_hist(universe_type, date):
         assert universe_type == "nifty500"
@@ -269,6 +284,30 @@ def test_pre_load_data_includes_historical_union_for_nifty500(monkeypatch):
     assert "OLD3" in captured["tickers"]
     assert "^NSEI" in captured["tickers"]
     assert "^CRSLDX" in captured["tickers"]
+
+
+def test_pre_load_data_skips_halt_simulation_when_disabled(monkeypatch):
+    monkeypatch.setattr(optimizer, "TRAIN_START", "2020-01-01")
+    monkeypatch.setattr(optimizer, "TEST_END", "2020-03-31")
+    monkeypatch.setattr(optimizer, "fetch_nse_equity_universe", lambda: ["ABC"])
+
+    cfg = optimizer.UltimateConfig()
+    cfg.SIMULATE_HALTS = False
+
+    monkeypatch.setattr(
+        optimizer,
+        "load_or_fetch",
+        lambda **kwargs: {"ok": True},
+    )
+
+    def _fail_if_called(_market_data):
+        raise AssertionError("apply_halt_simulation should not be called when disabled")
+
+    monkeypatch.setattr(optimizer, "apply_halt_simulation", _fail_if_called)
+
+    result = optimizer.pre_load_data("nse_total", cfg=cfg)
+
+    assert result == {"market_data": {"ok": True}, "precomputed_matrices": None}
 
 
 def test_build_sampler_returns_tpe_sampler(monkeypatch):


### PR DESCRIPTION
### Motivation
- The `ceiling_hit` diagnostic in the fitness scorer was effectively unreachable because it required >=99% of the asymptotic score, so the warning/diagnostic stayed dead for realistic strong-but-non-anomalous trials.
- Two `pre_load_data` tests contained stale `apply_halt_simulation` monkeypatches and misleading comments after the `SIMULATE_HALTS` gate was added, which is a maintenance trap.

### Description
- Lowered the ceiling threshold in the scorer from `score >= (_K * 0.99)` to `score >= (_K * 0.90)` in `optimizer._fitness_from_metrics` and updated the docstring to match the new behavior.
- Added `test_fitness_marks_reachable_score_plateaus_as_ceiling_hits` to assert a reachable high-score scenario triggers `ceiling_hit` without hitting the anomaly path.
- Removed the now-inert `apply_halt_simulation` monkeypatches from the two existing preload tests and deleted the misleading comments about them.
- Added `test_pre_load_data_skips_halt_simulation_when_disabled` to assert `apply_halt_simulation` is not called when `cfg.SIMULATE_HALTS` is `False`.

### Testing
- Ran `pytest test_optimizer.py -k 'ceiling_hits or pre_load_data'` and the selected tests passed.
- Ran `pytest test_optimizer.py -k 'hard_drawdown_prune or forced_cash or ceiling_hits'` and the selected tests passed.
- Ran the full `pytest test_optimizer.py` and all tests passed (`34 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd3890932c832badcab238f4e6bbd6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Fine-tuned the threshold for detecting when fitness scores reach a plateau in the optimization algorithm.

* **Tests**
  * Added comprehensive test coverage for score plateau detection and halt simulation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->