### PR TITLE
Wayback CDX: query multiple URL schemes and collapse monthly snapshots; add unit test

### DIFF
--- a/build_historical_fallback.py
+++ b/build_historical_fallback.py
@@ -175,29 +175,58 @@ def _fetch_with_retry(url: str, retries: int = 3, delay: float = 2.0) -> Optiona
 # ─── Wayback Machine PIT fetch ───────────────────────────────────────────────
 
 def _wbm_cdx_timestamps(nse_url: str, start_year: int = 2015) -> list[str]:
-    params = {
-        "url":      nse_url,
-        "output":   "json",
-        "fl":       "timestamp,statuscode",
-        "filter":   "statuscode:200",
-        "collapse": "timestamp:6",
-        "from":     str(start_year),
-        "limit":    "500",
-    }
-    try:
-        resp = requests.get(
-            _WBM_CDX_URL, params=params,
-            headers={"User-Agent": "Mozilla/5.0"},
-            timeout=30,
-        )
-        resp.raise_for_status()
-        rows = resp.json()
-        ts_list = [r[0] for r in rows[1:] if r[1] == "200"]
-        logger.info("[Wayback] CDX found %d monthly snapshots for %s", len(ts_list), nse_url)
-        return ts_list
-    except Exception as exc:
-        logger.warning("[Wayback] CDX query failed: %s", exc)
-        return []
+    """
+    Return one Wayback timestamp per month for the given Nifty500 CSV URL.
+
+    FIX-TRUE-PIT-01:
+    Some historical captures exist under HTTP vs HTTPS (or wildcard scheme),
+    so querying only one exact URL can massively undercount archival coverage.
+    We now query multiple URL patterns and then collapse to one snapshot per
+    month in Python (earliest snapshot in each month) for stable PIT anchors.
+    """
+    no_scheme = nse_url.split("://", 1)[1] if "://" in nse_url else nse_url
+    query_urls = [nse_url]
+    if nse_url.startswith("https://"):
+        query_urls.append(nse_url.replace("https://", "http://", 1))
+    query_urls.append(f"*://{no_scheme}")
+
+    collected: set[str] = set()
+    for query_url in query_urls:
+        params = {
+            "url": query_url,
+            "output": "json",
+            "fl": "timestamp,statuscode",
+            "filter": "statuscode:200",
+            "from": str(start_year),
+            "limit": "5000",
+        }
+        try:
+            resp = requests.get(
+                _WBM_CDX_URL, params=params,
+                headers={"User-Agent": "Mozilla/5.0"},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            rows = resp.json()
+            for row in rows[1:]:
+                if len(row) >= 2 and row[1] == "200":
+                    ts = str(row[0]).strip()
+                    if len(ts) >= 8 and ts[:4].isdigit():
+                        collected.add(ts)
+        except Exception as exc:
+            logger.debug("[Wayback] CDX query failed for %s: %s", query_url, exc)
+
+    month_to_ts: dict[str, str] = {}
+    for ts in sorted(collected):
+        month_key = ts[:6]
+        month_to_ts.setdefault(month_key, ts)
+    ts_list = [month_to_ts[m] for m in sorted(month_to_ts)]
+    logger.info(
+        "[Wayback] CDX found %d monthly snapshots for %s",
+        len(ts_list),
+        nse_url,
+    )
+    return ts_list
 
 
 def _wbm_fetch_csv(timestamp: str, original_url: str) -> pd.DataFrame | None:

--- a/test_build_historical_fallback.py
+++ b/test_build_historical_fallback.py
@@ -40,3 +40,48 @@ def test_load_env_file_fallback_strips_inline_comments_from_unquoted_values(tmp_
 def test_parse_args_defaults_start_to_2015():
     args = bhf._parse_args([])
     assert args.start == "2015-01-01"
+
+
+def test_wbm_cdx_timestamps_merges_scheme_variants_and_month_collapses(monkeypatch):
+    calls = []
+
+    class _Resp:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    def _fake_get(url, params=None, headers=None, timeout=None):  # noqa: ARG001
+        calls.append(params["url"])
+        payload_by_url = {
+            "https://example.com/file.csv": [
+                ["timestamp", "statuscode"],
+                ["20150101120000", "200"],
+                ["20150125120000", "200"],
+            ],
+            "http://example.com/file.csv": [
+                ["timestamp", "statuscode"],
+                ["20150201120000", "200"],
+            ],
+            "*://example.com/file.csv": [
+                ["timestamp", "statuscode"],
+                ["20150301120000", "200"],
+                ["20150305120000", "200"],
+            ],
+        }
+        return _Resp(payload_by_url.get(params["url"], [["timestamp", "statuscode"]]))
+
+    monkeypatch.setattr(bhf.requests, "get", _fake_get)
+
+    out = bhf._wbm_cdx_timestamps("https://example.com/file.csv", start_year=2015)
+
+    assert calls == [
+        "https://example.com/file.csv",
+        "http://example.com/file.csv",
+        "*://example.com/file.csv",
+    ]
+    assert out == ["20150101120000", "20150201120000", "20150301120000"]


### PR DESCRIPTION
### Motivation
- Historical Wayback captures were being undercounted when archives exist under different URL schemes (HTTP vs HTTPS or wildcard), which produced unstable PIT anchors.
- The goal is to reliably produce a single stable timestamp per month for a given Nifty500 CSV URL to improve PIT selection.

### Description
- ` _wbm_cdx_timestamps` now queries multiple URL patterns (`https://`, `http://`, and `*://` variants) instead of a single exact URL to capture more archival coverage.
- Collected timestamps from all queries are de-duplicated and collapsed in Python to one snapshot per month (the earliest timestamp for that month) and returned sorted.
- Increased the CDX `limit` to `5000`, hardened parsing of CDX rows, and lowered noisy failures to `debug` logging for query-specific errors.
- Added `test_wbm_cdx_timestamps_merges_scheme_variants_and_month_collapses` to validate scheme merging, call order, and monthly collapse behavior.

### Testing
- Ran the test file `test_build_historical_fallback.py` including the new `test_wbm_cdx_timestamps_merges_scheme_variants_and_month_collapses` unit test using `pytest`, and the tests passed.
- Existing unit tests in the same test file were executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a7036474832b85449edfd0d5cd38)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Wayback Machine timestamp retrieval by querying multiple URL pattern variants and consolidating results to one earliest timestamp per month, providing more complete historical data coverage.
  * Improved error handling to log individual query failures while continuing to collect and return available timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->