### PR TITLE
Add hysteresis breadth filter and reopen fast halflife search

### DIFF
--- a/optimizer.py
+++ b/optimizer.py
@@ -1,12 +1,12 @@
 """
-optimizer.py — Institutional Bayesian Time-Series CV Optimizer v11.54
+optimizer.py — Institutional Bayesian Time-Series CV Optimizer v11.55
 ====================================================================
 Automates the discovery of optimal risk and momentum parameters using Optuna.
 Uses expanding-window time-series cross-validation for parameter selection,
 followed by a true holdout Out-of-Sample (OOS) validation period.
 
 CHANGES vs v11_53:
-- OBJECTIVE_VERSION = fitness_v11_54: resets the study for the revised
+- OBJECTIVE_VERSION = fitness_v11_55: resets the study for the revised
   search bounds and turnover penalty.
 - N_TRIALS raised 150 -> 200: gives TPE a better chance to find robust
   regions of the tighter search space.
@@ -32,8 +32,8 @@ CHANGES vs v11_53:
   column from rebal_log (backtest_engine v11.52). Falls back to inference.
 - OOS_MAX_DD_CAP raised 35% -> 38%: 2023-2025 is harder than training.
 - OOS_SOFT_MAX_DD_CAP = 42%: NEAR diagnostic tier (display only, not a pass).
-- SEARCH_SPACE_BOUNDS tightened again: higher floors on HALFLIFE_FAST,
-  CONTINUITY_BONUS, and RISK_AVERSION remove fragile high-churn settings.
+- SEARCH_SPACE_BOUNDS keeps tighter continuity/risk bounds while restoring
+  HALFLIFE_FAST to 15 so the optimizer can explore faster signals again.
 - turnover_drag now uses realistic 30 bps round-trip friction plus a
   nonlinear churn penalty above 18x/year.
 """
@@ -122,12 +122,13 @@ OOS_TOP_K = 10
 
 _MIN_IS_CALENDAR_DAYS = 365
 
-# Narrowed vs v11_53:
-#   HALFLIFE_FAST floor 15->19: removes short-horizon churny variants
+# Revised vs v11_53:
+#   HALFLIFE_FAST restored to 15: breadth hysteresis now guards against
+#     bottom-whipsaw, so faster momentum variants are allowed again
 #   CONTINUITY_BONUS floor 0.06->0.12: requires stronger persistence reward
 #   RISK_AVERSION floor 12->14: removes aggressive leverage-seeking configs
 SEARCH_SPACE_BOUNDS = {
-    "HALFLIFE_FAST":    (19, 29, 2),
+    "HALFLIFE_FAST":    (15, 29, 2),
     "HALFLIFE_SLOW":    (60, 100, 5),
     "CONTINUITY_BONUS": (0.12, 0.18, 0.03),
     "RISK_AVERSION":    (14.0, 20.0, 0.5),
@@ -139,8 +140,8 @@ N_JOBS         = int(os.getenv("OPTUNA_N_JOBS", "1"))
 OPTUNA_SEED    = os.getenv("OPTUNA_SEED")
 OPTUNA_STORAGE = os.getenv("OPTUNA_STORAGE", "sqlite:///data/optuna_study.db")
 
-# Bumped to v11_54: guarantees a clean study after bounds & penalty revisions.
-OBJECTIVE_VERSION  = "fitness_v11_54"
+# Bumped to v11_55: guarantees a clean study after the hysteresis/bounds revision.
+OBJECTIVE_VERSION  = "fitness_v11_55"
 DEFAULT_STUDY_NAME = f"Momentum_Risk_Parity_{OBJECTIVE_VERSION}"
 
 MAX_REASONABLE_CAGR_PCT       = 300.0

--- a/signals.py
+++ b/signals.py
@@ -193,18 +193,34 @@ def compute_regime_score(
     composite = 0.5 * base_score + 0.3 * breadth_component + 0.2 * vol_component
     base_score = round(float(np.clip(composite, 0.0, 1.0)), 10)
 
-    if universe_close_hist is not None and len(universe_close_hist) >= 50:
+    if universe_close_hist is not None and len(universe_close_hist) >= 65:
         equity_cols = [c for c in universe_close_hist.columns if not str(c).startswith("^")]
         if equity_cols:
-            breadth_hist = universe_close_hist.loc[:, equity_cols].tail(50)
-            sma_50 = breadth_hist.mean(skipna=True)
-            current_prices = universe_close_hist.loc[:, equity_cols].iloc[-1]
-            breadth_flags = (current_prices > sma_50) & current_prices.notna() & sma_50.notna()
-            breadth_pct = float(breadth_flags.mean())
+            # Grab the last 65 days (50 for the SMA window + 15 days of rolling lookback)
+            _px_slice = universe_close_hist.loc[:, equity_cols].tail(65)
 
-            if breadth_pct < 0.35:
+            # Calculate the rolling 50-day SMA, then isolate the final 15 days
+            rolling_sma50 = _px_slice.rolling(window=50, min_periods=20).mean().tail(15)
+            recent_px = _px_slice.tail(15)
+
+            # Create a 15-day history of market breadth (% of stocks > their 50-SMA)
+            breadth_flags = (recent_px > rolling_sma50) & recent_px.notna() & rolling_sma50.notna()
+            breadth_history = breadth_flags.mean(axis=1)
+
+            current_breadth = float(breadth_history.iloc[-1])
+            min_recent_breadth = float(breadth_history.min())
+
+            # 1. Hard Crash Exit (Current breadth collapses)
+            if current_breadth < 0.35:
                 return 0.0
-            if breadth_pct < 0.45:
+
+            # 2. HYSTERESIS (The Schmitt Trigger)
+            # If the market crashed recently (<35%), demand a strong bounce (>50%) to allow re-entry.
+            if min_recent_breadth < 0.35 and current_breadth < 0.50:
+                return 0.0
+
+            # 3. Early Warning Trim (Market is weakening but hasn't crashed)
+            if current_breadth < 0.45:
                 return min(base_score, 0.5)
 
     return base_score


### PR DESCRIPTION
### Motivation
- The existing single-threshold breadth circuit breaker caused rapid in-and-out ‘‘strobe’’ behaviour during choppy market bottoms and needed decoupled exit/re-entry thresholds to avoid execution friction and capital bleed. 
- Introduce a Schmitt-trigger style hysteresis over a short rolling window so the system requires a stronger bounce to re-enter after a recent crash while still trimming exposure early when breadth weakens.

### Description
- Replaced the end-of-function breadth circuit-breaker in `compute_regime_score` with a 15-day rolling hysteresis filter that uses the last 65 sessions (50-day SMA + 15-day lookback), computes a rolling 50-day SMA, derives a 15-day breadth history, and implements: hard exit when `current_breadth < 0.35`, hysteresis blocking re-entry when `min_recent_breadth < 0.35 and current_breadth < 0.50`, and an early-warning trim that caps the score when `current_breadth < 0.45`, while preserving earlier composite/base score logic (including the `^` benchmark exclusion and existing regime calculations). 
- Restored the optimizer search floor for `HALFLIFE_FAST` from `19` to `15` in `SEARCH_SPACE_BOUNDS` so the optimizer can explore faster moving-average variants again. 
- Bumped `OBJECTIVE_VERSION` to `"fitness_v11_55"` and updated nearby header comments so Optuna will start a fresh study for the revised behavior. 

### Testing
- Ran `python -m py_compile signals.py optimizer.py` and it completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf72ce8510832b9817938299593dbc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced market regime detection with improved breadth-based market condition analysis, including hysteresis logic for more stable signal generation.

* **Chores**
  * Updated optimizer to version 11.55 with adjusted search parameters for improved algorithm convergence and tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->