### PR TITLE
Suppress yfinance noise and allow partial regime benchmark coverage

### DIFF
--- a/data_cache.py
+++ b/data_cache.py
@@ -38,6 +38,8 @@ import logging
 import os
 import random
 import time
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -56,6 +58,38 @@ _RATE_LIMITED = object()
 
 # Maximum consecutive 429 retries per symbol before aborting
 _MAX_RATE_LIMIT_RETRIES = 5
+
+
+def _safe_yf_download(*args, **kwargs) -> pd.DataFrame:
+    """
+    Run yf.download while suppressing yfinance's noisy stdout/stderr prints.
+
+    yfinance writes per-symbol "possibly delisted" and "Failed downloads"
+    messages directly to stderr/stdout. When pulling large universes this can
+    flood logs and hide real errors. We capture those streams and keep only a
+    compact debug summary.
+    """
+    out_buf = StringIO()
+    err_buf = StringIO()
+    with redirect_stdout(out_buf), redirect_stderr(err_buf):
+        data = yf.download(*args, **kwargs)
+
+    noisy_lines: list[str] = []
+    for text in (out_buf.getvalue(), err_buf.getvalue()):
+        if not text:
+            continue
+        noisy_lines.extend(
+            ln.strip() for ln in text.splitlines()
+            if ln.strip()
+        )
+
+    if noisy_lines:
+        logger.debug(
+            "[Cache] Suppressed %d yfinance warning line(s). First line: %s",
+            len(noisy_lines),
+            noisy_lines[0],
+        )
+    return data
 
 
 def _load_local_env_file(env_path: Path = Path('.env')) -> None:
@@ -409,7 +443,7 @@ class GrowwProvider(DataProvider):
         yf_raw = pd.DataFrame()
         if valid_groww_tickers:
             try:
-                yf_raw = yf.download(
+                yf_raw = _safe_yf_download(
                     valid_groww_tickers,
                     start=yf_start,
                     end=yf_end,
@@ -476,7 +510,7 @@ class YFinanceProvider(DataProvider):
 
     def _download_batch(self, tickers: List[str], start: str, end: str) -> Optional[pd.DataFrame]:
         try:
-            return yf.download(
+            return _safe_yf_download(
                 tickers,
                 start=start,
                 end=end,

--- a/optimizer.py
+++ b/optimizer.py
@@ -665,10 +665,19 @@ class MomentumObjective:
 # ─── Orchestration ────────────────────────────────────────────────────────────
 
 def _validate_regime_benchmark_data(market_data: dict, required_start: str, required_end: str) -> None:
-    """Fail fast when regime benchmark inputs are missing or unusable."""
+    """
+    Validate regime benchmark inputs.
+
+    Hard-fail only when no benchmark has any usable Close data at all.
+    Partial history (e.g. symbol history starts after required_start) is
+    accepted with a warning because the regime subsystem can safely default
+    to neutral when benchmark context is sparse.
+    """
     required_start_ts = pd.Timestamp(required_start)
     required_end_ts = pd.Timestamp(required_end)
     benchmark_notes: list[str] = []
+    partial_coverage_notes: list[str] = []
+    has_any_usable_close = False
 
     for ticker in ("^CRSLDX", "^NSEI"):
         df = market_data.get(ticker)
@@ -684,10 +693,11 @@ def _validate_regime_benchmark_data(market_data: dict, required_start: str, requ
             benchmark_notes.append(f"{ticker}: Close column has no finite values")
             continue
 
+        has_any_usable_close = True
         coverage_start = pd.Timestamp(close.index.min())
         coverage_end = pd.Timestamp(close.index.max())
         if coverage_start > required_start_ts or coverage_end < required_end_ts:
-            benchmark_notes.append(
+            partial_coverage_notes.append(
                 f"{ticker}: coverage {coverage_start.date()} -> {coverage_end.date()} does not span "
                 f"{required_start_ts.date()} -> {required_end_ts.date()}"
             )
@@ -708,9 +718,20 @@ def _validate_regime_benchmark_data(market_data: dict, required_start: str, requ
         )
         return
 
+    if has_any_usable_close:
+        warn_details = partial_coverage_notes + benchmark_notes
+        logger.warning(
+            "Regime benchmark has only partial coverage for %s -> %s. Proceeding with available history; "
+            "regime score may be neutral early in-sample. Details: %s",
+            required_start_ts.date(),
+            required_end_ts.date(),
+            "; ".join(warn_details) if warn_details else "n/a",
+        )
+        return
+
     raise OptimizationError(
-        "Regime benchmark validation failed. Neither ^CRSLDX nor ^NSEI has usable Close coverage for "
-        f"{required_start_ts.date()} -> {required_end_ts.date()}. Details: " + "; ".join(benchmark_notes),
+        "Regime benchmark validation failed. Neither ^CRSLDX nor ^NSEI has usable Close data. "
+        "Details: " + "; ".join(benchmark_notes),
         OptimizationErrorType.DATA,
     )
 

--- a/test_optimizer.py
+++ b/test_optimizer.py
@@ -374,6 +374,19 @@ def test_validate_regime_benchmark_data_accepts_nsei_fallback():
     optimizer._validate_regime_benchmark_data(market_data, "2020-01-01", "2025-12-31")
 
 
+def test_validate_regime_benchmark_data_allows_partial_coverage_with_warning(caplog):
+    idx = pd.date_range("2024-01-15", "2025-12-31", freq="B")
+    market_data = {
+        "^NSEI": pd.DataFrame({"Close": np.linspace(100.0, 200.0, len(idx))}, index=idx)
+    }
+
+    with caplog.at_level("WARNING"):
+        optimizer._validate_regime_benchmark_data(market_data, "2016-11-27", "2025-12-31")
+
+    assert "partial coverage" in caplog.text
+    assert "Proceeding with available history" in caplog.text
+
+
 def test_validate_regime_benchmark_data_raises_when_benchmarks_missing():
     with pytest.raises(optimizer.OptimizationError, match="Regime benchmark validation failed") as exc_info:
         optimizer._validate_regime_benchmark_data({}, "2020-01-01", "2025-12-31")


### PR DESCRIPTION
### Motivation
- Large-universe downloads produced overwhelming yfinance stdout/stderr spam (per-symbol "possibly delisted" / "Failed downloads") that obscured real issues and flooded logs. 
- The optimizer hard-failed when benchmark indices had partial history that started after the requested warmup, causing runs to abort even when usable recent benchmark data existed.

### Description
- Add a `_safe_yf_download()` wrapper in `data_cache.py` that captures `stdout`/`stderr` from `yf.download` and logs a compact debug summary instead of allowing yfinance to print noisy per-symbol lines. 
- Replace direct `yf.download(...)` calls in the Groww reconciliation path and the YFinance provider with `_safe_yf_download(...)` to suppress log spam during batch fetches. 
- Relax `_validate_regime_benchmark_data` in `optimizer.py` so it only raises `OptimizationError` when neither benchmark has any usable `Close` data; if a benchmark has partial coverage the code now emits a warning and proceeds (regime logic will default to neutral early in-sample). 
- Add `test_validate_regime_benchmark_data_allows_partial_coverage_with_warning` to `test_optimizer.py` to cover the new partial-coverage behavior.

### Testing
- Ran `pytest -q test_optimizer.py -k "validate_regime_benchmark_data"` and the related validation tests passed (`3 passed, 46 deselected`).
- Ran `pytest -q test_data_cache.py` and the data cache tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ac401398832b97c30bbc031dac97)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed verbose output from market data downloads for cleaner logs and console messages.
  * Improved regime benchmark validation to warn on partial historical data coverage instead of failing, enabling optimization to proceed with available history when at least one benchmark ticker has usable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->