### PR TITLE
Adjust fold/prune logic: ignore floor-clamped scores for pruning, allow two structural gate-hits, and move TRAIN_START to 2019

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -1,12 +1,16 @@
 """
-optimizer.py — Institutional Bayesian Time-Series CV Optimizer v11.52
+optimizer.py — Institutional Bayesian Time-Series CV Optimizer v11.53
 ====================================================================
 Automates the discovery of optimal risk and momentum parameters using Optuna.
 Uses expanding-window time-series cross-validation for parameter selection,
 followed by a true holdout Out-of-Sample (OOS) validation period.
 
-CHANGES vs v11_51:
-- OBJECTIVE_VERSION = fitness_v11_52: clean study, no old trial contamination.
+CHANGES vs v11_52:
+- OBJECTIVE_VERSION = fitness_v11_53: resets the study for the revised
+  walk-forward/pruning regime.
+- TRAIN_START moved 2018-01-01 -> 2019-01-01: drops the fragile 2019 OOS fold
+  that only had the minimum 365-day IS history and gives 2020+ folds a fuller
+  training window.
 - IS_DD_GATE kept at 40%: lowering to 35% caused every 2020 COVID fold to
   score -2.0, making positive aggregate scores mathematically impossible.
   IS_DD_GATE and OOS_MAX_DD_CAP serve different purposes and need not match.
@@ -16,8 +20,12 @@ CHANGES vs v11_51:
   continuous pressure across moderate-drawdown parameter sets.
 - Gate-hit fold scores INCLUDED in aggregate: previously one bad fold was
   silently excluded via `continue`, inflating aggregate for fragile strategies.
-  Now the bad score enters the average. The >1 gate-hit prune still eliminates
-  strategies failing in multiple years.
+  Now the bad score enters the average. Structural gate hits are allowed in up
+  to two folds before pruning so the unavoidable 2020 COVID regime does not
+  prevent trial completion.
+- Floor-clamped scores no longer consume the structural gate-hit budget. Only
+  DD-gate/anomaly diagnostics count toward pruning; harsh negative scores still
+  enter the aggregate and teach TPE to avoid those regions.
 - forced_cash_penalty: penalises forced CVaR liquidations. Reads forced_to_cash
   column from rebal_log (backtest_engine v11.52). Falls back to inference.
 - OOS_MAX_DD_CAP raised 35% -> 38%: 2023-2025 is harder than training.
@@ -93,7 +101,7 @@ logging.getLogger("data_cache").setLevel(logging.ERROR)
 
 # ─── Optimization Configuration ───────────────────────────────────────────────
 
-TRAIN_START = "2018-01-01"
+TRAIN_START = "2019-01-01"
 TRAIN_END   = "2022-12-31"
 TEST_START  = "2023-01-01"
 TEST_END    = os.environ.get("OPTIMIZER_OOS_CUTOFF", "2025-12-31")
@@ -128,8 +136,8 @@ N_JOBS         = int(os.getenv("OPTUNA_N_JOBS", "1"))
 OPTUNA_SEED    = os.getenv("OPTUNA_SEED")
 OPTUNA_STORAGE = os.getenv("OPTUNA_STORAGE", "sqlite:///data/optuna_study.db")
 
-# Bumped to v11_52: guarantees a clean study, no contamination from v11_51 trials.
-OBJECTIVE_VERSION  = "fitness_v11_52"
+# Bumped to v11_53: guarantees a clean study after the revised fold/prune logic.
+OBJECTIVE_VERSION  = "fitness_v11_53"
 DEFAULT_STUDY_NAME = f"Momentum_Risk_Parity_{OBJECTIVE_VERSION}"
 
 MAX_REASONABLE_CAGR_PCT       = 300.0
@@ -494,18 +502,22 @@ class MomentumObjective:
             if not pd.notna(score):
                 raise optuna.TrialPruned()
 
-            # Gate-hit fold score is appended BEFORE the >1 prune check.
+            # Structural gate-hit fold scores are appended BEFORE the >2 prune
+            # check. This lets bad-but-non-structural floor-clamped scores stay
+            # in the aggregate without burning the gate-hit budget, while still
+            # pruning strategies that trip genuine DD/anomaly gates in 3+ folds.
             # The bad score enters the aggregate — fragile strategies that fail
             # in one year receive a lower aggregate than strategies that pass
-            # all folds. The >1 prune eliminates strategies failing in 2+ years.
-            is_gate_hit = diag.get("dd_gate_hit") or diag.get("anomaly_hit") or score <= -2.0
+            # all folds. The >2 prune eliminates strategies failing structurally
+            # in 3+ years.
+            is_gate_hit = diag.get("dd_gate_hit") or diag.get("anomaly_hit")
             if is_gate_hit:
                 n_gate_hits += 1
                 scores.append(float(score))   # include — do NOT skip
-                if n_gate_hits > 1:
+                if n_gate_hits > 2:
                     raise optuna.TrialPruned()
                 logger.debug(
-                    "[Trial %s | %d] Single gate-hit fold included in aggregate "
+                    "[Trial %s | %d] Structural gate-hit fold included in aggregate "
                     "(dd_gate=%s anomaly=%s score=%.4f).",
                     trial_id, oos_year,
                     diag.get("dd_gate_hit"), diag.get("anomaly_hit"), score,

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -333,6 +333,17 @@ def test_iter_wfo_slices_keeps_first_full_calendar_year():
     ]
 
 
+def test_default_train_start_drops_2019_oos_fold():
+    slices = list(optimizer._iter_wfo_slices(optimizer.TRAIN_START, optimizer.TRAIN_END))
+
+    assert optimizer.TRAIN_START == "2019-01-01"
+    assert [oos_start for _, _, oos_start, _ in slices] == [
+        "2020-01-01",
+        "2021-01-01",
+        "2022-01-01",
+    ]
+
+
 def test_normalize_universe_type_falls_back_to_nifty500():
     assert optimizer._normalize_universe_type("  typo  ") == "nifty500"
 
@@ -968,6 +979,110 @@ def test_objective_prunes_when_cvar_lookback_bounds_are_infeasible(monkeypatch):
             "RISK_AVERSION": 5.0,
             "CVAR_DAILY_LIMIT": 0.04,
             "CVAR_LOOKBACK": 150,
+        }
+    )
+
+    with pytest.raises(optuna.TrialPruned):
+        objective(trial)
+
+
+def _objective_diag(*, score, dd_gate_hit=False, anomaly_hit=False):
+    return (
+        score,
+        {
+            "cagr": 0.0,
+            "max_dd": 0.0,
+            "turnover": 0.0,
+            "avg_exposure": 1.0,
+            "avg_positions": 10.0,
+            "avg_cvar_pct": 1.0,
+            "risk_penalty": 0.0,
+            "exposure_penalty": 0.0,
+            "dd_penalty": 0.0,
+            "forced_cash_penalty": 0.0,
+            "raw_score": score,
+            "score": score,
+            "dd_gate_hit": dd_gate_hit,
+            "anomaly_hit": anomaly_hit,
+            "ceiling_hit": False,
+        },
+    )
+
+
+def test_objective_does_not_count_floor_score_as_gate_hit(monkeypatch):
+    class _Result:
+        metrics = {"cagr": 0.0, "max_dd": 0.0, "turnover": 0.0}
+        rebal_log = pd.DataFrame()
+
+    monkeypatch.setattr(
+        optimizer,
+        "_iter_wfo_slices",
+        lambda *_args: [
+            ("2019-01-01", "2019-12-31", "2020-01-01", "2020-12-31"),
+            ("2019-01-01", "2020-12-31", "2021-01-01", "2021-12-31"),
+            ("2019-01-01", "2021-12-31", "2022-01-01", "2022-12-31"),
+        ],
+    )
+    monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
+
+    fold_diags = iter(
+        [
+            _objective_diag(score=-2.0),
+            _objective_diag(score=-2.0, dd_gate_hit=True),
+            _objective_diag(score=0.5),
+        ]
+    )
+    monkeypatch.setattr(optimizer, "_fitness_from_metrics", lambda *_args: next(fold_diags))
+
+    objective = optimizer.MomentumObjective(market_data={}, universe_type="nifty500")
+    trial = optuna.trial.FixedTrial(
+        {
+            "HALFLIFE_FAST": 21,
+            "HALFLIFE_SLOW": 65,
+            "CONTINUITY_BONUS": 0.15,
+            "RISK_AVERSION": 12.0,
+            "CVAR_DAILY_LIMIT": 0.04,
+        }
+    )
+
+    score = objective(trial)
+
+    assert score == pytest.approx((-2.0 - 2.0 + 0.5) / 3)
+
+
+def test_objective_prunes_after_third_structural_gate_hit(monkeypatch):
+    class _Result:
+        metrics = {"cagr": 0.0, "max_dd": 0.0, "turnover": 0.0}
+        rebal_log = pd.DataFrame()
+
+    monkeypatch.setattr(
+        optimizer,
+        "_iter_wfo_slices",
+        lambda *_args: [
+            ("2019-01-01", "2019-12-31", "2020-01-01", "2020-12-31"),
+            ("2019-01-01", "2020-12-31", "2021-01-01", "2021-12-31"),
+            ("2019-01-01", "2021-12-31", "2022-01-01", "2022-12-31"),
+        ],
+    )
+    monkeypatch.setattr(optimizer, "run_backtest", lambda **kwargs: _Result())
+
+    fold_diags = iter(
+        [
+            _objective_diag(score=-2.0, dd_gate_hit=True),
+            _objective_diag(score=-2.0, anomaly_hit=True),
+            _objective_diag(score=-1.5, dd_gate_hit=True),
+        ]
+    )
+    monkeypatch.setattr(optimizer, "_fitness_from_metrics", lambda *_args: next(fold_diags))
+
+    objective = optimizer.MomentumObjective(market_data={}, universe_type="nifty500")
+    trial = optuna.trial.FixedTrial(
+        {
+            "HALFLIFE_FAST": 21,
+            "HALFLIFE_SLOW": 65,
+            "CONTINUITY_BONUS": 0.15,
+            "RISK_AVERSION": 12.0,
+            "CVAR_DAILY_LIMIT": 0.04,
         }
     )
 


### PR DESCRIPTION
### Motivation
- Trials were being pruned prematurely because a floor-clamped fold score (`score == -2.0`) was treated the same as a structural gate hit, consuming the gate-hit budget and preventing TPE from observing completed trial aggregates. 
- The 2019 OOS fold is fragile (only the minimum IS days) and contributed misleading negative signals; dropping it improves signal quality for 2020+ folds. 
- Make structural failures (DD-gates / anomalies) the only items that burn the prune allowance so TPE can learn from harsh-but-non-structural penalties.

### Description
- Bumped the module/version header and `OBJECTIVE_VERSION` to `fitness_v11_53` and documented the rationale in the changelog comments in `optimizer.py`.
- Changed default training window start from `TRAIN_START = "2018-01-01"` to `TRAIN_START = "2019-01-01"` so the fragile 2019 OOS fold is dropped.  
- Modified pruning logic in `MomentumObjective.__call__` so `is_gate_hit = diag.get("dd_gate_hit") or diag.get("anomaly_hit")` (no longer `or score <= -2.0`), and increased the prune threshold from `if n_gate_hits > 1` to `if n_gate_hits > 2` so pruning occurs only after three structural gate-hits. 
- Added regression tests in `test_optimizer.py` covering the new default fold set (`test_default_train_start_drops_2019_oos_fold`), that floor-clamped `-2.0` scores do not count as gate-hits (`test_objective_does_not_count_floor_score_as_gate_hit`), and that pruning now fires after the third structural gate-hit (`test_objective_prunes_after_third_structural_gate_hit`).

### Testing
- Ran the targeted test selection: `pytest -q test_optimizer.py -k "default_train_start_drops_2019_oos_fold or does_not_count_floor_score_as_gate_hit or prunes_after_third_structural_gate_hit or iter_wfo_slices_keeps_first_full_calendar_year"` and these tests passed. 
- Ran `python -m compileall optimizer.py test_optimizer.py` and compilation succeeded. 
- Ran the full test suite `pytest -q test_optimizer.py`; this produced two existing, unrelated failures in historical-universe preload tests (`test_pre_load_data_includes_historical_union_for_nifty500` and `test_pre_load_data_uses_normalized_fallback_universe_for_history`) that were not touched by this change and appear orthogonal to the pruning/fold adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd87dcb704832bb789a9720b28cf0c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Version Update**
  * Optimizer updated to v11.53

* **Configuration & Logic Updates**
  * Modified walk-forward optimization training period
  * Adjusted trial pruning thresholds and gating behavior

* **Tests**
  * Expanded test coverage for pruning and optimization behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->