### PR TITLE
Clear universe-manager lookup/date caches in test fixture

### DIFF
--- a/test_universe_manager.py
+++ b/test_universe_manager.py
@@ -11,10 +11,14 @@ def reset_universe_warning_state():
     um._MISSING_PARQUET_WARNED.clear()
     um._NO_RECORD_WARNED.clear()
     um._HISTORICAL_UNIVERSE_DF_CACHE.clear()
+    um._UNIVERSE_LOOKUP_CACHE.clear()
+    um._HISTORICAL_UNIVERSE_DATES_CACHE.clear()
     yield
     um._MISSING_PARQUET_WARNED.clear()
     um._NO_RECORD_WARNED.clear()
     um._HISTORICAL_UNIVERSE_DF_CACHE.clear()
+    um._UNIVERSE_LOOKUP_CACHE.clear()
+    um._HISTORICAL_UNIVERSE_DATES_CACHE.clear()
 
 
 def test_get_historical_universe_uses_csv_without_survivorship_warning(tmp_path, monkeypatch, caplog):


### PR DESCRIPTION
### Motivation
- The `reset_universe_warning_state` autouse fixture did not clear the newly introduced `_UNIVERSE_LOOKUP_CACHE` and `_HISTORICAL_UNIVERSE_DATES_CACHE`, allowing stale cache entries to leak between tests and produce order-dependent failures (notably affecting parquet-cache reuse and historical-universe membership assertions). 

### Description
- Added `um._UNIVERSE_LOOKUP_CACHE.clear()` and `um._HISTORICAL_UNIVERSE_DATES_CACHE.clear()` to both the setup and teardown of the `reset_universe_warning_state` fixture in `test_universe_manager.py` to fully reset universe-manager cache state between tests. 

### Testing
- Ran `pytest -q test_universe_manager.py`, which completed with `9 passed` (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd6c6ac498832b80b0ae61d31ccaa5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test isolation by improving cache cleanup procedures in test fixtures to ensure consistent test execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->