### PR TITLE
Delegate compute_one_way_slip_rate to vectorized implementation

### DIFF
--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -841,10 +841,14 @@ def compute_one_way_slip_rate(
         if (trade_notional is not None and np.isfinite(trade_notional) and trade_notional > 0)
         else portfolio_value
     )
-    base_rate = cfg.ROUND_TRIP_SLIPPAGE_BPS / 20_000.0
-    impact = cfg.IMPACT_COEFF * trade_value / adv_notional
-    impact = min(max(impact, 0.0), 0.05)
-    return max(base_rate, impact)
+    return float(
+        _compute_one_way_slip_rate_vectorized(
+            cfg,
+            portfolio_value,
+            np.array([adv_notional], dtype=float),
+            np.array([trade_value], dtype=float),
+        )[0]
+    )
 
 
 def _compute_one_way_slip_rate_vectorized(

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -865,9 +865,11 @@ def _compute_one_way_slip_rate_from_trade_value(
 
 def _resolve_trade_notional(
     portfolio_value: float,
-    trade_notional: Union[float, np.ndarray],
+    trade_notional: Optional[Union[float, np.ndarray]],
 ) -> Union[float, np.ndarray]:
     """Return provided trade notional when valid/positive, otherwise fall back to portfolio value."""
+    if trade_notional is None:
+        return float(portfolio_value)
     trade_arr = np.asarray(trade_notional, dtype=float)
     resolved = np.where(np.isfinite(trade_arr) & (trade_arr > 0), trade_arr, float(portfolio_value))
     if np.ndim(resolved) == 0:

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -60,7 +60,7 @@ import warnings
 from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Any, ClassVar, Dict, List, Optional, Set, Tuple
+from typing import Any, ClassVar, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -841,14 +841,38 @@ def compute_one_way_slip_rate(
         if (trade_notional is not None and np.isfinite(trade_notional) and trade_notional > 0)
         else portfolio_value
     )
-    return float(
-        _compute_one_way_slip_rate_vectorized(
-            cfg,
-            portfolio_value,
-            np.array([adv_notional], dtype=float),
-            np.array([trade_value], dtype=float),
-        )[0]
-    )
+    return _compute_one_way_slip_rate_from_trade_value(cfg, float(adv_notional), float(trade_value))
+
+
+def _compute_one_way_slip_rate_from_trade_value(
+    cfg: UltimateConfig,
+    adv_notional: Union[float, np.ndarray],
+    trade_value: Union[float, np.ndarray],
+) -> Union[float, np.ndarray]:
+    """Compute one-way slippage rate from already-resolved trade notional(s)."""
+    base_rate = cfg.ROUND_TRIP_SLIPPAGE_BPS / 20_000.0
+    adv_arr = np.asarray(adv_notional, dtype=float)
+    trade_arr = np.asarray(trade_value, dtype=float)
+    valid_adv = np.isfinite(adv_arr) & (adv_arr > 0)
+    impact = np.zeros_like(trade_arr, dtype=float)
+    np.divide(cfg.IMPACT_COEFF * trade_arr, adv_arr, out=impact, where=valid_adv)
+    impact = np.clip(impact, 0.0, 0.05)
+    rates = np.where(valid_adv, np.maximum(base_rate, impact), base_rate)
+    if np.ndim(rates) == 0:
+        return float(rates)
+    return rates
+
+
+def _resolve_trade_notional(
+    portfolio_value: float,
+    trade_notional: Union[float, np.ndarray],
+) -> Union[float, np.ndarray]:
+    """Return provided trade notional when valid/positive, otherwise fall back to portfolio value."""
+    trade_arr = np.asarray(trade_notional, dtype=float)
+    resolved = np.where(np.isfinite(trade_arr) & (trade_arr > 0), trade_arr, float(portfolio_value))
+    if np.ndim(resolved) == 0:
+        return float(resolved)
+    return resolved
 
 
 def _compute_one_way_slip_rate_vectorized(
@@ -869,15 +893,8 @@ def _compute_one_way_slip_rate_vectorized(
     Returns:
         np.ndarray: Matrix of calculated one-way slippage rates.
     """
-    base_rate = cfg.ROUND_TRIP_SLIPPAGE_BPS / 20_000.0
-    adv_arr = np.asarray(adv_notional, dtype=float)
-    trade_arr = np.asarray(trade_notional, dtype=float)
-    numerator = np.where(np.isfinite(trade_arr) & (trade_arr > 0), trade_arr, float(portfolio_value))
-    valid_adv = np.isfinite(adv_arr) & (adv_arr > 0)
-    impact = np.zeros_like(numerator, dtype=float)
-    impact[valid_adv] = cfg.IMPACT_COEFF * numerator[valid_adv] / adv_arr[valid_adv]
-    impact = np.clip(impact, 0.0, 0.05)
-    return np.where(valid_adv, np.maximum(base_rate, impact), base_rate)
+    trade_values = _resolve_trade_notional(portfolio_value, trade_notional)
+    return _compute_one_way_slip_rate_from_trade_value(cfg, adv_notional, trade_values)
 
 
 # ─── Execution ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## **User description**
### Motivation
- Centralize slippage logic by replacing the duplicated scalar formula in `compute_one_way_slip_rate` with a call into the existing vectorized implementation to avoid divergence and duplication.

### Description
- Replaced the four-line independent slippage calculation at the end of `compute_one_way_slip_rate` with a thin delegation that returns `float(_compute_one_way_slip_rate_vectorized(cfg, portfolio_value, np.array([adv_notional], dtype=float), np.array([trade_value], dtype=float))[0])`, while preserving the original function signature, docstring, and guard-clause logic.

### Testing
- Ran `python -m py_compile momentum_engine.py` and an automated verification script that confirmed `IMPACT_COEFF`, `base_rate`, and `max(base_rate` no longer appear in `compute_one_way_slip_rate` and that `_compute_one_way_slip_rate_vectorized` appears exactly once; both checks passed.

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8913538a4832b96c1d21b156e812c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved slip-rate calculation robustness: vectorized handling avoids invalid computations, safely resolves trade value inputs, clamps computed impact to sensible bounds, and ensures stable fallback to the base rate when input data is missing or non-positive—maintaining prior public behavior while reducing edge-case errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Single-trade and bulk slippage now use the same pricing rules**

### What Changed
- Single-trade slippage now follows the same result as bulk slippage, keeping quote calculations aligned across order sizes
- Invalid or missing trade sizes still fall back to the portfolio value, and invalid ADV values still use the base slippage rate
- Slippage handling now applies the same cap and minimum rate rules in one place for both single and batch calculations

### Impact
`✅ Consistent slippage quotes`
`✅ Fewer pricing mismatches`
`✅ More predictable trade cost estimates`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
