### PR TITLE
Gate stale-price suppression on rebalance_allowed and document split-fallback risk

### DIFF
--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -490,6 +490,12 @@ def detect_and_apply_splits(state: PortfolioState, market_data: dict, cfg: Ultim
                 # dropping earlier split events inside the visible window. This keeps
                 # manual/fixture states without last_rebalance_date or a position
                 # marker internally consistent when multiple splits appear.
+                #
+                # Residual risk: a truly anchor-free restored/manual state can still
+                # over-apply older historical splits because there is no reliable way
+                # to distinguish "pre-position" events from "post-position" events.
+                # Normal live positions should carry either last_rebalance_date or a
+                # dividend_ledger marker and therefore avoid this fallback path.
                 window = split_series[split_series > 0]
 
             if not window.empty:
@@ -1040,7 +1046,7 @@ def _run_scan(
         # always safer to exit a position than to hold it with a stale price.
         _STALE_PRICE_DAYS = 2  # trading days
         _rebalance_stale_held: list = []
-        if (optimization_succeeded or apply_decay) and not _force_full_cash:
+        if rebalance_allowed and (optimization_succeeded or apply_decay) and not _force_full_cash:
             for _chk_sym in state.shares:
                 if _chk_sym not in active_idx:
                     continue  # absent symbols handled by execute_rebalance itself

--- a/test_daily_workflow.py
+++ b/test_daily_workflow.py
@@ -414,6 +414,75 @@ def test_run_scan_stale_prices_block_decay_rebalance(monkeypatch):
     assert out_state.shares == {"ABC": 10}
 
 
+def test_run_scan_cadence_stale_gate_does_not_emit_duplicate_rebalance_warning(monkeypatch, caplog):
+    idx = pd.date_range("2024-01-01", periods=6)
+    stale_idx = pd.date_range("2024-01-01", periods=3)
+    md = {
+        "ABC.NS": pd.DataFrame(
+            {"Close": [100.0] * len(stale_idx), "Dividends": [0.0] * len(stale_idx)},
+            index=stale_idx,
+        ),
+        "FRESH.NS": pd.DataFrame(
+            {"Close": [100.0] * len(idx), "Dividends": [0.0] * len(idx)},
+            index=idx,
+        ),
+        "^NSEI": pd.DataFrame({"Close": [100.0] * len(idx)}, index=idx),
+        "^CRSLDX": pd.DataFrame({"Close": [100.0] * len(idx)}, index=idx),
+    }
+    monkeypatch.setattr(dw, "load_or_fetch", lambda *_args, **_kwargs: md)
+    monkeypatch.setattr(dw, "_print_stage_status", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(dw, "detect_and_apply_splits", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(dw, "compute_regime_score", lambda *_args, **_kwargs: 0.5)
+    monkeypatch.setattr(dw, "compute_book_cvar", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(dw, "compute_adv", lambda *_args, **_kwargs: __import__("numpy").array([1e9, 1e9]))
+    monkeypatch.setattr(dw, "get_sector_map", lambda syms, cfg=None: {s: "Unknown" for s in syms})
+
+    def _fake_generate_signals(*_args, **_kwargs):
+        import numpy as np
+
+        return np.array([0.01, 0.0]), np.array([1.0, 0.0]), [0], {
+            "total": 2,
+            "history_failed": 0,
+            "adv_failed": 0,
+            "knife_failed": 1,
+            "selected": 1,
+        }
+
+    monkeypatch.setattr(dw, "generate_signals", _fake_generate_signals)
+
+    class _Engine:
+        def __init__(self, _cfg):
+            pass
+
+        def optimize(self, **_kwargs):
+            import numpy as np
+
+            return np.array([1.0])
+
+    monkeypatch.setattr(dw, "InstitutionalRiskEngine", _Engine)
+    monkeypatch.setattr(
+        dw,
+        "execute_rebalance",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("execute_rebalance should not be called when cadence staleness gate fires")
+        ),
+    )
+
+    state = PortfolioState(
+        shares={"ABC": 10},
+        entry_prices={"ABC": 100.0},
+        last_known_prices={"ABC": 100.0},
+        last_rebalance_date="2024-01-01",
+    )
+
+    with caplog.at_level("WARNING"):
+        out_state, _ = dw._run_scan(["ABC", "FRESH"], state, "TEST", cfg_override=UltimateConfig())
+
+    assert out_state.shares == {"ABC": 10}
+    assert sum("STALENESS GATE" in record.message for record in caplog.records) == 1
+    assert sum("REBALANCE SUPPRESSED" in record.message for record in caplog.records) == 0
+
+
 def test_run_scan_hard_cvar_breach_overrides_cadence_gate(monkeypatch):
     idx = pd.date_range("2024-01-01", periods=6)
     md = {


### PR DESCRIPTION
### Motivation
- Prevent emitting a duplicate stale-data warning when the cadence staleness gate already suppressed a rebalance. 
- Make the anchor-free split fallback's residual risk explicit in the code comments so maintainers understand the tradeoff for restored/manual states.

### Description
- Require `rebalance_allowed` in addition to `(optimization_succeeded or apply_decay)` before running the FIX-STALE-PRICE suppression block, to avoid a second `REBALANCE SUPPRESSED` log when the cadence gate already set `rebalance_allowed=False` (`daily_workflow.py`).
- Expanded the anchor-free split-fallback comment to document the residual risk that restored/manual states without anchors may over-apply historical splits (`daily_workflow.py`).
- Added a regression test `test_run_scan_cadence_stale_gate_does_not_emit_duplicate_rebalance_warning` that asserts only the primary `STALENESS GATE` warning is emitted and `REBALANCE SUPPRESSED` is not (`test_daily_workflow.py`).

### Testing
- Ran targeted tests with: `pytest -q test_daily_workflow.py -k "stale_prices_block_decay_rebalance or cadence_stale_gate_does_not_emit_duplicate_rebalance_warning or detect_and_apply_splits_without_anchor_compounds_visible_split_events or detect_and_apply_splits_first_run_uses_position_marker_not_full_history"`, and all selected tests passed (`4 passed, 15 deselected`).
- The new regression test verifies the duplicate-warning scenario and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c111ab616c832b919a55065bd0f348)