### PR TITLE
Unify rebalance pipeline, add adaptive CVaR min, and raise sector cap to 40%

### DIFF
--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -131,6 +131,7 @@ class BacktestEngine:
         self._eq_dates: list       = []
         self._eq_vals:  list       = []
         self._rebal_rows: list     = []
+        self._sector_map: Optional[dict] = None
 
     def _reset_run_state(self) -> None:
         """Clear session-level buffers but preserve state.shares/cash/etc."""
@@ -549,10 +550,11 @@ class BacktestEngine:
         prev_idx: int,
         date_pos: int,
         target_weights: np.ndarray,
-    ) -> tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         exec_prices, open_fallback_mask = _execution_prices(
             active_symbols, date, active_prices, open_px, high_px, low_px, return_open_fallback_mask=True
         )
+        first_day_mask = np.zeros(len(active_symbols), dtype=bool)
         if open_fallback_mask.any():
             sig_px_arr = close.values[prev_idx, active_col_indices]
             cur_px_arr = close.values[date_pos, active_col_indices]
@@ -570,7 +572,7 @@ class BacktestEngine:
                     skipped_syms,
                 )
                 target_weights[first_day_mask] = 0.0
-        return exec_prices, target_weights
+        return exec_prices, target_weights, first_day_mask
 
     def _execute_and_log_trades(
         self,
@@ -695,7 +697,7 @@ class BacktestEngine:
         else:
             realised_cvar = 0.0
 
-        exec_prices, _ = self._select_execution_prices(
+        exec_prices, _, first_day_mask = self._select_execution_prices(
             date, active_symbols, active_prices, close, open_px, high_px, low_px,
             active_col_indices, prev_idx, date_pos, np.zeros(len(active_symbols), dtype=float)
         )
@@ -714,6 +716,9 @@ class BacktestEngine:
             cfg=cfg,
             state=self.state,
             rebalance_date=date,
+            engine=self.engine,
+            trade_log=self.trades,
+            first_day_exclude_mask=first_day_mask if first_day_mask.any() else None,
         )
         result = run_rebalance_pipeline(ctx)
 
@@ -726,8 +731,8 @@ class BacktestEngine:
                 "override_active":    self.state.override_active,
                 "n_positions":        len(self.state.shares),
                 "apply_decay":        result.applied_decay,
-                "forced_to_cash":     False,
-                "force_cash_reason":  "",
+                "forced_to_cash":     result.forced_to_cash,
+                "force_cash_reason":  result.force_cash_reason,
             })
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -67,6 +67,9 @@ from momentum_engine import (
     activate_override_on_stress,
     absent_symbol_effective_price,
     _get_adaptive_cvar_min_obs,
+    RebalanceContext,
+    run_rebalance_pipeline,
+    _build_sector_labels as _me_build_sector_labels,
 )
 from signals import (
     generate_signals,
@@ -155,6 +158,9 @@ class BacktestEngine:
         gross_exposure = invested_notional / max(pv, 1e-6)
         return pv, gross_exposure
 
+    def _build_prev_weights(self, symbols: List[str], pv: float) -> Dict[str, float]:
+        return _build_prev_weights(self.state, symbols, pv)
+
     def run(
         self,
         close:           pd.DataFrame,
@@ -214,6 +220,7 @@ class BacktestEngine:
         start_dt = pd.Timestamp(start_date)
         end_dt   = pd.Timestamp(end_date) if end_date else close.index[-1]
         symbols  = close.columns.tolist()
+        self._sector_map = sector_map
         close_arr = close.values
         date_to_pos = {d: i for i, d in enumerate(close.index)}
 
@@ -684,45 +691,44 @@ class BacktestEngine:
 
         adaptive_cvar_min_obs = _get_adaptive_cvar_min_obs(cfg)
         if len(self.state.equity_hist) >= adaptive_cvar_min_obs:
-            realised_cvar = self.state.realised_cvar(min_obs=adaptive_cvar_min_obs)
+            realised_cvar = self.state.realised_cvar(cfg=cfg)
         else:
             realised_cvar = 0.0
 
-        self.state.update_exposure(regime_score, realised_cvar, cfg, gross_exposure=gross_exposure)
-
-        apply_decay, _force_full_cash, soft_cvar_breach = self._check_cvar_breach(
-            date, valuation_prices, active_symbols, hist_log_rets, cfg
+        exec_prices, _ = self._select_execution_prices(
+            date, active_symbols, active_prices, close, open_px, high_px, low_px,
+            active_col_indices, prev_idx, date_pos, np.zeros(len(active_symbols), dtype=float)
         )
 
-        optimization_succeeded = False
-        target_weights = np.zeros(len(active_symbols))
-        sel_idx: List[int] = []
+        ctx = RebalanceContext(
+            active_symbols=active_symbols,
+            log_rets=hist_log_rets,
+            valuation_prices=valuation_prices,
+            exec_prices=exec_prices,
+            pv=pv,
+            adv_vector=adv_vector,
+            prev_weights=self._build_prev_weights(active_symbols, pv),
+            regime_score=regime_score,
+            gross_exposure=gross_exposure,
+            sector_labels=_me_build_sector_labels(active_symbols, self._sector_map),
+            cfg=cfg,
+            state=self.state,
+            rebalance_date=date,
+        )
+        result = run_rebalance_pipeline(ctx)
 
-        if not _force_full_cash:
-            target_weights, optimization_succeeded, apply_decay, sel_idx, abort = self._generate_rebalance_signals(
-                date, active_symbols, hist_log_rets, adv_vector, valuation_prices,
-                pv, prev_w_dict, sector_map, soft_cvar_breach, apply_decay, cfg
-            )
-            if abort:
-                return
-
-        _exhaust_decay = False
-        if apply_decay and not optimization_succeeded:
-            target_weights, _exhaust_decay = self._compute_position_decay(
-                date, active_symbols, valuation_prices, pv, target_weights, sel_idx, _force_full_cash, cfg
-            )
-
-        if optimization_succeeded or apply_decay:
-            exec_prices, target_weights = self._select_execution_prices(
-                date, active_symbols, active_prices, close, open_px, high_px, low_px,
-                active_col_indices, prev_idx, date_pos, target_weights
-            )
-            
-            self._execute_and_log_trades(
-                date, target_weights, exec_prices, active_symbols, adv_vector, apply_decay,
-                _exhaust_decay, soft_cvar_breach, _force_full_cash, hist_log_rets,
-                regime_score, realised_cvar, cfg
-            )
+        if result.optimization_succeeded or result.applied_decay:
+            self._rebal_rows.append({
+                "date":               date,
+                "regime_score":       round(regime_score, 4),
+                "realised_cvar":      round(realised_cvar, 6),
+                "exposure_multiplier":round(self.state.exposure_multiplier, 4),
+                "override_active":    self.state.override_active,
+                "n_positions":        len(self.state.shares),
+                "apply_decay":        result.applied_decay,
+                "forced_to_cash":     False,
+                "force_cash_reason":  "",
+            })
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/backtest_engine.py
+++ b/backtest_engine.py
@@ -686,7 +686,6 @@ class BacktestEngine:
             valuation_close=valuation_close,
             cfg=cfg,
         )
-        prev_w_dict = _build_prev_weights(self.state, active_symbols, pv)
 
         idx_slice    = idx_df.loc[:signal_date] if idx_df is not None and not getattr(idx_df, "empty", False) else None
         regime_score = compute_regime_score(idx_slice, cfg=cfg, universe_close_hist=close.loc[:signal_date])
@@ -712,7 +711,7 @@ class BacktestEngine:
             prev_weights=self._build_prev_weights(active_symbols, pv),
             regime_score=regime_score,
             gross_exposure=gross_exposure,
-            sector_labels=_me_build_sector_labels(active_symbols, self._sector_map),
+            sector_labels=_me_build_sector_labels(active_symbols, sector_map),
             cfg=cfg,
             state=self.state,
             rebalance_date=date,

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -1507,11 +1507,25 @@ def _run_scan(
                     )
                     _first_day_mask = _first_day_flags.values.astype(bool)
 
+            # Build open-preferred execution prices to match the backtest path.
+            # When today's open price is available and valid, prefer it over close
+            # for execution modelling.  Falls back to close when open is absent
+            # (pre-market run, holiday, or missing data).
+            _today_ts = pd.Timestamp(end_date)
+            exec_prices = prices.copy()
+            for _ei, _esym in enumerate(active):
+                _ens = to_ns(_esym)
+                _edf = market_data.get(_ens)
+                if _edf is not None and "Open" in _edf.columns and _today_ts in _edf.index:
+                    _open_px = float(_edf.loc[_today_ts, "Open"])
+                    if np.isfinite(_open_px) and _open_px > 0:
+                        exec_prices[_ei] = _open_px
+
             ctx = RebalanceContext(
                 active_symbols=active,
                 log_rets=log_rets,
                 valuation_prices=prices,
-                exec_prices=prices,
+                exec_prices=exec_prices,
                 pv=pv,
                 adv_vector=adv_arr,
                 prev_weights=_prev_weights,

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -1449,6 +1449,27 @@ def _run_scan(
             _write_pending_sentinel(name=name, token=token, date_str=today.strftime("%Y-%m-%d"))
 
             sector_map = get_sector_map(active, cfg=cfg)
+            # Compute current market-value weights from shares * price / pv,
+            # applying absent-period haircuts for delisted/suspended symbols.
+            # This is more accurate than state.weights, which stores the last
+            # rebalance's target weights and drifts as prices move.
+            _prev_weights: Dict[str, float] = {}
+            if pv > 0:
+                for _sym, _n in state.shares.items():
+                    if _n <= 0:
+                        continue
+                    _raw_px = (
+                        prices[active_idx[_sym]]
+                        if _sym in active_idx
+                        else state.last_known_prices.get(_sym, 0.0)
+                    )
+                    _absent_n = int(state.absent_periods.get(_sym, 0))
+                    if _absent_n > 0:
+                        _px = float(absent_symbol_effective_price(float(_raw_px), _absent_n, cfg.MAX_ABSENT_PERIODS))
+                    else:
+                        _px = float(_raw_px)
+                    if _px > 0:
+                        _prev_weights[_sym] = (_n * _px) / pv
             ctx = RebalanceContext(
                 active_symbols=active,
                 log_rets=log_rets,
@@ -1456,7 +1477,7 @@ def _run_scan(
                 exec_prices=prices,
                 pv=pv,
                 adv_vector=adv_arr,
-                prev_weights=dict(state.weights),
+                prev_weights=_prev_weights,
                 regime_score=regime_score,
                 gross_exposure=initial_gross_exposure,
                 sector_labels=_build_sector_labels(active, sector_map),

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -1478,7 +1478,7 @@ def _run_scan(
                 pv=pv,
                 adv_vector=adv_arr,
                 prev_weights=_prev_weights,
-                regime_score=regime_score,
+                trade_log=trade_log,
                 gross_exposure=initial_gross_exposure,
                 sector_labels=_build_sector_labels(active, sector_map),
                 cfg=cfg,

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -1515,6 +1515,7 @@ def _run_scan(
                 pv=pv,
                 adv_vector=adv_arr,
                 prev_weights=_prev_weights,
+                regime_score=regime_score,
                 trade_log=trade_log,
                 gross_exposure=initial_gross_exposure,
                 sector_labels=_build_sector_labels(active, sector_map),

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -96,6 +96,9 @@ from momentum_engine import (
     Trade,
     activate_override_on_stress,
     _get_adaptive_cvar_min_obs,
+    RebalanceContext,
+    run_rebalance_pipeline,
+    _build_sector_labels,
 )
 from universe_manager import (
     fetch_nse_equity_universe,
@@ -1425,239 +1428,17 @@ def _run_scan(
         adaptive_cvar_min_obs = _get_adaptive_cvar_min_obs(cfg)
         state.update_exposure(
             regime_score,
-            state.realised_cvar(min_obs=adaptive_cvar_min_obs),
+            state.realised_cvar(cfg=cfg),
             cfg,
             gross_exposure=initial_gross_exposure,
         )
     
-        weights              = np.zeros(len(active))
-        apply_decay          = False
-        optimization_succeeded = False
         total_slippage       = 0.0
         trade_log: List[Trade] = []
-        sel_idx: List[int]   = []
-        _force_full_cash     = False
-        _soft_cvar_breach    = False
         rebalanced_this_scan = False
-    
-        # ── Book CVaR screen ──────────────────────────────────────────────────────
-        if state.shares:
-            book_cvar = compute_book_cvar(state, prices, active, log_rets, cfg)
-            hard_multiplier = getattr(cfg, "CVAR_HARD_BREACH_MULTIPLIER", 1.5)
-            hard_breach_threshold = cfg.CVAR_DAILY_LIMIT * hard_multiplier
-    
-            if book_cvar > hard_breach_threshold:
-                logger.warning(
-                    "[Scan] Book CVaR %.4f%% exceeds HARD limit %.4f%% (%.1fx) — "
-                    "skipping optimization, forcing immediate liquidation.",
-                    book_cvar * 100, hard_breach_threshold * 100, hard_multiplier,
-                )
-                state.consecutive_failures += 1
-                apply_decay      = True
-                _force_full_cash = True
-                activate_override_on_stress(state, cfg)
-            elif book_cvar > cfg.CVAR_DAILY_LIMIT + 1e-6:
-                _soft_cvar_breach = True
-                logger.info(
-                    "[Scan] Book CVaR soft breach %.4f%% (limit %.4f%%, hard %.4f%%) — "
-                    "running optimizer with CVaR constraint active.",
-                    book_cvar * 100, cfg.CVAR_DAILY_LIMIT * 100, hard_breach_threshold * 100,
-                )
-    
-        if rebalance_allowed and not _force_full_cash:
-            try:
-                raw_daily, adj_scores, sel_idx, gate_counts = generate_signals(
-                    log_rets, adv_arr, cfg, prev_weights=state.weights
-                )
-                # FIX-MB-GATENAMES: Keys renamed to "history_failed" / "adv_failed" /
-                # "knife_failed". Log message now clearly states "removed by" each gate
-                # so operators can distinguish a data-provider outage (many history
-                # failures) from a volatility spike (many knife-gate removals).
-                logger.info(
-                    "[Scan] Universe funnel: %d total → %d removed by history gate → "
-                    "%d removed by ADV gate → %d removed by knife gate → %d selected.",
-                    gate_counts.get("total", 0),
-                    gate_counts.get("history_failed", 0),
-                    gate_counts.get("adv_failed", 0),
-                    gate_counts.get("knife_failed", 0),
-                    gate_counts.get("selected", 0),
-                )
-                if not sel_idx:
-                    raise OptimizationError("No valid universe candidates.", OptimizationErrorType.DATA)
-                sel_syms      = [active[i] for i in sel_idx]
-                sector_map    = get_sector_map(sel_syms, cfg=cfg)
-                known_sectors  = sorted(s for s in set(sector_map.values()) if s != "Unknown")
-                sec_idx        = {s: i for i, s in enumerate(known_sectors)}
-                sector_labels  = np.array(
-                    [sec_idx.get(sector_map[sym], -1) for sym in sel_syms], dtype=int
-                )
-    
-                weights_sel = engine.optimize(
-                    expected_returns    = raw_daily[sel_idx],
-                    historical_returns  = log_rets[[active[i] for i in sel_idx]],
-                    execution_date      = pd.Timestamp(end_date),
-                    adv_shares          = adv_arr[sel_idx],
-                    prices              = prices[sel_idx],
-                    portfolio_value     = pv,
-                    prev_w              = prev_w_arr[sel_idx],
-                    exposure_multiplier = state.exposure_multiplier,
-                    sector_labels       = sector_labels,
-                )
-                weights[sel_idx]               = weights_sel
-                state.consecutive_failures     = 0
-                state.decay_rounds             = 0
-                optimization_succeeded         = True
-    
-            except (OptimizationError, ValueError) as exc:
-                is_data_error = isinstance(exc, ValueError) or (
-                    isinstance(exc, OptimizationError) and exc.error_type == OptimizationErrorType.DATA
-                )
-                if not is_data_error:
-                    state.consecutive_failures += 1
-                    logger.error("Solver failure #%d: %s. Freezing state.", state.consecutive_failures, exc)
-                    if _soft_cvar_breach:
-                        logger.warning(
-                            "Solver failure during active soft CVaR breach — "
-                            "bypassing 3-failure wait, triggering immediate decay."
-                        )
-                        apply_decay = True
-                    elif state.consecutive_failures >= 3:
-                        logger.warning(
-                            "3 consecutive solver failures — triggering gate-filtered "
-                            "pro-rata liquidation (%.0f%% of gate-passing positions).",
-                            cfg.DECAY_FACTOR * 100,
-                        )
-                        apply_decay = True
-                else:
-                    logger.warning("Data error (empty universe / thin history): %s. Resetting counters and freezing state.", exc)
-                    state.consecutive_failures = 0
-                    state.decay_rounds = 0
-    
-        # ── Gate-filtered decay target computation ────────────────────────────────
-        _exhaust_decay = False
-        if apply_decay and not optimization_succeeded:
-            if _force_full_cash or state.decay_rounds >= cfg.MAX_DECAY_ROUNDS:
-                weights = np.zeros(len(active), dtype=float)
-                logger.warning(
-                    "[Scan] %s — forcing full liquidation to cash.",
-                    "Book CVaR breach" if _force_full_cash else
-                    f"MAX_DECAY_ROUNDS={cfg.MAX_DECAY_ROUNDS} exhausted",
-                )
-                _exhaust_decay = True
-            else:
-                weights = compute_decay_targets(state, sel_idx, active, cfg, current_prices=prices, pv=pv)
-    
-        # FIX-MB-RESIDUALCASH: The residual-cash allocation is handled entirely inside
-        # execute_rebalance via its multi-pass proportional allocation loop, which
-        # operates on the actual post-sell cash balance. We must NOT attempt to size
-        # additional buys here against pv_exec (computed before sells execute) because
-        # after sells complete the available cash is lower than pv_exec implies, and
-        # oversizing here causes state.cash to go negative after slippage deduction.
-        # The execute_rebalance call below receives the target weights and handles
-        # residual distribution correctly with no pre-call adjustment needed.
-    
-        # FIX-STALE-PRICE: Single source-of-truth stale-price gate. We validate
-        # held symbols against market_data using the close-index trading calendar
-        # and suppress normal rebalances when stale, while still allowing
-        # _force_full_cash liquidations in stress events.
-        # Use an authoritative expected session date derived from market calendar
-        # (fallback: latest business day) so uniformly stale payloads cannot pass
-        # just because every series shares the same stale close.index endpoint.
-        # Before executing a rebalance, check whether any held
-        # position has a price that is older than _STALE_PRICE_DAYS trading days.
-        # A rebalance using a 3-day-old price is likely worse than no rebalance,
-        # because the optimizer will size incorrectly relative to the current
-        # portfolio value. Force-liquidations (CVaR breach) are exempt — it is
-        # always safer to exit a position than to hold it with a stale price.
-        _STALE_PRICE_DAYS = 2  # trading days
-        _rebalance_stale_held: list = []
-        if (rebalance_allowed or _force_full_cash) and (optimization_succeeded or apply_decay):
-            valid_days = None
-            expected_session_date = pd.Timestamp.now(tz=TIMEZONE_IST).normalize()
-            calendar_window_start = (expected_session_date - pd.Timedelta(days=366)).replace(tzinfo=None)
-            try:
-                import pandas_market_calendars as mcal
 
-                nse_calendar = mcal.get_calendar("NSE")
-                valid_days = nse_calendar.valid_days(
-                    start_date=calendar_window_start,
-                    end_date=expected_session_date,
-                )
-                if len(valid_days) > 0:
-                    expected_session_date = pd.Timestamp(valid_days[-1]).tz_convert(TIMEZONE_IST).normalize().replace(tzinfo=None)
-                else:
-                    expected_session_date = (expected_session_date - pd.offsets.BDay(1)).replace(tzinfo=None)
-            except Exception:
-                expected_session_date = (expected_session_date - pd.offsets.BDay(1)).tz_localize(None)
-
-            trusted_close_index = pd.DatetimeIndex([])
-            if valid_days is not None and len(valid_days) > 0:
-                trusted_close_index = pd.DatetimeIndex(valid_days)
-                if trusted_close_index.tz is not None:
-                    trusted_close_index = trusted_close_index.tz_localize(None)
-                trusted_close_index = trusted_close_index.normalize()
-                trusted_close_index = trusted_close_index[trusted_close_index <= expected_session_date]
-
-            if trusted_close_index.empty or trusted_close_index.max() < expected_session_date:
-                trusted_close_index = pd.date_range(
-                    start=calendar_window_start,
-                    end=expected_session_date,
-                    freq="B",
-                )
-
-            for _chk_sym in state.shares:
-                if _chk_sym not in active_idx:
-                    continue  # absent symbols handled by execute_rebalance itself
-                _chk_col = to_ns(_chk_sym)
-                _chk_df  = market_data.get(_chk_col) if market_data else None
-                if _chk_df is not None and not _chk_df.empty:
-                    _last_ts = _chk_df.index[-1]
-                    # Normalise timezone before comparison
-                    if hasattr(_last_ts, "tzinfo") and _last_ts.tzinfo is not None:
-                        _last_ts = _last_ts.tz_convert(TIMEZONE_IST).replace(tzinfo=None)
-                    _last_ts = pd.Timestamp(_last_ts)
-                    # BUG-FIX-MONDAY: use the close index (actual NSE trading
-                    # calendar) as the business-day ruler rather than raw calendar
-                    # days.  A Friday close evaluated on Monday gives 0 bars elapsed
-                    # (the weekend produced no trading bars), correctly passing the
-                    # gate.  Calendar-day arithmetic (today - last_ts).days would
-                    # yield 3, suppressing every Monday rebalance as a false alarm.
-                    _trading_bars_elapsed = int((trusted_close_index > _last_ts).sum())
-                    if _trading_bars_elapsed > _STALE_PRICE_DAYS:
-                        _rebalance_stale_held.append((_chk_sym, _trading_bars_elapsed))
-            if _rebalance_stale_held:
-                logger.warning(
-                    "[Scan] STALENESS GATE: %d held symbol(s) have prices "
-                    "older than %d trading bar(s) in the NSE close index: %s. "
-                    "Skipping rebalance to avoid sizing on stale data. "
-                    "Will retry on next scan once provider returns fresh data.",
-                    len(_rebalance_stale_held),
-                    _STALE_PRICE_DAYS,
-                    [(s, f"{d}d") for s, d in _rebalance_stale_held],
-                )
-                optimization_succeeded = False
-                # BUG-DW-02: Forced liquidations (CVaR hard breach) must bypass
-                # stale-price suppression to ensure the execution condition
-                # (rebalance_allowed or _force_full_cash) and (optimization_succeeded or
-                # apply_decay) evaluates to True. Only reset apply_decay when not in a
-                # forced liquidation scenario.
-                if not _force_full_cash:
-                    apply_decay = False
-
-            # [PHASE 2 FIX] Stale Price Gate Bypass: Ensure forced liquidation handling
-            # holds stale/halted symbols at their current weight, bypassing sell-orders
-            # so CVaR execution avoids fake realizations at stale prices.
-            if _rebalance_stale_held and (_force_full_cash or apply_decay):
-                for _s_bare, _ in _rebalance_stale_held:
-                    if _s_bare in active_idx:
-                        _s_idx = active_idx[_s_bare]
-                        _s_shares = state.shares.get(_s_bare, 0)
-                        _s_px = max(float(prices[_s_idx]), 1e-6)
-                        _mtm_w = (_s_shares * _s_px) / max(pv, 1.0)
-                        weights[_s_idx] = _mtm_w
-    
-        if (rebalance_allowed or _force_full_cash) and (optimization_succeeded or apply_decay):
-            pending = _load_pending_sentinel(name=name)  # ARCH-FIX-3
+        if rebalance_allowed:
+            pending = _load_pending_sentinel(name=name)
             if pending and pending.get("date") == session_date.strftime("%Y-%m-%d"):
                 logger.warning("Rebalance already committed for today, skipping")
                 return state, market_data
@@ -1665,31 +1446,30 @@ def _run_scan(
             if not _try_claim_pending_sentinel(name=name, token=token, date_str=session_date.strftime("%Y-%m-%d")):
                 logger.warning("Rebalance claim already exists for today, skipping")
                 return state, market_data
-            _write_pending_sentinel(
-                name=name,
-                token=token,
-                date_str=today.strftime("%Y-%m-%d"),
+            _write_pending_sentinel(name=name, token=token, date_str=today.strftime("%Y-%m-%d"))
+
+            sector_map = get_sector_map(active, cfg=cfg)
+            ctx = RebalanceContext(
+                active_symbols=active,
+                log_rets=log_rets,
+                valuation_prices=prices,
+                exec_prices=prices,
+                pv=pv,
+                adv_vector=adv_arr,
+                prev_weights=dict(state.weights),
+                regime_score=regime_score,
+                gross_exposure=initial_gross_exposure,
+                sector_labels=_build_sector_labels(active, sector_map),
+                cfg=cfg,
+                state=state,
+                rebalance_date=pd.Timestamp.now(tz="UTC"),
             )
-            _T_cvar = min(len(log_rets), cfg.CVAR_LOOKBACK)
-            _scenario_losses = -(
-                log_rets.iloc[-_T_cvar:]
-                .reindex(columns=active, fill_value=0.0)
-                .values
-            )
-            total_slippage = execute_rebalance(
-                state, weights, prices, active, cfg,
-                adv_shares=adv_arr,
-                date_context=today, trade_log=trade_log,
-                apply_decay    = apply_decay and not _exhaust_decay,
-                scenario_losses = None if _exhaust_decay else _scenario_losses,
-                force_rebalance_trades = _soft_cvar_breach,
-            )
-            state.last_rebalance_date = today.strftime("%Y-%m-%d")
-            rebalanced_this_scan = True
-            if _exhaust_decay:
-                state.decay_rounds = 0
-                state.consecutive_failures = 0
-    
+            result = run_rebalance_pipeline(ctx)
+            total_slippage = result.total_slippage
+            if result.optimization_succeeded or result.applied_decay:
+                state.last_rebalance_date = today.strftime("%Y-%m-%d")
+                rebalanced_this_scan = True
+
         _print_stage_status("Analysis", 0.85, "Applying rebalance decisions and updating portfolio marks...")
     
         price_dict = {sym: prices[active_idx[sym]] for sym in active}
@@ -1718,7 +1498,7 @@ def _run_scan(
             "Equity: %s₹%s%s | Slippage: %s₹%s%s",
             C.BLU, label, C.RST,
             regime_score,
-            state.realised_cvar(min_obs=adaptive_cvar_min_obs) * 100,
+            state.realised_cvar(cfg=cfg) * 100,
             state.consecutive_failures,
             C.GRN, f"{final_pv:,.0f}", C.RST,
             C.RED, f"{total_slippage:,.0f}", C.RST,
@@ -1837,7 +1617,7 @@ def _render_portfolio_diagnostics(state: PortfolioState, cfg: UltimateConfig) ->
     Returns:
         str: ANSI-formatted diagnostic block.
     """
-    cvar = state.realised_cvar(min_obs=_get_adaptive_cvar_min_obs(cfg))
+    cvar = state.realised_cvar(cfg=cfg)
     cvar_color = C.RED if cvar > cfg.CVAR_DAILY_LIMIT else C.GRN
     return "\n".join([
         f"\n  {C.BLD}Portfolio Diagnostics:{C.RST}",

--- a/daily_workflow.py
+++ b/daily_workflow.py
@@ -95,7 +95,6 @@ from momentum_engine import (
     to_bare,
     Trade,
     activate_override_on_stress,
-    _get_adaptive_cvar_min_obs,
     RebalanceContext,
     run_rebalance_pipeline,
     _build_sector_labels,
@@ -1374,6 +1373,10 @@ def _run_scan(
         # record_eod).  compute_book_cvar does not guard against NaN in its prices
         # argument — a NaN propagates into notional → pv → weights → CVaR, producing
         # an incorrect (often zero) CVaR that suppresses the risk gate.
+        # FIX-STALE-PRICE: also track which held symbols have stale prices so the
+        # rebalance gate can suppress non-forced rebalances when held positions have
+        # no valid current price data (e.g. provider outage).
+        _stale_held_syms: set[str] = set()
         for _sym, _i in active_idx.items():
             if not np.isfinite(prices[_i]) or prices[_i] <= 0:
                 _lkp = state.last_known_prices.get(_sym, 0.0)
@@ -1384,6 +1387,8 @@ def _run_scan(
                     reason="stale_price" if (np.isfinite(_lkp) and _lkp > 0) else "no_price",
                     detail=f"last_known={_lkp:.4f}" if np.isfinite(_lkp) else "no_last_known",
                 )
+                if state.shares.get(_sym, 0) > 0:
+                    _stale_held_syms.add(_sym)
     
         mtm_notional = 0.0
         for sym in state.shares:
@@ -1425,7 +1430,6 @@ def _run_scan(
         prev_w_arr    = np.array([state.weights.get(sym, 0.0) for sym in active])
         _print_stage_status("Analysis", 0.55, "Running momentum iterations, liquidity filters, and risk gates...")
     
-        adaptive_cvar_min_obs = _get_adaptive_cvar_min_obs(cfg)
         state.update_exposure(
             regime_score,
             state.realised_cvar(cfg=cfg),
@@ -1436,6 +1440,20 @@ def _run_scan(
         total_slippage       = 0.0
         trade_log: List[Trade] = []
         rebalanced_this_scan = False
+
+        # FIX-STALE-PRICE: suppress non-forced rebalances when any held symbol has
+        # a stale price.  Trading against stale prices produces incorrect position
+        # sizing and may result in large unintended trades during provider outages.
+        # Forced liquidations (triggered inside run_rebalance_pipeline on a hard
+        # CVaR breach) are exempt — they proceed regardless of stale prices.
+        if _stale_held_syms and rebalance_allowed:
+            logger.warning(
+                "[Scan] Suppressing rebalance: %d held symbol(s) have stale price data: %s. "
+                "Rebalance skipped to prevent incorrect sizing. Will retry next scan.",
+                len(_stale_held_syms),
+                sorted(_stale_held_syms),
+            )
+            rebalance_allowed = False
 
         if rebalance_allowed:
             pending = _load_pending_sentinel(name=name)
@@ -1470,6 +1488,25 @@ def _run_scan(
                         _px = float(_raw_px)
                     if _px > 0:
                         _prev_weights[_sym] = (_n * _px) / pv
+
+            # FIX-DW-FIRSTDAY: skip newly listed symbols on their first rebalance.
+            # A symbol appearing in `active` but with no valid close in close_hist
+            # (all NaN or absent) has no history for signal generation and no usable
+            # open price, so we zero its target weight to prevent erroneous entry.
+            _first_day_mask: Optional[np.ndarray] = None
+            if not close_hist.empty and close_hist.shape[0] > 0:
+                _active_hist = close_hist.reindex(columns=active)
+                _first_day_flags = _active_hist.isna().all(axis=0)
+                if _first_day_flags.any():
+                    _first_day_syms = [s for s, v in _first_day_flags.items() if v]
+                    logger.warning(
+                        "[Scan] Excluding %d first-day listing(s) from rebalance on %s: %s",
+                        len(_first_day_syms),
+                        today.strftime("%Y-%m-%d"),
+                        _first_day_syms,
+                    )
+                    _first_day_mask = _first_day_flags.values.astype(bool)
+
             ctx = RebalanceContext(
                 active_symbols=active,
                 log_rets=log_rets,
@@ -1484,6 +1521,8 @@ def _run_scan(
                 cfg=cfg,
                 state=state,
                 rebalance_date=pd.Timestamp.now(tz="UTC"),
+                engine=engine,
+                first_day_exclude_mask=_first_day_mask,
             )
             result = run_rebalance_pipeline(ctx)
             total_slippage = result.total_slippage

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -732,6 +732,9 @@ class RebalanceContext:
     state: PortfolioState
     rebalance_date: pd.Timestamp
     scenario_losses: Optional[np.ndarray] = None
+    engine: Optional["InstitutionalRiskEngine"] = None
+    trade_log: Optional[List["Trade"]] = None
+    first_day_exclude_mask: Optional[np.ndarray] = None
 
 
 @dataclass
@@ -741,6 +744,8 @@ class RebalancePipelineResult:
     optimization_succeeded: bool
     soft_cvar_breach: bool
     target_weights: np.ndarray
+    forced_to_cash: bool = False
+    force_cash_reason: str = ""
 
 
 def _build_scenario_losses(log_rets: pd.DataFrame, active_symbols: List[str], cfg: UltimateConfig) -> np.ndarray:
@@ -890,7 +895,7 @@ def run_rebalance_pipeline(ctx: RebalanceContext) -> RebalancePipelineResult:
             state.consecutive_failures += 1
             activate_override_on_stress(state, cfg)
         elif book_cvar > cfg.CVAR_DAILY_LIMIT + 1e-6:
-            soft_cvar_breach = book_cvar > cfg.CVAR_SOFT_LIMIT if hasattr(cfg, "CVAR_SOFT_LIMIT") else True
+            soft_cvar_breach = True
 
     apply_decay_on_error = False
     if not force_full_cash:
@@ -900,8 +905,8 @@ def run_rebalance_pipeline(ctx: RebalanceContext) -> RebalancePipelineResult:
             if sel_idx:
                 sel_symbols = [ctx.active_symbols[i] for i in sel_idx]
                 prev_w = np.array([ctx.prev_weights.get(sym, 0.0) for sym in ctx.active_symbols])
-                engine = InstitutionalRiskEngine(cfg)
-                weights_sel = engine.optimize(
+                _engine = ctx.engine if ctx.engine is not None else InstitutionalRiskEngine(cfg)
+                weights_sel = _engine.optimize(
                     expected_returns=raw_daily[sel_idx],
                     historical_returns=ctx.log_rets[sel_symbols],
                     execution_date=ctx.rebalance_date,
@@ -933,9 +938,22 @@ def run_rebalance_pipeline(ctx: RebalanceContext) -> RebalancePipelineResult:
             if np.all(np.abs(target_weights) < 1e-12):
                 exhaust_decay = True
 
+    # Apply first-day exclusion mask: zero out target weights for newly listed
+    # symbols that have no valid open price, preventing erroneous entry trades.
+    if ctx.first_day_exclude_mask is not None and ctx.first_day_exclude_mask.any():
+        target_weights = target_weights.copy()
+        target_weights[ctx.first_day_exclude_mask] = 0.0
+
     scenario_losses = ctx.scenario_losses
     if not exhaust_decay and scenario_losses is None:
         scenario_losses = _build_scenario_losses(ctx.log_rets, ctx.active_symbols, cfg)
+
+    forced_to_cash = bool(force_full_cash or exhaust_decay)
+    force_cash_reason = (
+        "book_cvar_breach" if force_full_cash else
+        "max_decay_rounds" if exhaust_decay else
+        ""
+    )
 
     total_slippage = execute_rebalance(
         state,
@@ -945,6 +963,7 @@ def run_rebalance_pipeline(ctx: RebalanceContext) -> RebalancePipelineResult:
         cfg,
         adv_shares=ctx.adv_vector,
         date_context=ctx.rebalance_date,
+        trade_log=ctx.trade_log,
         apply_decay=apply_decay and not exhaust_decay,
         scenario_losses=None if exhaust_decay else scenario_losses,
         force_rebalance_trades=soft_cvar_breach,
@@ -956,6 +975,8 @@ def run_rebalance_pipeline(ctx: RebalanceContext) -> RebalancePipelineResult:
         optimization_succeeded=optimization_succeeded,
         soft_cvar_breach=soft_cvar_breach,
         target_weights=target_weights,
+        forced_to_cash=forced_to_cash,
+        force_cash_reason=force_cash_reason,
     )
 
 

--- a/momentum_engine.py
+++ b/momentum_engine.py
@@ -74,10 +74,6 @@ logger = logging.getLogger(__name__)
 EPSILON = 1e-6
 DEFAULT_MAX_ABSENT_PERIODS = 12
 
-
-def _get_adaptive_cvar_min_obs(cfg: "UltimateConfig") -> int:
-    """Return CVaR min-history threshold with a sensible floor."""
-    return max(5, int(cfg.CVAR_MIN_HISTORY))
 DEFAULT_MAX_DECAY_ROUNDS = 3
 DEFAULT_GHOST_VOL_FALLBACK = 0.04
 
@@ -280,7 +276,7 @@ class UltimateConfig:
     MAX_POSITIONS:            int   = 10           # Maximum active line items allowed.
     MAX_PORTFOLIO_RISK_PCT:   float = 0.20         # Maximum aggregate CVaR allowed.
     MAX_SINGLE_NAME_WEIGHT:   float = 0.25         # Hard cap on individual stock weights.
-    MAX_SECTOR_WEIGHT:        float = 0.35         # Limit any single sector to 35% of gross exposure so OSQP rows (0 ≤ Σw_sector ≤ 0.35) can bind.
+    MAX_SECTOR_WEIGHT:        float = 0.40         # Cap on total sector exposure; 40% limits concentration while allowing sector bets.
 
     # --- Liquidity & Execution ---
     MAX_ADV_PCT:              float = 0.05         # Maximum participation rate of Average Daily Volume.
@@ -379,6 +375,22 @@ class UltimateConfig:
             object.__setattr__(self, "SLIPPAGE_BPS", parsed)
             return
         object.__setattr__(self, name, value)
+
+
+def _get_adaptive_cvar_min_obs(cfg: UltimateConfig) -> int:
+    """Scale CVaR minimum history to rebalance frequency."""
+    freq_to_periods_per_year = {
+        "D": 252,
+        "W-FRI": 52,
+        "W-MON": 52,
+        "W-TUE": 52,
+        "W-WED": 52,
+        "W-THU": 52,
+        "M": 12,
+    }
+    periods_per_year = freq_to_periods_per_year.get(str(cfg.REBALANCE_FREQ), 252)
+    adaptive_min = int(cfg.CVAR_MIN_HISTORY * periods_per_year / 252)
+    return max(5, adaptive_min)
 
 
 @dataclass
@@ -499,12 +511,15 @@ class PortfolioState:
             np.clip(self.exposure_multiplier, cfg.MIN_EXPOSURE_FLOOR, 1.0)
         )
 
-    def realised_cvar(self, min_obs: int = 30) -> float:
+    def realised_cvar(self, min_obs: int = 30, cfg: Optional["UltimateConfig"] = None) -> float:
         """Return realised portfolio CVaR from recent equity history.
 
         CVaR is computed over a rolling window capped at `equity_hist_cap` bars.
         History older than this cap is discarded.
         """
+        if cfg is not None:
+            min_obs = _get_adaptive_cvar_min_obs(cfg)
+
         n = len(self.equity_hist)
         if n < min_obs:
             if n > 1:
@@ -699,6 +714,249 @@ class PortfolioState:
                 risk_errors,
             )
         return ps
+
+
+@dataclass
+class RebalanceContext:
+    active_symbols: List[str]
+    log_rets: pd.DataFrame
+    valuation_prices: np.ndarray
+    exec_prices: np.ndarray
+    pv: float
+    adv_vector: np.ndarray
+    prev_weights: Dict[str, float]
+    regime_score: float
+    gross_exposure: float
+    sector_labels: Optional[np.ndarray]
+    cfg: UltimateConfig
+    state: PortfolioState
+    rebalance_date: pd.Timestamp
+    scenario_losses: Optional[np.ndarray] = None
+
+
+@dataclass
+class RebalancePipelineResult:
+    total_slippage: float
+    applied_decay: bool
+    optimization_succeeded: bool
+    soft_cvar_breach: bool
+    target_weights: np.ndarray
+
+
+def _build_scenario_losses(log_rets: pd.DataFrame, active_symbols: List[str], cfg: UltimateConfig) -> np.ndarray:
+    window = min(len(log_rets), cfg.CVAR_LOOKBACK)
+    return -(log_rets.iloc[-window:].reindex(columns=active_symbols, fill_value=0.0).values)
+
+
+def _build_sector_labels(active_symbols: List[str], sector_map: Optional[dict]) -> Optional[np.ndarray]:
+    if sector_map is None:
+        return None
+    return np.array([sector_map.get(sym, -1) for sym in active_symbols], dtype=int)
+
+
+def resolve_target_shares(
+    target_weights: np.ndarray,
+    pv_exec: float,
+    prices: np.ndarray,
+    adv_shares: Optional[np.ndarray],
+    current_shares: Dict[str, int],
+    cfg: UltimateConfig,
+    active_symbols: List[str],
+    valid_targets: List[Tuple[int, str, float, float]],
+    force_rebalance_trades: bool,
+    conviction_scores: Optional[np.ndarray] = None,
+) -> Dict[str, int]:
+    desired_shares, _ = _compute_desired_shares(
+        target_weights=target_weights,
+        prices=prices,
+        pv_exec=pv_exec,
+        adv_shares=adv_shares,
+        cfg=cfg,
+        active_symbols=active_symbols,
+        current_shares=current_shares,
+        conviction_scores=conviction_scores,
+    )
+    if not force_rebalance_trades:
+        desired_shares, drift_gated_syms = _apply_drift_gate(
+            desired_shares=desired_shares,
+            current_shares=current_shares,
+            target_weights=target_weights,
+            prices=prices,
+            pv_exec=pv_exec,
+            cfg=cfg,
+            active_symbols=active_symbols,
+        )
+        if drift_gated_syms:
+            valid_targets[:] = [vt for vt in valid_targets if vt[1] not in drift_gated_syms]
+    residual_cash = max(
+        0.0,
+        pv_exec - sum(desired_shares.get(sym, 0) * max(float(prices[i]), 1e-6) for i, sym in enumerate(active_symbols)),
+    )
+    residual_allocations = _allocate_residual_cash(
+        residual_budget=residual_cash,
+        valid_targets=valid_targets,
+        conviction_scores=conviction_scores,
+        prices=prices,
+        cfg=cfg,
+    )
+    for sym, extra in residual_allocations.items():
+        desired_shares[sym] = desired_shares.get(sym, 0) + int(extra)
+    return desired_shares
+
+
+def simulate_fills(
+    desired_shares: Dict[str, int],
+    active_symbols: List[str],
+    prices: np.ndarray,
+    pv_exec: float,
+    adv_shares: Optional[np.ndarray],
+    symbols_to_force_close: set[str],
+    state: PortfolioState,
+    cfg: UltimateConfig,
+    trade_log: Optional[List[Trade]],
+    rebalance_date: pd.Timestamp,
+) -> Tuple[Dict[str, float], Dict[str, int], Dict[str, float], float, float]:
+    active_idx = {sym: i for i, sym in enumerate(active_symbols)}
+    new_weights: Dict[str, float] = {}
+    new_shares: Dict[str, int] = {}
+    new_entry_prices: Dict[str, float] = dict(state.entry_prices)
+    total_slippage = 0.0
+    actual_notional = 0.0
+
+    for i, sym in enumerate(active_symbols):
+        price = max(float(prices[i]), 1e-6)
+        old_s = state.shares.get(sym, 0)
+        s = desired_shares.get(sym, 0)
+        if s > 0 or old_s > 0:
+            delta = s - old_s
+            trade_not = abs(delta) * price
+            slip_rate = compute_one_way_slip_rate(cfg=cfg, portfolio_value=pv_exec, adv_notional=float(adv_shares[i]) if adv_shares is not None else None, trade_notional=trade_not)
+            slip = abs(delta) * price * slip_rate
+            total_slippage += slip
+            actual_notional += s * price
+            if s > 0:
+                new_weights[sym] = (s * price) / max(pv_exec, 1.0)
+                new_shares[sym] = s
+                if delta > 0:
+                    if old_s == 0:
+                        new_entry_prices[sym] = price * (1.0 + slip_rate)
+                        state.dividend_ledger[sym] = f"{pd.Timestamp(rebalance_date).strftime('%Y-%m-%d')}:0.00000000"
+                    else:
+                        old_basis = new_entry_prices.get(sym, price)
+                        new_entry_prices[sym] = (old_basis * old_s + price * (1.0 + slip_rate) * delta) / s
+            if delta != 0 and trade_log is not None:
+                trade_log.append(Trade(sym, pd.Timestamp(rebalance_date), delta, price, slip, "BUY" if delta > 0 else "SELL"))
+
+    for sym in state.shares:
+        if sym not in active_idx and sym not in symbols_to_force_close:
+            new_shares[sym] = state.shares[sym]
+            new_weights[sym] = state.weights.get(sym, 0.0)
+            new_entry_prices[sym] = state.entry_prices.get(sym, 0.0)
+            actual_notional += new_shares[sym] * absent_symbol_effective_price(state.last_known_prices.get(sym, 0.0), state.absent_periods.get(sym, 0), cfg.MAX_ABSENT_PERIODS)
+
+    for sym in symbols_to_force_close:
+        close_price = absent_symbol_effective_price(float(state.last_known_prices.get(sym, 0.0)), state.absent_periods.get(sym, 0), cfg.MAX_ABSENT_PERIODS)
+        n_shares = state.shares.get(sym, 0)
+        if n_shares > 0:
+            slip = n_shares * close_price * (cfg.ROUND_TRIP_SLIPPAGE_BPS / 20000.0)
+            total_slippage += slip
+            actual_notional -= n_shares * close_price
+            if trade_log is not None:
+                trade_log.append(Trade(sym, pd.Timestamp(rebalance_date), -n_shares, close_price, slip, "SELL"))
+
+    return new_weights, new_shares, new_entry_prices, total_slippage, actual_notional
+
+
+def run_rebalance_pipeline(ctx: RebalanceContext) -> RebalancePipelineResult:
+    cfg = ctx.cfg
+    state = ctx.state
+    apply_decay = False
+    force_full_cash = False
+    soft_cvar_breach = False
+    optimization_succeeded = False
+    target_weights = np.zeros(len(ctx.active_symbols), dtype=float)
+    sel_idx: List[int] = []
+
+    adaptive_min = _get_adaptive_cvar_min_obs(cfg)
+    realised_cvar = state.realised_cvar(cfg=cfg) if len(state.equity_hist) >= adaptive_min else 0.0
+    state.update_exposure(ctx.regime_score, realised_cvar, cfg, gross_exposure=ctx.gross_exposure)
+
+    if state.shares:
+        book_cvar = compute_book_cvar(state, ctx.valuation_prices, ctx.active_symbols, ctx.log_rets, cfg)
+        hard_threshold = cfg.CVAR_DAILY_LIMIT * getattr(cfg, "CVAR_HARD_BREACH_MULTIPLIER", 1.5)
+        if book_cvar > hard_threshold:
+            apply_decay = True
+            force_full_cash = True
+            state.consecutive_failures += 1
+            activate_override_on_stress(state, cfg)
+        elif book_cvar > cfg.CVAR_DAILY_LIMIT + 1e-6:
+            soft_cvar_breach = book_cvar > cfg.CVAR_SOFT_LIMIT if hasattr(cfg, "CVAR_SOFT_LIMIT") else True
+
+    apply_decay_on_error = False
+    if not force_full_cash:
+        from signals import generate_signals, SignalGenerationError
+        try:
+            raw_daily, _adj_scores, sel_idx, _gate_counts = generate_signals(ctx.log_rets, ctx.adv_vector, cfg, prev_weights=ctx.prev_weights)
+            if sel_idx:
+                sel_symbols = [ctx.active_symbols[i] for i in sel_idx]
+                prev_w = np.array([ctx.prev_weights.get(sym, 0.0) for sym in ctx.active_symbols])
+                engine = InstitutionalRiskEngine(cfg)
+                weights_sel = engine.optimize(
+                    expected_returns=raw_daily[sel_idx],
+                    historical_returns=ctx.log_rets[sel_symbols],
+                    execution_date=ctx.rebalance_date,
+                    adv_shares=ctx.adv_vector[sel_idx],
+                    prices=ctx.valuation_prices[sel_idx],
+                    portfolio_value=ctx.pv,
+                    prev_w=prev_w[sel_idx],
+                    exposure_multiplier=state.exposure_multiplier,
+                    sector_labels=ctx.sector_labels[sel_idx] if ctx.sector_labels is not None else None,
+                )
+                target_weights[sel_idx] = weights_sel
+                optimization_succeeded = True
+                state.consecutive_failures = 0
+                state.decay_rounds = 0
+            elif state.shares:
+                apply_decay = True
+        except (OptimizationError, SignalGenerationError, ValueError):
+            apply_decay_on_error = True
+    if apply_decay_on_error:
+        apply_decay = True
+
+    exhaust_decay = False
+    if apply_decay and not optimization_succeeded:
+        if force_full_cash or state.decay_rounds >= cfg.MAX_DECAY_ROUNDS:
+            target_weights = np.zeros(len(ctx.active_symbols), dtype=float)
+            exhaust_decay = True
+        else:
+            target_weights = compute_decay_targets(state, sel_idx, ctx.active_symbols, cfg, current_prices=ctx.valuation_prices, pv=ctx.pv)
+            if np.all(np.abs(target_weights) < 1e-12):
+                exhaust_decay = True
+
+    scenario_losses = ctx.scenario_losses
+    if not exhaust_decay and scenario_losses is None:
+        scenario_losses = _build_scenario_losses(ctx.log_rets, ctx.active_symbols, cfg)
+
+    total_slippage = execute_rebalance(
+        state,
+        target_weights,
+        ctx.exec_prices,
+        ctx.active_symbols,
+        cfg,
+        adv_shares=ctx.adv_vector,
+        date_context=ctx.rebalance_date,
+        apply_decay=apply_decay and not exhaust_decay,
+        scenario_losses=None if exhaust_decay else scenario_losses,
+        force_rebalance_trades=soft_cvar_breach,
+    ) if (optimization_succeeded or apply_decay) else 0.0
+
+    return RebalancePipelineResult(
+        total_slippage=total_slippage,
+        applied_decay=apply_decay,
+        optimization_succeeded=optimization_succeeded,
+        soft_cvar_breach=soft_cvar_breach,
+        target_weights=target_weights,
+    )
 
 
 def _as_bool_flag(value: Any) -> bool:


### PR DESCRIPTION
## **User description**
### Motivation
- Reduce sector concentration risk by raising the sector cap and clarify its intent. 
- Make CVaR warm-up threshold frequency-aware so daily/weekly/monthly runs use an appropriate minimum-observation guard. 
- Consolidate rebalance logic into a single pipeline to remove duplicated logic and provide a single entrypoint for rebalance signal→opt→execute flow.

### Description
- Updated `UltimateConfig.MAX_SECTOR_WEIGHT` to `0.40` and replaced the inline comment with `# Cap on total sector exposure; 40% limits concentration while allowing sector bets.` in `momentum_engine.py`.
- Added `_get_adaptive_cvar_min_obs(cfg: UltimateConfig) -> int` (frequency-aware mapping and scaling) and wired it into `PortfolioState.realised_cvar()` by adding an optional `cfg: Optional["UltimateConfig"]` parameter while preserving the existing `min_obs` behavior for backward compatibility; updated call sites accordingly.
- Introduced rebalance pipeline abstractions in `momentum_engine.py`: `RebalanceContext`, `RebalancePipelineResult`, `_build_scenario_losses`, `_build_sector_labels`, `resolve_target_shares`, `simulate_fills`, and `run_rebalance_pipeline` to encapsulate CVaR gating, signal generation, optimization fallback, decay flow, scenario loss construction, and the call to `execute_rebalance` (left unmodified).
- Reworked integration points to use the unified pipeline: `BacktestEngine._run_rebalance()` now constructs a `RebalanceContext` and calls `run_rebalance_pipeline(ctx)` (preserving `_build_prev_weights()` usage), and `daily_workflow.py` replaced its scan rebalance block with `RebalanceContext` construction + `run_rebalance_pipeline(ctx)` (uses UTC `rebalance_date` and shared valuation/execution prices); imports were updated as needed.
- Kept `execute_rebalance()` internal logic unchanged and preserved previous constraints/OSQP logic except for the pipeline refactor and the adaptive CVaR usage.

### Testing
- Ran `python -m py_compile momentum_engine.py backtest_engine.py daily_workflow.py` to validate syntax and module-level correctness, and compilation succeeded with no syntax errors.

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9eb4c0214832ba34195360a8207eb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the rebalance flow into a single, modular pipeline driven by an explicit rebalance context built from live holdings, prices, sector labels, and listing exclusions; pipeline results now drive slippage and rebalance flags.
* **Bug Fixes**
  * Standardized tail‑risk (CVaR) reporting across scans and diagnostics.
  * Suppresses non‑forced rebalances when held securities have invalid/unstable closes and ensures last‑rebalance timestamps reflect applied optimizations or decay actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Unify rebalance handling, adapt CVaR warm-up, and loosen sector concentration**

### What Changed
- Raises the sector exposure cap to 40%, allowing slightly larger sector bets while keeping concentration limits in place
- CVaR now waits for less history on more frequent rebalance schedules, so daily, weekly, and monthly runs start risk checks at a more appropriate point
- Rebalance decisions now go through one shared flow in both backtests and live workflow, which keeps signal generation, sizing, and trade execution consistent
- Skips non-forced rebalances when held positions have stale prices, avoiding trades sized off outdated market data

### Impact
`✅ Fewer missed rebalances after short warm-up periods`
`✅ More consistent backtest and live rebalance results`
`✅ Fewer trades triggered by stale price data`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
