### PR TITLE
Tighten regime filter: add fast SMA and raise deleveraging rate

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -190,7 +190,7 @@ class UltimateConfig:
     DRIFT_TOLERANCE:             float = 0.02
 
     # Exposure management
-    DELEVERAGING_LIMIT:          float = 0.10
+    DELEVERAGING_LIMIT:          float = 0.20
     MIN_EXPOSURE_FLOOR:          float = 0.40
     CAPITAL_ELASTICITY:          float = 0.15
 
@@ -241,6 +241,7 @@ class UltimateConfig:
     REGIME_VOL_FLOOR:         float = 0.18
     REGIME_VOL_MULTIPLIER:    float = 1.5
     REGIME_SIGMOID_STEEPNESS: float = 10.0
+    REGIME_SMA_FAST_WINDOW:   int   = 50
     REGIME_SMA_WINDOW:        int   = 200
     REGIME_VOL_EWMA_SPAN:     int   = 20
     REGIME_LT_VOL_EWMA_SPAN:  int   = 1260

--- a/signals.py
+++ b/signals.py
@@ -88,16 +88,30 @@ def compute_regime_score(
     close_series = idx_hist["Close"]
 
     sma_window = int(getattr(cfg, "REGIME_SMA_WINDOW", 200)) if cfg else 200
+    sma_fast_window = int(getattr(cfg, "REGIME_SMA_FAST_WINDOW", 50)) if cfg else 50
+    min_sma_periods = 20
+    min_fast_periods = max(10, min_sma_periods // 2)
+
     if len(close_series) >= sma_window:
-        sma200 = float(close_series.rolling(window=sma_window, min_periods=20).mean().iloc[-1])
+        sma200 = float(close_series.rolling(window=sma_window, min_periods=min_sma_periods).mean().iloc[-1])
     else:
-        sma200 = float(close_series.expanding(min_periods=20).mean().iloc[-1])
+        sma200 = float(close_series.expanding(min_periods=min_sma_periods).mean().iloc[-1])
+
+    if len(close_series) >= sma_fast_window:
+        sma_fast = float(
+            close_series.rolling(window=sma_fast_window, min_periods=min_fast_periods).mean().iloc[-1]
+        )
+    else:
+        sma_fast = float(close_series.expanding(min_periods=min_fast_periods).mean().iloc[-1])
+
     last_price = float(close_series.iloc[-1])
 
     if sma200 <= 0 or not np.isfinite(sma200):
         return 0.5
 
-    trend_deviation = (last_price / sma200) - 1.0
+    trend_dev_slow = (last_price / sma200) - 1.0
+    trend_dev_fast = (last_price / sma_fast) - 1.0 if sma_fast > 0 and np.isfinite(sma_fast) else trend_dev_slow
+    trend_deviation = 0.6 * trend_dev_fast + 0.4 * trend_dev_slow
     trend_steepness = float(getattr(cfg, "REGIME_SIGMOID_STEEPNESS", 10.0)) if cfg else 10.0
     base_score = 1.0 / (1.0 + np.exp(-trend_steepness * trend_deviation))
 


### PR DESCRIPTION
### Motivation
- Reduce catastrophic lag in the regime filter so risk-off signals fire earlier during sharp corrections instead of waiting for the 200-day SMA alone.
- Shorten time-to-floor deleveraging so exposure can be cut materially faster once a defensive regime is detected.

### Description
- Added a configurable fast SMA (`REGIME_SMA_FAST_WINDOW`, default 50) and blend it 60/40 fast/slow into `compute_regime_score` so the base regime sigmoid reacts sooner to short-term trend deterioration (file: `signals.py`).
- Preserved fallbacks for short histories by using expanding means with reasonable `min_periods` for both fast and slow SMAs (file: `signals.py`).
- Introduced `REGIME_SMA_FAST_WINDOW` into `UltimateConfig` and increased `DELEVERAGING_LIMIT` from `0.10` to `0.20` to halve the weeks-to-floor in the deleveraging cadence (file: `momentum_engine.py`).

### Testing
- Compiled `signals.py` and `momentum_engine.py` successfully using `python -m compileall` with no syntax errors observed.
- Ran a synthetic sanity check calling `compute_regime_score` on a constructed long-bull then 6-week drop price series and observed a regime score produced with the new fast-window in effect, and the config returned `DELEVERAGING_LIMIT=0.2` and `REGIME_SMA_FAST_WINDOW=50`, all returning successfully.
- No automated tests failed during these checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be8bf3e8bc832bb8c929b0bffd75fd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Market regime signal calculation now integrates dual-timeframe trend deviation analysis, combining fast and slow timeframe measurements for comprehensive market condition assessment
* **Chores**
  - Portfolio exposure adjustment limit expanded to support greater flexibility in portfolio deleveraging operations during market transitions
  - New configuration parameter introduced for customizable market regime baseline analysis window settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->