### PR TITLE
Apply stale-price gate to decay path and compound split fallback; add tests

### DIFF
--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -485,11 +485,12 @@ def detect_and_apply_splits(state: PortfolioState, market_data: dict, cfg: Ultim
 
                 window = split_series.loc[split_series.index > split_start_date]
             else:
-                positive = split_series[split_series > 0]
-                if not positive.empty:
-                    window = positive.loc[positive.index == positive.index.max()]
-                else:
-                    window = positive
+                # When no trustworthy anchor exists at all, prefer compounding the
+                # explicit split signals present in the payload rather than silently
+                # dropping earlier split events inside the visible window. This keeps
+                # manual/fixture states without last_rebalance_date or a position
+                # marker internally consistent when multiple splits appear.
+                window = split_series[split_series > 0]
 
             if not window.empty:
                 positive = window[window > 0]
@@ -1039,7 +1040,7 @@ def _run_scan(
         # always safer to exit a position than to hold it with a stale price.
         _STALE_PRICE_DAYS = 2  # trading days
         _rebalance_stale_held: list = []
-        if optimization_succeeded and not _force_full_cash:
+        if (optimization_succeeded or apply_decay) and not _force_full_cash:
             for _chk_sym in state.shares:
                 if _chk_sym not in active_idx:
                     continue  # absent symbols handled by execute_rebalance itself

--- a/test_daily_workflow.py
+++ b/test_daily_workflow.py
@@ -273,6 +273,32 @@ def test_detect_and_apply_splits_first_run_uses_position_marker_not_full_history
     assert state.shares["ABC"] == 20
     assert state.entry_prices["ABC"] == 500.0
 
+def test_detect_and_apply_splits_without_anchor_compounds_visible_split_events():
+    cfg = UltimateConfig(AUTO_ADJUST_PRICES=True)
+    state = PortfolioState(
+        shares={"ABC": 10},
+        entry_prices={"ABC": 1000.0},
+        last_known_prices={"ABC": 1000.0},
+        cash=0.0,
+    )
+    idx = pd.date_range("2024-01-01", periods=5)
+    market_data = {
+        "ABC.NS": pd.DataFrame(
+            {
+                "Close": [1000.0, 500.0, 505.0, 252.5, 255.0],
+                "Dividends": [0.0] * 5,
+                "Stock Splits": [0.0, 2.0, 0.0, 2.0, 0.0],
+            },
+            index=idx,
+        )
+    }
+
+    adjusted = dw.detect_and_apply_splits(state, market_data, cfg)
+
+    assert adjusted == ["ABC"]
+    assert state.shares["ABC"] == 40
+    assert state.entry_prices["ABC"] == 250.0
+
 
 def test_run_scan_cadence_gate_skips_rebalance(monkeypatch):
     idx = pd.date_range("2024-01-01", periods=6)
@@ -379,6 +405,7 @@ def test_run_scan_stale_prices_block_decay_rebalance(monkeypatch):
         entry_prices={"ABC": 100.0},
         last_known_prices={"ABC": 100.0},
         last_rebalance_date="2024-01-01",
+        consecutive_failures=2,
     )
 
     out_state, _ = dw._run_scan(["ABC", "FRESH"], state, "TEST", cfg_override=UltimateConfig())


### PR DESCRIPTION
### Motivation
- Prevent unintended rebalances when held symbols have stale prices even if decay liquidation is being triggered by prior solver failures. 
- Avoid silently dropping earlier explicit split events when no reliable anchor (`last_rebalance_date` or `dividend_ledger`) exists, so visible split events compound correctly.
- Cover these edge cases with focused regression tests to prevent regressions in future changes.

### Description
- Update `daily_workflow.py` so the stale-price suppression runs when either `optimization_succeeded` or `apply_decay` is active by changing the guard to `if (optimization_succeeded or apply_decay) and not _force_full_cash:`. 
- Change the split-detection fallback in `daily_workflow.py` to compound all explicit positive split signals in the provider payload when no trustworthy anchor exists by using `window = split_series[split_series > 0]` instead of selecting only the latest positive split. 
- Add a new test `test_detect_and_apply_splits_without_anchor_compounds_visible_split_events` and update `test_run_scan_stale_prices_block_decay_rebalance` to start with `consecutive_failures=2` so the `apply_decay` decay path is actually exercised by the scan. 
- Only the `daily_workflow.py` logic and the corresponding tests in `test_daily_workflow.py` were modified for these fixes and coverage additions.

### Testing
- Ran `pytest -q test_daily_workflow.py -k 'stale_prices_block_decay_rebalance or without_anchor_compounds_visible_split_events or first_run_uses_position_marker_not_full_history'` which produced `3 passed, 15 deselected`.
- Ran `pytest -q test_momentum.py -k 'supports_copy_on_write_for_ghost_positions or detects_midweek_event_since_last_rebalance'` which produced `2 passed, 85 deselected`.
- Targeted regressions for the updated scan and split logic passed under the test matrix above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c10e408bc8832ba2941c725d66e971)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multiple split events in historical data by compounding all relevant events instead of selecting only the most recent one.
  * Extended stale price validation to decay-driven rebalancing operations, ensuring price staleness checks apply consistently across all rebalancing scenarios.

* **Tests**
  * Added test coverage for split event compounding behavior in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->