### PR TITLE
Pass force-close set and active_symbols to rebalance helpers; simplify signal cfg access

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -54,7 +54,7 @@ import logging
 import warnings
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import ClassVar, Dict, List, Optional, Tuple
+from typing import ClassVar, Dict, List, Optional, Set, Tuple
 
 import numpy as np
 import pandas as pd
@@ -577,12 +577,10 @@ def _compute_pv_exec(
     prices: np.ndarray,
     active_symbols: List[str],
     cfg: UltimateConfig,
+    symbols_to_force_close: Set[str],
 ) -> Tuple[float, float]:
     active_idx = {sym: i for i, sym in enumerate(active_symbols)}
     absent_snapshot: Dict[str, int] = dict(state.absent_periods)
-    symbols_to_force_close: set[str] = {
-        sym for sym, count in state.absent_periods.items() if count >= cfg.MAX_ABSENT_PERIODS
-    }
     t1_price_snapshot: Dict[str, float] = dict(state.last_known_prices)
     pv_t1 = state.cash
     pv_exec = state.cash
@@ -657,13 +655,17 @@ def _apply_drift_gate(
     prices: np.ndarray,
     pv_exec: float,
     cfg: UltimateConfig,
+    active_symbols: List[str],
 ) -> Tuple[Dict[str, int], set[str]]:
     drift_threshold = cfg.DRIFT_TOLERANCE
     drift_gated_syms: set[str] = set()
-    symbols = list(desired_shares.keys())
-    for i, sym in enumerate(symbols):
+    active_idx = {sym: i for i, sym in enumerate(active_symbols)}
+    for sym in active_symbols:
+        if sym not in desired_shares:
+            continue
         old_s = current_shares.get(sym, 0)
         s = desired_shares.get(sym, 0)
+        i = active_idx[sym]
         price = max(float(prices[i]), 1e-6)
         if old_s > 0 and s > 0 and s != old_s:
             w_target = float(target_weights[i]) if np.isfinite(target_weights[i]) else 0.0
@@ -751,7 +753,8 @@ def execute_rebalance(
                 symbols_to_force_close.append(sym)
 
     # Phase 1: build pv_exec excluding force-close candidates (see docstring)
-    pv_exec, pv_t1 = _compute_pv_exec(state, local_prices, active_symbols, cfg)
+    force_close_set = set(symbols_to_force_close)
+    pv_exec, pv_t1 = _compute_pv_exec(state, local_prices, active_symbols, cfg, force_close_set)
 
     if apply_decay:
         state.decay_rounds += 1
@@ -850,6 +853,7 @@ def execute_rebalance(
             prices=local_prices,
             pv_exec=pv_exec,
             cfg=cfg,
+            active_symbols=active_symbols,
         )
 
         # FIX-DRIFT-GATE-RESIDUAL: Remove gated symbols from valid_targets so
@@ -898,13 +902,9 @@ def execute_rebalance(
             _base_slip_reserve += _delta_not * _sr
 
     residual_cash = max(0.0, pv_exec - base_notional - _base_slip_reserve)
-    _ = _allocate_residual_cash(
-        residual_budget=residual_cash,
-        valid_targets=valid_targets,
-        conviction_scores=conviction_scores,
-        prices=local_prices,
-        cfg=cfg,
-    )
+    # TODO: _allocate_residual_cash was intended to replace the inline allocation
+    # loop below, but currently lacks ADV caps, per-name concentration limits,
+    # and multi-pass tracking.
 
     if valid_targets and residual_cash > 0:
         eligible = {

--- a/signals.py
+++ b/signals.py
@@ -345,8 +345,7 @@ def generate_signals(
 
     active_symbols = list(log_rets.columns)
 
-    _raw_lag = getattr(cfg, "SIGNAL_LAG_DAYS", 0)
-    signal_lag_days = max(int(_raw_lag if _raw_lag is not None else 0), 0)
+    signal_lag_days = max(cfg.SIGNAL_LAG_DAYS, 0)
     if signal_lag_days > 0 and len(log_rets) >= signal_lag_days:
         if len(log_rets) == signal_lag_days:
             logger.warning(
@@ -402,7 +401,7 @@ def generate_signals(
     # CONTINUITY_MAX_SCALAR * CONTINUITY_DISPERSION_FLOOR.  Use the floor
     # value directly in this degenerate case.
     if not gate_pass_mask.any():
-        std_cross = float(getattr(cfg, "CONTINUITY_DISPERSION_FLOOR", 0.1))
+        std_cross = cfg.CONTINUITY_DISPERSION_FLOOR
     else:
         std_cross = max(np.nanstd(norm_src), 1e-8)
 
@@ -469,7 +468,7 @@ def generate_signals(
     knife_pre_bonus_suppress = np.zeros(len(active_symbols), dtype=bool)
 
     if prev_weights and valid_mask.any():
-        cap = float(getattr(cfg, "CONTINUITY_MAX_SCALAR", 0.20))
+        cap = cfg.CONTINUITY_MAX_SCALAR
         # FIX-MB-DISPERSION: Scale the continuity bonus by the cross-sectional
         # return dispersion, clamped at CONTINUITY_DISPERSION_FLOOR. std_cross
         # was computed above from gate-passing symbols; using it here makes the
@@ -478,7 +477,7 @@ def generate_signals(
         # markets. Without this scaling, CONTINUITY_DISPERSION_FLOOR in
         # UltimateConfig was defined but never used, and tests that expected
         # dispersion-scaled bonus values would fail.
-        dispersion_floor = float(getattr(cfg, "CONTINUITY_DISPERSION_FLOOR", 0.1))
+        dispersion_floor = cfg.CONTINUITY_DISPERSION_FLOOR
         # FIX-DISPERSION-SCALE: scale bonus DOWN in low-dispersion markets.
         # Previous code multiplied by max(std_cross, floor) which both inverted
         # the direction (high-dispersion got bigger bonus) and produced a unit
@@ -486,11 +485,11 @@ def generate_signals(
         dispersion_scale = min(1.0, std_cross / max(dispersion_floor, 1e-12))
         base_bonus = min(cfg.CONTINUITY_BONUS, cap) * dispersion_scale
 
-        activity_window = max(int(getattr(cfg, "CONTINUITY_ACTIVITY_WINDOW", 5)), 1)
-        stale_sessions = max(int(getattr(cfg, "CONTINUITY_STALE_SESSIONS", 10)), 1)
-        min_nonzero_days = max(int(getattr(cfg, "CONTINUITY_MIN_NONZERO_DAYS", 1)), 1)
-        flat_ret_eps = float(getattr(cfg, "CONTINUITY_FLAT_RET_EPS", 1e-12))
-        continuity_min_adv = float(getattr(cfg, "CONTINUITY_MIN_ADV_NOTIONAL", 0.0))
+        activity_window = max(cfg.CONTINUITY_ACTIVITY_WINDOW, 1)
+        stale_sessions = max(cfg.CONTINUITY_STALE_SESSIONS, 1)
+        min_nonzero_days = max(cfg.CONTINUITY_MIN_NONZERO_DAYS, 1)
+        flat_ret_eps = cfg.CONTINUITY_FLAT_RET_EPS
+        continuity_min_adv = cfg.CONTINUITY_MIN_ADV_NOTIONAL
 
         stale_denied = 0
         liquidity_denied = 0
@@ -530,7 +529,7 @@ def generate_signals(
                 if is_stale or not passes_continuity_liquidity or not continuity_eligible:
                     continue
 
-                decay = float(np.clip(prev_w / max(getattr(cfg, "CONTINUITY_MAX_HOLD_WEIGHT", 0.10), 1e-6), 0.25, 1.0))
+                decay = float(np.clip(prev_w / max(cfg.CONTINUITY_MAX_HOLD_WEIGHT, 1e-6), 0.25, 1.0))
                 adj_scores[i] += base_bonus * decay
 
         if stale_denied or liquidity_denied:

--- a/test_momentum.py
+++ b/test_momentum.py
@@ -854,9 +854,25 @@ def test_compute_pv_exec_helper_includes_active_and_stale_positions():
     state.shares = {"A": 2, "B": 3}
     state.last_known_prices = {"A": 10.0, "B": 5.0}
     state.absent_periods = {"B": 1}
-    pv_exec, pv_t1 = _compute_pv_exec(state, np.array([11.0]), ["A"], cfg)
+    pv_exec, pv_t1 = _compute_pv_exec(state, np.array([11.0]), ["A"], cfg, symbols_to_force_close=set())
     assert pv_exec == pytest.approx(100.0 + 2 * 11.0 + 3 * absent_symbol_effective_price(5.0, 1, 10))
     assert pv_t1 == pytest.approx(100.0 + 2 * 10.0 + 3 * absent_symbol_effective_price(5.0, 1, 10))
+
+
+def test_compute_pv_exec_excludes_force_close_symbols():
+    cfg = UltimateConfig(MAX_ABSENT_PERIODS=10)
+    state = PortfolioState(cash=100.0)
+    state.shares = {"KEEP": 2, "FORCE": 3}
+    state.last_known_prices = {"KEEP": 10.0, "FORCE": 5.0}
+    pv_exec, pv_t1 = _compute_pv_exec(
+        state,
+        prices=np.array([11.0]),
+        active_symbols=["KEEP"],
+        cfg=cfg,
+        symbols_to_force_close={"FORCE"},
+    )
+    assert pv_exec == pytest.approx(100.0 + 2 * 11.0)
+    assert pv_t1 == pytest.approx(100.0 + 2 * 10.0)
 
 
 def test_compute_desired_shares_helper_handles_simple_case():
@@ -883,6 +899,7 @@ def test_apply_drift_gate_helper_blocks_small_change():
         prices=np.array([100.0]),
         pv_exec=20_000.0,
         cfg=cfg,
+        active_symbols=["A"],
     )
     assert desired["A"] == 100
     assert "A" in gated


### PR DESCRIPTION
### Motivation
- Make PV and drift computations explicit about which symbols are considered force-closed and ensure the drift gate uses the active-universe ordering rather than dict ordering. 
- Remove a dead `_allocate_residual_cash` invocation that was not used and clarify intent with a TODO. 
- Simplify `generate_signals` by using direct `cfg.FIELD` access to reduce noise from redundant `getattr` fallback lookups.

### Description
- In `momentum_engine.py` updated `_compute_pv_exec` to accept `symbols_to_force_close: Set[str]` and removed its internal reconstruction of the set, and updated `execute_rebalance` to pass the `force_close_set` into it. 
- In `momentum_engine.py` updated `_apply_drift_gate` to accept `active_symbols: List[str]`, index prices/weights against the active-ordering, and changed its call site in `execute_rebalance` to pass `active_symbols`. 
- Removed the dead `_allocate_residual_cash(...)` call and replaced it with a TODO explaining why the inline allocator remains, and added `Set` to typing imports. 
- In `signals.py` replaced `getattr(cfg, "FIELD", ...)` uses inside `generate_signals` with direct `cfg.FIELD` access for signal lag and continuity-related fields and removed redundant `float()` wrappers. 
- Updated `test_momentum.py` to match the new helper signatures, added `test_compute_pv_exec_excludes_force_close_symbols`, and adjusted existing tests to pass `active_symbols` and `symbols_to_force_close` where required.

### Testing
- Ran the focused pytest selection with `pytest -q test_momentum.py -k "compute_pv_exec_helper_includes_active_and_stale_positions or compute_pv_exec_excludes_force_close_symbols or apply_drift_gate_helper_blocks_small_change"`. 
- Result: `3 passed, 99 deselected` (run time ~3.4s). 
- The new and updated unit tests exercise the changed signatures for `_compute_pv_exec` and `_apply_drift_gate` and confirm force-close symbols are excluded from PV accounting and that the drift gate blocks small changes when appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6e02e9770832bbf577c999dd081fd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Configuration now requires explicit definition of signal generation parameters (signal lag, continuity settings); missing attributes will no longer use fallback defaults.
  * Enhanced rebalancing engine for improved symbol management, force-close handling, and drift-gating alignment.
  * Updated internal tests to validate symbol handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->