### PR TITLE
Decouple structural gate-hit logic and update objective pruning; align preload tests with QE sampling

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -473,7 +473,6 @@ class MomentumObjective:
             score, diag = _fitness_from_metrics(m, getattr(oos, "rebal_log", pd.DataFrame()))
 
             diag["year"]     = oos_year
-            diag["excluded"] = False
             diag["eq_start"] = wf_oos_start
             diag["eq_end"]   = wf_oos_end
             slice_diags.append(diag)
@@ -502,27 +501,20 @@ class MomentumObjective:
             if not pd.notna(score):
                 raise optuna.TrialPruned()
 
-            # Structural gate-hit fold scores are appended BEFORE the >2 prune
-            # check. This lets bad-but-non-structural floor-clamped scores stay
-            # in the aggregate without burning the gate-hit budget, while still
-            # pruning strategies that trip genuine DD/anomaly gates in 3+ folds.
-            # The bad score enters the aggregate — fragile strategies that fail
-            # in one year receive a lower aggregate than strategies that pass
-            # all folds. The >2 prune eliminates strategies failing structurally
-            # in 3+ years.
-            is_gate_hit = diag.get("dd_gate_hit") or diag.get("anomaly_hit")
-            if is_gate_hit:
+            is_structural_gate_hit = diag.get("dd_gate_hit") or diag.get("anomaly_hit")
+            diag["excluded"] = is_structural_gate_hit
+            if is_structural_gate_hit:
                 n_gate_hits += 1
-                scores.append(float(score))   # include — do NOT skip
-                if n_gate_hits > 2:
+                scores.append(float(score))
+                if n_gate_hits > 1:
                     raise optuna.TrialPruned()
                 logger.debug(
-                    "[Trial %s | %d] Structural gate-hit fold included in aggregate "
+                    "[Trial %s | %d] Single structural gate-hit fold included in aggregate "
                     "(dd_gate=%s anomaly=%s score=%.4f).",
                     trial_id, oos_year,
                     diag.get("dd_gate_hit"), diag.get("anomaly_hit"), score,
                 )
-                continue   # skip the duplicate append below
+                continue
 
             scores.append(float(score))
 

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -250,14 +250,14 @@ def test_pre_load_data_deduplicates_inputs_and_appends_crsldx_index(monkeypatch)
 
 def test_pre_load_data_includes_historical_union_for_nifty500(monkeypatch):
     monkeypatch.setattr(optimizer, "TRAIN_START", "2020-01-01")
-    monkeypatch.setattr(optimizer, "TEST_END", "2020-03-31")
+    monkeypatch.setattr(optimizer, "TEST_END", "2020-09-30")
     monkeypatch.setattr(optimizer, "get_nifty500", lambda: ["LIVEONLY"])
 
     def _fake_hist(universe_type, date):
         assert universe_type == "nifty500"
-        if pd.Timestamp(date) == pd.Timestamp("2020-01-31"):
+        if pd.Timestamp(date) == pd.Timestamp("2020-03-31"):
             return ["OLD1", "OLD2"]
-        if pd.Timestamp(date) == pd.Timestamp("2020-02-29"):
+        if pd.Timestamp(date) == pd.Timestamp("2020-06-30"):
             return ["OLD2", "OLD3"]
         return []
 
@@ -277,7 +277,7 @@ def test_pre_load_data_includes_historical_union_for_nifty500(monkeypatch):
 
     assert result == {"market_data": {"ok": True}, "precomputed_matrices": None}
     assert captured["required_start"] == optimizer._compute_warmup_start("2020-01-01", optimizer.UltimateConfig())
-    assert captured["required_end"] == "2020-03-31"
+    assert captured["required_end"] == "2020-09-30"
     assert "LIVEONLY" in captured["tickers"]
     assert "OLD1" in captured["tickers"]
     assert "OLD2" in captured["tickers"]
@@ -350,7 +350,7 @@ def test_normalize_universe_type_falls_back_to_nifty500():
 
 def test_pre_load_data_uses_normalized_fallback_universe_for_history(monkeypatch):
     monkeypatch.setattr(optimizer, "TRAIN_START", "2020-01-01")
-    monkeypatch.setattr(optimizer, "TEST_END", "2020-01-31")
+    monkeypatch.setattr(optimizer, "TEST_END", "2020-03-31")
     monkeypatch.setattr(optimizer, "get_nifty500", lambda: ["LIVEONLY"])
 
     historical_calls = []


### PR DESCRIPTION
### Motivation
- Ensure only genuine structural failures (drawdown/anomaly) count toward the prune budget while still including their large negative fold scores in the aggregate so the sampler receives learning signal.
- Keep diagnostic `diag["excluded"]` accurate for structural gate hits.
- Make `pre_load_data` tests exercise the current quarter-end historical-universe sampling behavior so tests are deterministic.

### Description
- In `optimizer.py` renamed the local flag to `is_structural_gate_hit` (from `is_gate_hit`), set `diag["excluded"] = is_structural_gate_hit`, and append the fold score before applying structural pruning so gate-hit fold scores remain in the aggregate. (Objective loop changes around fold scoring/pruning.)
- Tightened structural pruning to prune after more than one structural gate hit by changing the threshold to `if n_gate_hits > 1: raise optuna.TrialPruned()`.
- Removed the prior unconditional `diag["excluded"] = False` assignment so `diag["excluded"]` reflects the structural gate-hit condition.
- Adjusted `test_optimizer.py` historical-universe/pre-load tests to match the optimizer's quarter-end (`freq="QE"`) sampling (updated `TEST_END` dates and target quarter-end return values) so the tests exercise `get_historical_universe` and the historical-union logic correctly.

### Testing
- Ran `pytest -q test_optimizer.py test_universe_manager.py` and all tests passed: `50 passed, 18 warnings`.
- Verified the modified tests now exercise the quarter-end historical-universe sampling and the objective-loop diagnostics/logging during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd8b288fb4832b9dd14f9cc1c609a6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fold diagnostics to accurately reflect structural gate conditions
  * Adjusted fold pruning threshold for improved filtering accuracy
  * Enhanced logging clarity for structural gate inclusion tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->